### PR TITLE
Whitelist deps of build artifacts

### DIFF
--- a/build/allowed_deps.txt
+++ b/build/allowed_deps.txt
@@ -1,0 +1,15 @@
+# This file lists all the SO files that the final build artifacts are allowed to directly depend on
+# The content below must exactly match `readelf -d /usr/src/dist_test/lib/*.so | grep NEEDED | sort | uniq`
+# (ignoring lines that start with #). See `neuropods.dockerfile` for more details
+#
+# This check ensures that we don't accidentally link against other shared objects
+#
+ 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
+ 0x0000000000000001 (NEEDED)             Shared library: [libboost_python-py27.so.1.58.0]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libneuropods.so]
+ 0x0000000000000001 (NEEDED)             Shared library: [libpython2.7.so.1.0]
+ 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libtorch.so.1]

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -21,3 +21,13 @@ RUN bazel build //...:all
 
 # Run native tests
 RUN bazel test //...
+
+# Copy the build artificts into a dist folder
+RUN mkdir -p /usr/src/dist && \
+    cp bazel-bin/neuropods/libneuropods.tar.gz python/dist/*.whl /usr/src/dist
+
+# Make sure we only depend on .so files we whitelist (and we depend on all the whitelisted ones)
+RUN mkdir -p /tmp/dist_test && \
+    tar -xvf /usr/src/dist/libneuropods.tar.gz -C /tmp/dist_test && \
+    readelf -d /tmp/dist_test/lib/*.so | grep NEEDED | sort | uniq |\
+    diff -I '^#.*' /usr/src/build/allowed_deps.txt -


### PR DESCRIPTION
This ensures we don't accidentally link against other `.so` files.

For example, for libtorch, we only want to link against `libtorch.so.1`, not all the files included in the libtorch package (e.g. `libmkldnn.so.0`). One reason for this is that the set of other `.so` files varies depending on whether we're using a CPU or GPU version of libtorch.

By ensuring we only link against `libtorch.so.1`, we're compatible with both the CPU and GPU version at runtime