### PR TITLE
Add the ability to wrap user-owned memory

### DIFF
--- a/source/neuropods/backends/BUILD
+++ b/source/neuropods/backends/BUILD
@@ -15,6 +15,7 @@ cc_library(
     ],
     deps = [
         "//neuropods/internal:backend_registration",
+        "//neuropods/internal:deleter",
         "//neuropods/internal:neuropod_tensor",
         "//neuropods/internal:tensor_store",
     ],

--- a/source/neuropods/backends/neuropod_backend.hh
+++ b/source/neuropods/backends/neuropod_backend.hh
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "neuropods/internal/backend_registration.hh"
+#include "neuropods/internal/deleter.hh"
 #include "neuropods/internal/neuropod_tensor.hh"
 #include "neuropods/internal/tensor_types.hh"
 
@@ -30,6 +31,18 @@ public:
                                                             TensorType                  tensor_type)
         = 0;
 
+    // Allocate a tensor of a specific type and wrap existing memory.
+    // Note: Some backends may have specific alignment requirements (e.g. tensorflow).
+    // To support all the built-in backends, `data` should be aligned to 64 bytes.
+    // `deleter` will be called with a pointer to `data` when the tensor is
+    // deallocated
+    virtual std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
+                                                               const std::vector<int64_t> &input_dims,
+                                                               TensorType                  tensor_type,
+                                                               void *                      data,
+                                                               const Deleter &             deleter)
+        = 0;
+
     // Run inference
     virtual std::unique_ptr<TensorStore> infer(const TensorStore &inputs) = 0;
 };
@@ -43,6 +56,15 @@ public:
                                                     TensorType                  tensor_type)
     {
         return make_tensor<TensorImpl>(tensor_type, node_name, input_dims);
+    }
+
+    std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
+                                                       const std::vector<int64_t> &input_dims,
+                                                       TensorType                  tensor_type,
+                                                       void *                      data,
+                                                       const Deleter &             deleter)
+    {
+        return make_tensor_no_string<TensorImpl>(tensor_type, node_name, input_dims, data, deleter);
     }
 };
 

--- a/source/neuropods/backends/python_bridge/BUILD
+++ b/source/neuropods/backends/python_bridge/BUILD
@@ -23,6 +23,7 @@ cc_binary(
     ],
     deps = [
         "//neuropods/backends:neuropod_backend",
+        "//neuropods/internal:deleter",
         "@boost_repo//:boost",
     ] + select({
         "@bazel_tools//src/conditions:darwin": ["@python_numpy_repo_darwin//:python_numpy"],

--- a/source/neuropods/backends/tensorflow/BUILD
+++ b/source/neuropods/backends/tensorflow/BUILD
@@ -21,6 +21,7 @@ cc_binary(
     ],
     deps = [
         "//neuropods/backends:neuropod_backend",
+        "//neuropods/internal:deleter",
         "@tensorflow_repo//:tensorflow_c_hdrs",
         "@tensorflow_repo//:libtensorflow",
     ]

--- a/source/neuropods/backends/test_backend/BUILD
+++ b/source/neuropods/backends/test_backend/BUILD
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         "//neuropods/backends:neuropod_backend",
+        "//neuropods/internal:deleter",
     ],
 )
 

--- a/source/neuropods/backends/torchscript/BUILD
+++ b/source/neuropods/backends/torchscript/BUILD
@@ -20,6 +20,7 @@ cc_binary(
     ],
     deps = [
         "//neuropods/backends:neuropod_backend",
+        "//neuropods/internal:deleter",
         "@libtorch_repo//:libtorch_hdrs",
         "@libtorch_repo//:libtorch",
     ]

--- a/source/neuropods/internal/BUILD
+++ b/source/neuropods/internal/BUILD
@@ -91,6 +91,19 @@ cc_library(
     linkopts = ["-ldl"],
 )
 
