### PR TITLE
Add string tensor support to the torchscript backend (C++)

### DIFF
--- a/build/allowed_deps.txt
+++ b/build/allowed_deps.txt
@@ -6,6 +6,8 @@
 #
  0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc10.so]
+ 0x0000000000000001 (NEEDED)             Shared library: [libcaffe2.so]
  0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
  0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]

--- a/source/deps/BUILD.libtorch
+++ b/source/deps/BUILD.libtorch
@@ -23,11 +23,38 @@ cc_library(
     ],
 )
 
-cc_import(
+cc_library(
     name = "libtorch",
+    deps = [
+        ":libtorch_so",
+        ":libc10_so",
+        ":libcaffe2_so",
+    ],
+)
+
+cc_import(
+    name = "libtorch_so",
     interface_library = select({
         "@bazel_tools//src/conditions:darwin": "lib/libtorch.dylib",
         "//conditions:default": "lib/libtorch.so",
+    }),
+    system_provided = True,
+)
+
+cc_import(
+    name = "libc10_so",
+    interface_library = select({
+        "@bazel_tools//src/conditions:darwin": "lib/libc10.dylib",
+        "//conditions:default": "lib/libc10.so",
+    }),
+    system_provided = True,
+)
+
+cc_import(
+    name = "libcaffe2_so",
+    interface_library = select({
+        "@bazel_tools//src/conditions:darwin": "lib/libcaffe2.dylib",
+        "//conditions:default": "lib/libcaffe2.so",
     }),
     system_provided = True,
 )

--- a/source/neuropods/backends/torchscript/BUILD
+++ b/source/neuropods/backends/torchscript/BUILD
@@ -2,12 +2,26 @@
 # Uber, Inc. (c) 2018
 #
 
+cc_library(
+    name = "torchscript_backend_hdrs",
+    hdrs = [
+        "torch_backend.hh",
+        "torch_tensor.hh",
+    ],
+    visibility = [
+        "//neuropods:__subpackages__",
+    ],
+    deps = [
+        "//neuropods/backends:neuropod_backend",
+        "@libtorch_repo//:libtorch_hdrs",
+        "@libtorch_repo//:libtorch",
+    ],
+)
+
 cc_binary(
     name = "libneuropod_torchscript_backend.so",
     srcs = [
         "torch_backend.cc",
-        "torch_backend.hh",
-        "torch_tensor.hh",
         "type_utils.cc",
         "type_utils.hh",
         "//neuropods:libneuropods.so",
@@ -19,8 +33,6 @@ cc_binary(
         "//neuropods:__subpackages__",
     ],
     deps = [
-        "//neuropods/backends:neuropod_backend",
-        "@libtorch_repo//:libtorch_hdrs",
-        "@libtorch_repo//:libtorch",
+        ":torchscript_backend_hdrs",
     ]
 )

--- a/source/neuropods/backends/torchscript/torch_backend.cc
+++ b/source/neuropods/backends/torchscript/torch_backend.cc
@@ -96,16 +96,39 @@ std::unique_ptr<TensorStore> TorchNeuropodBackend::infer(const TensorStore &inpu
     const auto &outputs_dict = result.toGenericDict()->elements();
     for (const auto &elem : outputs_dict)
     {
-        // Get the name and torch tensor
-        const std::string &name   = elem.first.toString()->string();
-        auto               tensor = elem.second.toTensor();
+        // Get the name of the tensor
+        const std::string &name = elem.first.toString()->string();
 
-        // Get the type and make a TorchNeuropodTensor
-        auto tensor_type = get_neuropod_type_from_torch_type(tensor.scalar_type());
-        auto neuropod_tensor = make_tensor<TorchNeuropodTensor>(tensor_type, name, tensor);
+        if (elem.second.isGenericList())
+        {
+            // A list or nested lists
+            // This is used in place of string tensors because torch does not
+            // have native support for string tensors
+            auto tensor = elem.second;
 
-        // Add it to our TensorStore
-        to_return->tensors.emplace_back(std::move(neuropod_tensor));
+            // Make a TorchNeuropodTensor
+            auto neuropod_tensor = stdx::make_unique<TorchNeuropodTensor<std::string>>(name, tensor);
+
+            // Add it to our TensorStore
+            to_return->tensors.emplace_back(std::move(neuropod_tensor));
+        }
+        else if (elem.second.isTensor())
+        {
+            // Torch tensor
+            auto tensor = elem.second.toTensor();
+
+            // Get the type and make a TorchNeuropodTensor
+            auto tensor_type = get_neuropod_type_from_torch_type(tensor.scalar_type());
+            auto neuropod_tensor = make_tensor<TorchNeuropodTensor>(tensor_type, name, tensor);
+
+            // Add it to our TensorStore
+            to_return->tensors.emplace_back(std::move(neuropod_tensor));
+        }
+        else
+        {
+            throw std::runtime_error("Neuropod returned an invalid type! All outputs must be tensors"
+                "or (potentially nested) lists of strings.");
+        }
     }
 
     return to_return;

--- a/source/neuropods/backends/torchscript/torch_tensor.hh
+++ b/source/neuropods/backends/torchscript/torch_tensor.hh
@@ -25,12 +25,6 @@ T *get_data_from_torch_tensor(const torch::Tensor &tensor)
 }
 
 template <>
-std::string *get_data_from_torch_tensor(const torch::Tensor &tensor)
-{
-    throw std::runtime_error("String support is not implemented yet");
-}
-
-template <>
 uint16_t *get_data_from_torch_tensor(const torch::Tensor &tensor)
 {
     throw std::runtime_error("TorchScript doesn't support type uint16_t");
@@ -82,6 +76,150 @@ public:
 
     // The underlying torch tensor
     torch::Tensor tensor;
+};
+
+// Utility function to get the dims of a string "tensor" represented by nested
+// lists.
+// Note: this function assumes that the list of lists are rectangular (i.e. the
+// level of nesting is the same throughout the whole structure)
+std::vector<int64_t> get_dims_from_nested_lists(const c10::intrusive_ptr<at::ivalue::GenericList> &input)
+{
+    std::vector<int64_t> out;
+
+    c10::intrusive_ptr<at::ivalue::GenericList> curr = input;
+    while (true)
+    {
+        out.push_back(curr->elements().size());
+
+        if (curr->elements()[0].isGenericList())
+        {
+            // List of lists meaning that there are more dims
+            curr = curr->elements()[0].toGenericList();
+        }
+        else
+        {
+            // No more nested lists
+            return out;
+        }
+    }
+}
+
+// Iterates through nested lists in row major order and fills a vector of output data
+void row_major_fill(const c10::intrusive_ptr<at::ivalue::GenericList> &input, std::vector<std::string> &output_data)
+{
+    const auto &elems = input->elements();
+    if (elems[0].isGenericList())
+    {
+        for (const auto &elem : elems)
+        {
+            // Recursive call
+            row_major_fill(elem.toGenericList(), output_data);
+        }
+    }
+    else
+    {
+        // Copy the data into the vector
+        for (const auto &elem : elems)
+        {
+            output_data.push_back(elem.toStringRef());
+        }
+    }
+}
+
+// Iterates through a vector and creates nested lists to match the specified dimensions
+c10::intrusive_ptr<at::ivalue::GenericList> make_nested_list(std::vector<std::string>::const_iterator &it,
+                                                             const std::vector<int64_t> &              dims,
+                                                             int                                       depth = 0)
+{
+    std::vector<torch::jit::IValue> out;
+
+    const int dim_size = dims[depth];
+    if (depth == dims.size() - 1)
+    {
+        // Base case
+        for (int i = 0; i < dim_size; i++)
+        {
+            // Get the next item from the iterator
+            // Note: there is a bounds check that happens outside of this function
+            // so we don't need to repeat it in this loop
+            out.emplace_back(*(it++));
+        }
+    }
+    else
+    {
+        // Recursive call
+        for (int i = 0; i < dim_size; i++)
+        {
+            out.emplace_back(make_nested_list(it, dims, depth + 1));
+        }
+    }
+
+    return at::ivalue::GenericList::create(out);
+}
+
+// Specialization for strings
+// Torch does not natively support string tensors. We will be using
+// (potentially nested) lists instead
+template <>
+class TorchNeuropodTensor<std::string> : public TypedNeuropodTensor<std::string>,
+                                         public NativeDataContainer<torch::jit::IValue>
+{
+public:
+    // Allocate a torch tensor
+    TorchNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<std::string>(name, dims)
+    {
+    }
+
+    // Wrap an existing string "tensor"
+    TorchNeuropodTensor(const std::string &name, torch::jit::IValue tensor)
+        : TypedNeuropodTensor<std::string>(name, get_dims_from_nested_lists(tensor.toGenericList())),
+          list_(tensor.toGenericList())
+    {
+    }
+
+    ~TorchNeuropodTensor() = default;
+
+    void set(const std::vector<std::string> &data)
+    {
+        // Sanity check
+        if (data.size() != get_num_elements())
+        {
+            throw std::runtime_error(
+                "Error. Size of supplied vector does not match the number of elements in the tensor.");
+        }
+
+        // Get a const_iterator from the vector
+        auto it = data.begin();
+
+        // Make the list
+        list_ = make_nested_list(it, get_dims());
+    }
+
+    std::vector<std::string> get_data_as_vector()
+    {
+        std::vector<std::string> out;
+        // Reserve space for the whole tensor
+        out.reserve(get_num_elements());
+
+        // Fill the vector in row major order
+        row_major_fill(list_, out);
+
+        // Sanity check
+        if (out.size() != get_num_elements())
+        {
+            throw std::runtime_error("Error converting TorchScript list into vector of strings. "
+                                     "Make sure that the dimensions of the returned list are correct.");
+        }
+
+        // Return the filled vector
+        return out;
+    }
+
+    torch::jit::IValue get_native_data() { return list_; }
+
+    // The underlying torchscript list
+    c10::intrusive_ptr<at::ivalue::GenericList> list_;
 };
 
 } // namespace neuropods

--- a/source/neuropods/tests/BUILD
+++ b/source/neuropods/tests/BUILD
@@ -41,6 +41,17 @@ cc_test(
 )
 
 cc_test(
+    name = "test_torch_string_tensor",
+    srcs = [
+        "test_torch_string_tensor.cc",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropods/backends/torchscript:torchscript_backend_hdrs",
+    ],
+)
+
+cc_test(
     name = "test_tensorflow_backend",
     srcs = [
         "test_tensorflow_backend.cc",

--- a/source/neuropods/tests/test_default_backend.cc
+++ b/source/neuropods/tests/test_default_backend.cc
@@ -22,12 +22,11 @@ TEST(test_default_backend, test_torchscript_addition_model)
     test_addition_model("neuropods/tests/test_data/torchscript_addition_model/");
 }
 
-// TODO(vip): enable once C++ support for torchscript string "tensors" (nested lists or tuples) lands
-// TEST(test_default_backend, test_torchscript_strings_model)
-// {
-//     // Test the TorchScript strings model
-//     test_strings_model("neuropods/tests/test_data/torchscript_strings_model/");
-// }
+TEST(test_default_backend, test_torchscript_strings_model)
+{
+    // Test the TorchScript strings model
+    test_strings_model("neuropods/tests/test_data/torchscript_strings_model/");
+}
 
 TEST(test_default_backend, test_tensorflow_addition_model)
 {

--- a/source/neuropods/tests/test_torch_string_tensor.cc
+++ b/source/neuropods/tests/test_torch_string_tensor.cc
@@ -1,0 +1,47 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include "gtest/gtest.h"
+
+#include "neuropods/backends/torchscript/torch_tensor.hh"
+
+namespace
+{
+
+std::vector<std::string> get_sample_data(size_t numel)
+{
+    // Create a vector and fill it with sample data
+    std::vector<std::string> sample_data;
+    for (int i = 0; i < numel; i++) {
+        sample_data.emplace_back("item" + std::to_string(i));
+    }
+
+    return sample_data;
+}
+
+}
+
+TEST(test_torch_tensor, test_create_read_string_tensor)
+{
+    // Create a vector and fill it with sample data
+    const std::vector<int64_t> dims = {1, 5, 6};
+    auto numel = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int64_t>());
+    const auto sample_data = get_sample_data(numel);
+
+    // Convert to torchscript nested lists
+    auto it = sample_data.begin();
+    auto tensor = neuropods::make_nested_list(it, dims);
+
+    // Get as a vector
+    std::vector<std::string> out;
+    out.reserve(numel);
+    neuropods::row_major_fill(tensor, out);
+
+    // Get the dims
+    auto out_dims = neuropods::get_dims_from_nested_lists(tensor);
+
+    // Check that everything matches
+    EXPECT_TRUE(sample_data == out);
+    EXPECT_TRUE(dims == out_dims);
+}

--- a/source/neuropods/tests/test_torchscript_backend.cc
+++ b/source/neuropods/tests/test_torchscript_backend.cc
@@ -9,3 +9,9 @@ TEST(test_models, test_torchscript_addition_model)
     // Test the TorchScript addition model using the native torchscript backend
     test_addition_model("neuropods/tests/test_data/torchscript_addition_model/", "TorchNeuropodBackend");
 }
+
+TEST(test_models, test_torchscript_strings_model)
+{
+    // Test the TorchScript strings model using the native torchscript backend
+    test_strings_model("neuropods/tests/test_data/torchscript_strings_model/", "TorchNeuropodBackend");
+}


### PR DESCRIPTION
TorchScript and PyTorch do not natively support string tensors. This PR implements string tensors as nested lists and adds some tests.

To create a string "tensor" given dimensions and a flat vector of data, we build a structure of nested lists to match the expected dimensions and fill the structure with the provided data.

To get a flat vector of strings from a string "tensor", we iterate through the structure of nested lists in row major order and append to the output vector.