### PR TITLE
Use prebuilt base docker image to make CI builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 install:
-  # TODO(vip): prebuild the base image and pull it here instead of rebuilding
-  # every time
-  - docker build -f build/neuropods_base.dockerfile -t neuropods_base .
+  # TODO(vip): update this image to be Neuropods specific once we open source
+  - docker pull vpanyam/dl_base:latest
 
 script:
   # This builds both the C++ and python versions and runs tests

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -2,7 +2,10 @@
 # It starts from the `neuropods_base` image which contains some of the large
 # dependencies for Neuropods
 
-FROM neuropods_base
+# TODO(vip): After open sourcing, update the base image (and use `neuropods_base.dockerfile` to generate it)
+# For now, this public base image has all the deps installed (but has no references to neuropods)
+# FROM neuropods_base
+FROM vpanyam/dl_base:latest
 
 # Create a source dir and copy the code in
 RUN mkdir -p /usr/src


### PR DESCRIPTION
The base image (`vpanyam/dl_base`) was created with the following Dockerfile:

```dockerfile
FROM ubuntu:16.04

# Install pip and bazel dependencies
RUN apt-get update && apt-get install -y openjdk-8-jdk curl wget gcc-4.9 g++-4.9 python-pip

# Add bazel sources
RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -

# Install bazel and other native deps
RUN apt-get update && \
    apt-get install -y bazel python-dev && \
    rm -rf /var/lib/apt/lists/*

# Run a bazel command to extract the bazel installation
RUN bazel version

# Make sure we build with gcc/g++ 4.9
ENV CC=/usr/bin/gcc-4.9 CXX=/usr/bin/g++-4.9

# Install python deps
RUN pip install numpy testpath six tensorflow torch==1.0.0 torchvision
```