+cc_library(
+    name = "deleter",
+    hdrs = [
+        "deleter.hh",
+    ],
+    srcs = [
+        "deleter.cc",
+    ],
+    visibility = [
+        "//neuropods:__subpackages__",
+    ],
+)
+
 # Package all the header files
 pkg_tar(
     name = "libneuropods_internal_hdrs",

--- a/source/neuropods/internal/deleter.cc
+++ b/source/neuropods/internal/deleter.cc
@@ -1,0 +1,43 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include "neuropods/internal/deleter.hh"
+
+namespace neuropods
+{
+namespace
+{
+
+struct deleter_wrapper
+{
+    // A user provided deleter function to run
+    Deleter deleter;
+
+    // The data pointer to pass to the deleter
+    void * data;
+};
+
+} // namespace
+
+void run_deleter(void * handle)
+{
+    if (handle == nullptr)
+    {
+        return;
+    }
+
+    // Run the deleter and then delete the wrapper
+    auto wrapper = static_cast<deleter_wrapper *>(handle);
+    wrapper->deleter(wrapper->data);
+    delete wrapper;
+}
+
+void * register_deleter(const Deleter &deleter, void * data)
+{
+    // Create a new wrapper and return a handle
+    // This is deleted in `run_deleter`
+    return new deleter_wrapper({deleter, data});
+}
+
+} // namespace neuropods

--- a/source/neuropods/internal/deleter.hh
+++ b/source/neuropods/internal/deleter.hh
@@ -1,0 +1,22 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#pragma once
+
+#include <functional>
+
+namespace neuropods
+{
+
+// Used to deallocate user provided memory
+using Deleter = std::function<void(void*)>;
+
+// Run a deleter with a specific handle and then delete the deleter
+void run_deleter(void * handle);
+
+// Register a deleter function for some memory. Returns an opaque
+// handle
+void * register_deleter(const Deleter &deleter, void * data);
+
+} // namespace neuropods

--- a/source/neuropods/internal/neuropod_tensor.hh
+++ b/source/neuropods/internal/neuropod_tensor.hh
@@ -337,15 +337,15 @@ public:
 
 
 // Utility to make a tensor of a specific type
-template <template <class> class TensorClass, typename... Params>
-std::unique_ptr<NeuropodTensor> make_tensor(TensorType tensor_type, Params &&... params)
-{
 #define MAKE_TENSOR(CPP_TYPE, NEUROPOD_TYPE)                                              \
     case NEUROPOD_TYPE:                                                                   \
     {                                                                                     \
         return stdx::make_unique<TensorClass<CPP_TYPE>>(std::forward<Params>(params)...); \
     }
 
+template <template <class> class TensorClass, typename... Params>
+std::unique_ptr<NeuropodTensor> make_tensor(TensorType tensor_type, Params &&... params)
+{
     // Make a tensor of the correct type and return it
     switch (tensor_type)
     {
@@ -353,8 +353,21 @@ std::unique_ptr<NeuropodTensor> make_tensor(TensorType tensor_type, Params &&...
     default:
         throw std::runtime_error("Unsupported tensor type!");
     }
-#undef MAKE_TENSOR
 }
+
+template <template <class> class TensorClass, typename... Params>
+std::unique_ptr<NeuropodTensor> make_tensor_no_string(TensorType tensor_type, Params &&... params)
+{
+    // Make a tensor of the correct type and return it
+    switch (tensor_type)
+    {
+        FOR_EACH_TYPE_MAPPING_EXCEPT_STRING(MAKE_TENSOR)
+    default:
+        throw std::runtime_error("Unsupported tensor type!");
+    }
+}
+
+#undef MAKE_TENSOR
 
 // Utility superclass for getting data from a tensor
 // without having to downcast to a specific TypedNeuropodTensor

--- a/source/neuropods/neuropod_input_builder.hh
+++ b/source/neuropods/neuropod_input_builder.hh
@@ -48,10 +48,24 @@ public:
                                      const std::vector<int64_t> &input_dims);
 
     // Add a tensor of a certain shape
-    // The InputBuilder will allocate the memory and return a
+    // The InputBuilder will allocate the memory and return a pointer to a
     // TypedNeuropodTensor<T> object that can be used to write the data.
     template <typename T>
     TypedNeuropodTensor<T> *allocate_tensor(const std::string &node_name, const std::vector<int64_t> &input_dims);
+
+    // Add a tensor of a certain shape with existing data
+    // The InputBuilder will wrap the provided memory and return a
+    // pointer to a TypedNeuropodTensor<T> object
+    //
+    // Note: Some backends may have specific alignment requirements (e.g. tensorflow).
+    // To support all the built-in backends, `data` should be aligned to 64 bytes.
+    // `deleter` will be called with a pointer to `data` when the tensor is
+    // deallocated
+    template <typename T>
+    TypedNeuropodTensor<T> *tensor_from_memory(const std::string &         node_name,
+                                               const std::vector<int64_t> &input_dims,
+                                               void *                      data,
+                                               const Deleter &             deleter);
 
     // Get the data
     std::unique_ptr<TensorStore> build();

--- a/source/neuropods/tests/test_utils.hh
+++ b/source/neuropods/tests/test_utils.hh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -12,47 +13,87 @@
 
 #include "neuropods/neuropods.hh"
 
+void test_addition_model(neuropods::Neuropod &neuropod, bool copy_mem)
+{
+    std::atomic_int free_counter{0};
+    {
+        // Check the input and output tensor specs
+        auto input_specs  = neuropod.get_inputs();
+        auto output_specs = neuropod.get_outputs();
+        EXPECT_EQ(input_specs.at(0).name, "x");
+        EXPECT_EQ(input_specs.at(0).type, neuropods::FLOAT_TENSOR);
+
+        EXPECT_EQ(input_specs.at(1).name, "y");
+        EXPECT_EQ(input_specs.at(1).type, neuropods::FLOAT_TENSOR);
+
+        EXPECT_EQ(output_specs.at(0).name, "out");
+        EXPECT_EQ(output_specs.at(0).type, neuropods::FLOAT_TENSOR);
+
+        // Some sample input data
+        std::vector<int64_t> shape = {2, 2};
+        const float x_data[] = {1, 2, 3, 4};
+        const float y_data[] = {7, 8, 9, 10};
+        const float target[] = {8, 10, 12, 14};
+
+        // Get an input builder and add some data
+        auto input_builder = neuropod.get_input_builder();
+
+        if (copy_mem)
+        {
+            input_builder->add_tensor("x", x_data, 4, shape).add_tensor("y", y_data, 4, shape);
+        }
+        else
+        {
+            // 64 byte aligned input data
+            float * x_data_aligned = static_cast<float *>(aligned_alloc(64, 64));
+            float * y_data_aligned = static_cast<float *>(aligned_alloc(64, 64));
+
+            // Set the data
+            std::copy(x_data, x_data + 4, x_data_aligned);
+            std::copy(y_data, y_data + 4, y_data_aligned);
+
+            // Set up a deleter to free the memory
+            auto deleter = [&](void * data) {
+                free(data);
+                free_counter++;
+            };
+
+            input_builder->tensor_from_memory<float>("x", shape, const_cast<float *>(x_data_aligned), deleter);
+            input_builder->tensor_from_memory<float>("y", shape, const_cast<float *>(y_data_aligned), deleter);
+        }
+
+        auto input_data = input_builder->build();
+
+        // Run inference
+        const auto output_data = neuropod.infer(input_data);
+
+        // Get the data in the output tensor
+        const std::vector<float>   out_vector = output_data->find_or_throw("out")
+                                                           ->as_typed_tensor<float>()
+                                                           ->get_data_as_vector();
+
+        const std::vector<int64_t> out_shape  = output_data->find_or_throw("out")->get_dims();
+
+        // Check that the output data matches
+        EXPECT_EQ(out_vector.size(), 4);
+        EXPECT_TRUE(std::equal(out_vector.begin(), out_vector.end(), target));
+
+        // Check that the shape matches
+        EXPECT_TRUE(out_shape == shape);
+    }
+
+    if (!copy_mem)
+    {
+        // Make sure we ran the deleter
+        EXPECT_EQ(free_counter, 2);
+    }
+}
+
 void test_addition_model(neuropods::Neuropod &neuropod)
 {
-    // Check the input and output tensor specs
-    auto input_specs  = neuropod.get_inputs();
-    auto output_specs = neuropod.get_outputs();
-    EXPECT_EQ(input_specs.at(0).name, "x");
-    EXPECT_EQ(input_specs.at(0).type, neuropods::FLOAT_TENSOR);
-
-    EXPECT_EQ(input_specs.at(1).name, "y");
-    EXPECT_EQ(input_specs.at(1).type, neuropods::FLOAT_TENSOR);
-
-    EXPECT_EQ(output_specs.at(0).name, "out");
-    EXPECT_EQ(output_specs.at(0).type, neuropods::FLOAT_TENSOR);
-
-    // Some sample input data
-    std::vector<int64_t> shape = {2, 2};
-
-    const float x_data[] = {1, 2, 3, 4};
-    const float y_data[] = {7, 8, 9, 10};
-    const float target[] = {8, 10, 12, 14};
-
-    // Get an input builder and add some data
-    auto input_builder = neuropod.get_input_builder();
-    auto input_data    = input_builder->add_tensor("x", x_data, 4, shape).add_tensor("y", y_data, 4, shape).build();
-
-    // Run inference
-    const auto output_data = neuropod.infer(input_data);
-
-    // Get the data in the output tensor
-    const std::vector<float>   out_vector = output_data->find_or_throw("out")
-                                                       ->as_typed_tensor<float>()
-                                                       ->get_data_as_vector();
-
-    const std::vector<int64_t> out_shape  = output_data->find_or_throw("out")->get_dims();
-
-    // Check that the output data matches
-    EXPECT_EQ(out_vector.size(), 4);
-    EXPECT_TRUE(std::equal(out_vector.begin(), out_vector.end(), target));
-
-    // Check that the shape matches
-    EXPECT_TRUE(out_shape == shape);
+    // Run the test with and without copying the input data
+    test_addition_model(neuropod, true);
+    test_addition_model(neuropod, false);
 }
 
 void test_addition_model(const std::string &neuropod_path, const std::string &backend)


### PR DESCRIPTION
This PR makes it possible to allocate a NeuropodTensor using user provided memory.

It updates every backend to add support for this and adds tests to make sure inference and deallocation works correctly.

Note: `NeuropodInputBuilder` will be refactored or removed in another PR and the public interface will become a little more intuitive