### PR TITLE
Upgrade libtorch and pytorch to a nightly build

### DIFF
--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -32,6 +32,10 @@ ENV NEUROPODS_PYTORCH_SHA256=$NEUROPODS_PYTORCH_SHA256
 ARG PIP_OVERRIDES
 RUN [ ! -z "${PIP_OVERRIDES}" ] && pip install ${PIP_OVERRIDES} || echo "No pip overrides specified."
 
+# TODO(vip): for some reason, adding to `/etc/ld.so.conf.d/libtorch.conf` does not work for
+# new versions of libtorch. Setting LD_LIBRARY_PATH does work correctly, however
+ENV LD_LIBRARY_PATH="/usr/src/source/bazel-source/external/libtorch_repo/lib"
+
 # Create a source dir and copy the code in
 RUN mkdir -p /usr/src
 COPY . /usr/src
@@ -59,7 +63,6 @@ RUN mkdir -p /tmp/dist_test && \
 
 # Make sure the tests can find all the `.so` files for the backends
 RUN echo "/tmp/dist_test/lib" > /etc/ld.so.conf.d/libneuropods.conf && \
-    echo "/usr/src/source/bazel-source/external/libtorch_repo/lib" > /etc/ld.so.conf.d/libtorch.conf && \
     echo "/usr/src/source/bazel-source/external/tensorflow_repo/lib" > /etc/ld.so.conf.d/tensorflow.conf && \
     ldconfig
 

--- a/build/neuropods_base.dockerfile
+++ b/build/neuropods_base.dockerfile
@@ -26,10 +26,11 @@ RUN mkdir -p /usr/src
 COPY . /usr/src
 
 # Install deps for the python interface
+# (the -f flag tells pip where to find the torch nightly builds)
 WORKDIR /usr/src/source/python
 RUN pip install -U pip setuptools && \
     python setup.py egg_info && \
-    cat neuropods.egg-info/requires.txt  | sed '/^\[/ d' | paste -sd " " - | xargs pip install
+    cat neuropods.egg-info/requires.txt  | sed '/^\[/ d' | paste -sd " " - | xargs pip install -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
 # Delete the source code we copied in
 WORKDIR /usr/src

--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -6,7 +6,7 @@ load("//bazel:libtorch.bzl", "libtorch_repository")
 libtorch_repository(
     name = "libtorch_repo",
     build_file = "@//deps:BUILD.libtorch",
-    default_version = "1.0.0",
+    default_version = "1.0.0.dev20190318",
 )
 
 tensorflow_repository(

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -6,9 +6,9 @@ def _impl(repository_ctx):
     else:
         version = repository_ctx.os.environ.get("NEUROPODS_PYTORCH_VERSION", "") or repository_ctx.attr.default_version
         if repository_ctx.os.name.startswith("mac"):
-            download_url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-" + version + ".zip"
+            download_url = "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-" + version + ".zip"
         else:
-            download_url = "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-" + version + ".zip"
+            download_url = "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-" + version + ".zip"
         download_sha = ''
 
     repository_ctx.download_and_extract(download_url, sha256=download_sha, stripPrefix="libtorch")

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -8,7 +8,7 @@ REQUIRED_PACKAGES = [
 
 EXTRA_REQUIRE = {
     "tensorflow": ["tensorflow"],
-    "torch": ["torch==1.0.0", "torchvision"],
+    "torch": ["torch_nightly==1.0.0.dev20190318"],
 }
 
 setup(


### PR DESCRIPTION
Things like support for `dict` was added after the latest stable release of libtorch. Upgrading to a nightly build lets us start using such features