### PR TITLE
Make the Docker build configurable

### DIFF
--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -7,6 +7,31 @@
 # FROM neuropods_base
 FROM vpanyam/dl_base:latest
 
+# Set the GCC version used for this build
+ARG GCC_VERSION=4.9
+ENV CC=/usr/bin/gcc-${GCC_VERSION} CXX=/usr/bin/g++-${GCC_VERSION}
+
+# Optional overrides used by the bazel build
+ARG NEUROPODS_TENSORFLOW_VERSION
+ARG NEUROPODS_TENSORFLOW_URL
+ARG NEUROPODS_TENSORFLOW_SHA256
+ARG NEUROPODS_PYTORCH_VERSION
+ARG NEUROPODS_PYTORCH_URL
+ARG NEUROPODS_PYTORCH_SHA256
+
+ENV NEUROPODS_TENSORFLOW_VERSION=$NEUROPODS_TENSORFLOW_VERSION
+ENV NEUROPODS_TENSORFLOW_URL=$NEUROPODS_TENSORFLOW_URL
+ENV NEUROPODS_TENSORFLOW_SHA256=$NEUROPODS_TENSORFLOW_SHA256
+ENV NEUROPODS_PYTORCH_VERSION=$NEUROPODS_PYTORCH_VERSION
+ENV NEUROPODS_PYTORCH_URL=$NEUROPODS_PYTORCH_URL
+ENV NEUROPODS_PYTORCH_SHA256=$NEUROPODS_PYTORCH_SHA256
+
+# Install any pip packages that were requested
+# This lets us do things like using a different build of torch
+# TODO(vip): Move this into bazel
+ARG PIP_OVERRIDES
+RUN [ ! -z "${PIP_OVERRIDES}" ] && pip install ${PIP_OVERRIDES} || echo "No pip overrides specified."
+
 # Create a source dir and copy the code in
 RUN mkdir -p /usr/src
 COPY . /usr/src

--- a/build/neuropods_base.dockerfile
+++ b/build/neuropods_base.dockerfile
@@ -7,7 +7,7 @@
 FROM ubuntu:16.04
 
 # Install pip and bazel dependencies
-RUN apt-get update && apt-get install -y openjdk-8-jdk curl wget gcc-4.9 g++-4.9 python-pip
+RUN apt-get update && apt-get install -y openjdk-8-jdk curl wget gcc-4.9 g++-4.9 gcc-4.8 g++-4.8 python-pip
 
 # Add bazel sources
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
@@ -24,10 +24,6 @@ RUN bazel version
 # Create a source dir and copy the code in
 RUN mkdir -p /usr/src
 COPY . /usr/src
-
-# Make sure we build with gcc/g++ 4.9
-# (to make sure that libtorch works)
-ENV CC=/usr/bin/gcc-4.9 CXX=/usr/bin/g++-4.9
 
 # Install deps for the python interface
 WORKDIR /usr/src/source/python

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -4,7 +4,7 @@ def _impl(repository_ctx):
         download_url = repository_ctx.os.environ["NEUROPODS_PYTORCH_URL"]
         download_sha = repository_ctx.os.environ.get("NEUROPODS_PYTORCH_SHA256", '')
     else:
-        version = repository_ctx.os.environ.get("NEUROPODS_PYTORCH_VERSION", repository_ctx.attr.default_version)
+        version = repository_ctx.os.environ.get("NEUROPODS_PYTORCH_VERSION", "") or repository_ctx.attr.default_version
         if repository_ctx.os.name.startswith("mac"):
             download_url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-" + version + ".zip"
         else:

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -4,7 +4,7 @@ def _impl(repository_ctx):
         download_url = repository_ctx.os.environ["NEUROPODS_TENSORFLOW_URL"]
         download_sha = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_SHA256", '')
     else:
-        version = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_VERSION", repository_ctx.attr.default_version)
+        version = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_VERSION", "") or repository_ctx.attr.default_version
         if repository_ctx.os.name.startswith("mac"):
             download_url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-" + version + ".tar.gz"
         else:


### PR DESCRIPTION
This PR lets us build with different versions of packages and different compiler versions.

The intended use case is building with GCC 4.8 (for Ubuntu 14.04):
```
docker build
    -f build/neuropods.dockerfile
    -t neuropods:gcc_4.8
    --build-arg GCC_VERSION=4.8
    --build-arg NEUROPODS_PYTORCH_URL=https://github.com/VivekPanyam/pytorch-gcc-4.8/releases/download/v1.0.0/libtorch_gcc_4.8_nomkl_a3f600e39495.tar.gz
    --build-arg PIP_OVERRIDES="future https://github.com/VivekPanyam/pytorch-gcc-4.8/releases/download/v1.0.0/torch-1.1.0a0_gcc_4.8_nomkl_a3f600e39495-cp27-none-linux_x86_64.whl"
    .
```