### PR TITLE
Refactor NeuropodBackend and add a default allocator

### DIFF
--- a/source/neuropods/backends/neuropod_backend.hh
+++ b/source/neuropods/backends/neuropod_backend.hh
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "neuropods/internal/backend_registration.hh"
+#include "neuropods/internal/neuropod_tensor.hh"
 #include "neuropods/internal/tensor_types.hh"
 
 namespace neuropods
@@ -32,4 +33,17 @@ public:
     // Run inference
     virtual std::unique_ptr<TensorStore> infer(const TensorStore &inputs) = 0;
 };
+
+template<template <class> class TensorImpl>
+class NeuropodBackendWithDefaultAllocator : public NeuropodBackend
+{
+public:
+    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
+                                                    const std::vector<int64_t> &input_dims,
+                                                    TensorType                  tensor_type)
+    {
+        return make_tensor<TensorImpl>(tensor_type, node_name, input_dims);
+    }
+};
+
 } // namespace neuropods

--- a/source/neuropods/backends/python_bridge/python_bridge.cc
+++ b/source/neuropods/backends/python_bridge/python_bridge.cc
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <vector>
 
-#include "neuropods/backends/python_bridge/numpy_neuropod_tensor.hh"
 #include "neuropods/backends/python_bridge/type_utils.hh"
 #include "neuropods/internal/tensor_store.hh"
 
@@ -107,14 +106,6 @@ PythonBridge::PythonBridge(const std::string &             neuropod_path,
 }
 
 PythonBridge::~PythonBridge() = default;
-
-// Allocate a tensor of a specific type
-std::unique_ptr<NeuropodTensor> PythonBridge::allocate_tensor(const std::string &         node_name,
-                                                              const std::vector<int64_t> &input_dims,
-                                                              TensorType                  tensor_type)
-{
-    return make_tensor<NumpyNeuropodTensor>(tensor_type, node_name, input_dims);
-}
 
 // Run inference
 std::unique_ptr<TensorStore> PythonBridge::infer(const TensorStore &inputs)

--- a/source/neuropods/backends/python_bridge/python_bridge.hh
+++ b/source/neuropods/backends/python_bridge/python_bridge.hh
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "neuropods/backends/neuropod_backend.hh"
+#include "neuropods/backends/python_bridge/numpy_neuropod_tensor.hh"
 
 namespace neuropods
 {
@@ -29,7 +30,7 @@ std::vector<std::string> get_default_python_path()
 // This backend starts an embedded python interpreter and is used
 // to execute neuropods that contain python code. This includes
 // models from PyTorch < 1.0 and PyTorch models that don't use TorchScript
-class PythonBridge : public NeuropodBackend
+class PythonBridge : public NeuropodBackendWithDefaultAllocator<NumpyNeuropodTensor>
 {
 private:
     py::object main_module_;
@@ -43,11 +44,6 @@ public:
                  const std::vector<std::string> &python_path_additions = get_default_python_path());
 
     ~PythonBridge();
-
-    // Allocate a tensor of a specific type
-    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                    const std::vector<int64_t> &input_dims,
-                                                    TensorType                  tensor_type);
 
     // Run inference
     std::unique_ptr<TensorStore> infer(const TensorStore &inputs);

--- a/source/neuropods/backends/tensorflow/tf_backend.cc
+++ b/source/neuropods/backends/tensorflow/tf_backend.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#include "neuropods/backends/tensorflow/tf_tensor.hh"
 #include "neuropods/backends/tensorflow/type_utils.hh"
 #include "neuropods/internal/tensor_store.hh"
 
@@ -169,15 +168,6 @@ void TensorflowNeuropodBackend::load_graph(const std::string &graph_path)
         ss << "Failed to load graph: " << graph_path;
         throw std::runtime_error(ss.str());
     }
-}
-
-
-// Allocate a tensor of a specific type
-std::unique_ptr<NeuropodTensor> TensorflowNeuropodBackend::allocate_tensor(const std::string &         node_name,
-                                                                           const std::vector<int64_t> &input_dims,
-                                                                           TensorType                  tensor_type)
-{
-    return make_tensor<TensorflowNeuropodTensor>(tensor_type, node_name, input_dims);
 }
 
 // Run inference

--- a/source/neuropods/backends/tensorflow/tf_backend.hh
+++ b/source/neuropods/backends/tensorflow/tf_backend.hh
@@ -11,6 +11,7 @@
 #include <tensorflow/c/c_api.h>
 
 #include "neuropods/backends/neuropod_backend.hh"
+#include "neuropods/backends/tensorflow/tf_tensor.hh"
 #include "neuropods/backends/tensorflow/tf_wrappers.hh"
 
 namespace neuropods
@@ -18,7 +19,7 @@ namespace neuropods
 
 
 // This backend can execute TensorFlow models
