### PR TITLE
Adding `init_op_names` argument to tensorflow packaging function.

### DIFF
--- a/source/neuropods/python/backends/tensorflow/packager.py
+++ b/source/neuropods/python/backends/tensorflow/packager.py
@@ -19,6 +19,7 @@ def create_tensorflow_neuropod(
         output_spec,
         frozen_graph_path=None,
         graph_def=None,
+        init_op_names=None,
         test_input_data=None,
         test_expected_out=None):
     """
@@ -56,6 +57,11 @@ def create_tensorflow_neuropod(
 
     :param  graph_def:          A tensorflow GraphDef object. If this is not provided, `frozen_graph_path` must
                                 be set
+
+    :param init_op_names:       A list of initialization operator names. These operations are evaluated in the session
+                                used for inference right after the session is created. These operators may be used
+                                for initialization of variables.
+
 
     :param  test_input_data:    Optional sample input data. This is a dict mapping input names to
                                 values. If this is provided, inference will be run in an isolated environment
@@ -107,8 +113,14 @@ def create_tensorflow_neuropod(
     # We also need to save the node name mapping so we know how to run the model
     # This is tensorflow specific config so it's not saved in the overall neuropod config
     with open(os.path.join(neuropod_path, "0", "config.json"), "w") as config_file:
+        if init_op_names is None:
+            init_op_names = []
+        else:
+            init_op_names = init_op_names if isinstance(init_op_names, list) else [init_op_names]
+
         json.dump({
             "node_name_mapping": node_name_mapping,
+            "init_op_names": init_op_names,
         }, config_file)
 
     if test_input_data is not None:

--- a/source/neuropods/python/tests/test_tensorflow_packaging.py
+++ b/source/neuropods/python/tests/test_tensorflow_packaging.py
@@ -9,6 +9,7 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropods.backends.tensorflow.packager import create_tensorflow_neuropod
+from neuropods.loader import load_neuropod
 
 
 def create_tf_addition_model():
@@ -25,6 +26,24 @@ def create_tf_addition_model():
             out = tf.add(x, y, name="out")
 
     return g.as_graph_def()
+
+
+def create_tf_accumulator_model():
+    """
+    Accumulate input x into a variable. Return the accumulated value.
+    """
+    g = tf.Graph()
+    with g.as_default():
+        with tf.name_scope("some_namespace"):
+            acc = tf.get_variable('accumulator', initializer=tf.zeros_initializer(), shape=(), dtype=tf.float32)
+            x = tf.placeholder(tf.float32, name="in_x")
+
+            assign_op = tf.assign_add(acc, x)
+            with tf.control_dependencies([assign_op]):
+                tf.identity(acc, name="out")
+        init_op = tf.global_variables_initializer()
+
+    return g.as_graph_def(), init_op.name
 
 
 class TestTensorflowPackaging(unittest.TestCase):
@@ -61,6 +80,35 @@ class TestTensorflowPackaging(unittest.TestCase):
                 },
             )
 
+    def package_accumulator_model(self, neuropod_path, init_op_name_as_list):
+        graph_def, init_op_name = create_tf_accumulator_model()
+
+        # `create_tensorflow_neuropod` runs inference with the test data immediately
+        # after creating the neuropod. Raises a ValueError if the model output
+        # does not match the expected output.
+        create_tensorflow_neuropod(
+            neuropod_path=neuropod_path,
+            model_name="accumulator_model",
+            graph_def=graph_def,
+            node_name_mapping={
+                "x": "some_namespace/in_x:0",
+                "out": "some_namespace/out:0",
+            },
+            input_spec=[
+                {"name": "x", "dtype": "float32", "shape": ()},
+            ],
+            output_spec=[
+                {"name": "out", "dtype": "float32", "shape": ()},
+            ],
+            init_op_names=[init_op_name] if init_op_name_as_list else init_op_name,
+            test_input_data={
+                "x": np.float32(5.0),
+            },
+            test_expected_out={
+                "out": np.float32(5.0),
+            },
+        )
+
     def test_simple_addition_model(self):
         # Tests a case where packaging works correctly and
         # the model output matches the expected output
@@ -70,6 +118,16 @@ class TestTensorflowPackaging(unittest.TestCase):
         # Tests a case where the output does not match the expected output
         with self.assertRaises(ValueError):
             self.package_simple_addition_model(do_fail=True)
+
+    def test_stateful_model(self):
+        # `init_op` can be passed a list of strings or a string
+        for init_op_name_as_list in [False, True]:
+            with TemporaryDirectory() as test_dir:
+                neuropod_path = os.path.join(test_dir, "test_neuropod")
+                self.package_accumulator_model(neuropod_path, init_op_name_as_list)
+                neuropod_path = load_neuropod(neuropod_path)
+                np.testing.assert_equal(neuropod_path.infer({"x": np.float32(2.0)}), {"out": 2.0})
+                np.testing.assert_equal(neuropod_path.infer({"x": np.float32(4.0)}), {"out": 6.0})
 
 
 if __name__ == '__main__':

--- a/source/neuropods/tests/test_data/tf_addition_model/0/config.json
+++ b/source/neuropods/tests/test_data/tf_addition_model/0/config.json
@@ -1,1 +1,1 @@
-{"node_name_mapping": {"y": "some_namespace/in_y:0", "x": "some_namespace/in_x:0", "out": "some_namespace/out:0"}}
+{"node_name_mapping": {"y": "some_namespace/in_y:0", "x": "some_namespace/in_x:0", "out": "some_namespace/out:0"}, "init_op_names": {}}

--- a/source/neuropods/tests/test_data/tf_strings_model/0/config.json
+++ b/source/neuropods/tests/test_data/tf_strings_model/0/config.json
@@ -1,1 +1,1 @@
-{"node_name_mapping": {"y": "some_namespace/in_y:0", "x": "some_namespace/in_x:0", "out": "some_namespace/out:0"}}
+{"node_name_mapping": {"y": "some_namespace/in_y:0", "x": "some_namespace/in_x:0", "out": "some_namespace/out:0"}, "init_op_names": {}}


### PR DESCRIPTION
This enables usage of neuropods with stateful models. New arguement specifies a list of operators to be invoked right after a tensorflow session is created. Should be used to initialize state.