-class TensorflowNeuropodBackend : public NeuropodBackend
+class TensorflowNeuropodBackend : public NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>
 {
 private:
     // Setup setup inputs given a TensorStore
@@ -53,11 +54,6 @@ public:
     explicit TensorflowNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
 
     ~TensorflowNeuropodBackend();
-
-    // Allocate a tensor of a specific type
-    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                    const std::vector<int64_t> &input_dims,
-                                                    TensorType                  tensor_type);
 
     // Run inference
     std::unique_ptr<TensorStore> infer(const TensorStore &inputs);

--- a/source/neuropods/backends/test_backend/BUILD
+++ b/source/neuropods/backends/test_backend/BUILD
@@ -6,6 +6,7 @@ cc_library(
     name = "test_backend_hdrs",
     hdrs = [
         "test_neuropod_backend.hh",
+        "test_neuropod_tensor.hh",
     ],
     visibility = [
         "//neuropods:__subpackages__",
@@ -19,7 +20,6 @@ cc_binary(
     name = "libneuropod_test_backend.so",
     srcs = [
         "test_neuropod_backend.cc",
-        "test_neuropod_tensor.hh",
         "//neuropods:libneuropods.so",
     ],
     linkshared = True,

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.cc
@@ -4,7 +4,6 @@
 
 #include "test_neuropod_backend.hh"
 
-#include "neuropods/backends/test_backend/test_neuropod_tensor.hh"
 #include "neuropods/internal/tensor_store.hh"
 
 namespace neuropods
@@ -13,14 +12,6 @@ namespace neuropods
 TestNeuropodBackend::TestNeuropodBackend() {}
 TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config) {}
 TestNeuropodBackend::~TestNeuropodBackend() = default;
-
-// Allocate a tensor of a specific type
-std::unique_ptr<NeuropodTensor> TestNeuropodBackend::allocate_tensor(const std::string &         node_name,
-                                                                     const std::vector<int64_t> &input_dims,
-                                                                     TensorType                  tensor_type)
-{
-    return make_tensor<TestNeuropodTensor>(tensor_type, node_name, input_dims);
-}
 
 // Run inference
 std::unique_ptr<TensorStore> TestNeuropodBackend::infer(const TensorStore &inputs)

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.hh
@@ -8,22 +8,18 @@
 #include <vector>
 
 #include "neuropods/backends/neuropod_backend.hh"
+#include "neuropods/backends/test_backend/test_neuropod_tensor.hh"
 
 namespace neuropods
 {
 
 // A NeuropodBackend used in tests
-class TestNeuropodBackend : public NeuropodBackend
+class TestNeuropodBackend : public NeuropodBackendWithDefaultAllocator<TestNeuropodTensor>
 {
 public:
     TestNeuropodBackend();
     TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
     ~TestNeuropodBackend();
-
-    // Allocate a tensor of a specific type
-    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                    const std::vector<int64_t> &input_dims,
-                                                    TensorType                  tensor_type);
 
     // Run inference
     std::unique_ptr<TensorStore> infer(const TensorStore &inputs);

--- a/source/neuropods/backends/torchscript/torch_backend.cc
+++ b/source/neuropods/backends/torchscript/torch_backend.cc
@@ -8,7 +8,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#include "neuropods/backends/torchscript/torch_tensor.hh"
 #include "neuropods/backends/torchscript/type_utils.hh"
 #include "neuropods/internal/tensor_store.hh"
 
@@ -65,16 +64,6 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, std
 }
 
 TorchNeuropodBackend::~TorchNeuropodBackend() = default;
-
-
-// Allocate a tensor of a specific type
-std::unique_ptr<NeuropodTensor> TorchNeuropodBackend::allocate_tensor(const std::string &         node_name,
-                                                                      const std::vector<int64_t> &input_dims,
-                                                                      TensorType                  tensor_type)
-{
-    torch::NoGradGuard guard;
-    return make_tensor<TorchNeuropodTensor>(tensor_type, node_name, input_dims);
-}
 
 // Run inference
 std::unique_ptr<TensorStore> TorchNeuropodBackend::infer(const TensorStore &inputs)

--- a/source/neuropods/backends/torchscript/torch_backend.hh
+++ b/source/neuropods/backends/torchscript/torch_backend.hh
@@ -11,6 +11,7 @@
 #include <torch/torch.h>
 
 #include "neuropods/backends/neuropod_backend.hh"
+#include "neuropods/backends/torchscript/torch_tensor.hh"
 
 namespace neuropods
 {
@@ -18,7 +19,7 @@ namespace neuropods
 
 // This backend can execute TorchScript models using the
 // native C++ torch API
-class TorchNeuropodBackend : public NeuropodBackend
+class TorchNeuropodBackend : public NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>
 {
 private:
     // The loaded TorchScript Module
@@ -28,11 +29,6 @@ public:
     TorchNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
 
     ~TorchNeuropodBackend();
-
-    // Allocate a tensor of a specific type
-    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                    const std::vector<int64_t> &input_dims,
-                                                    TensorType                  tensor_type);
 
     // Run inference
     std::unique_ptr<TensorStore> infer(const TensorStore &inputs);


### PR DESCRIPTION
Refactor to share tensor allocation code between backends