### PR TITLE
Add 1D string tensor support to the torchscript backend (C++)

### DIFF
--- a/source/neuropods/tests/test_default_backend.cc
+++ b/source/neuropods/tests/test_default_backend.cc
@@ -22,12 +22,11 @@ TEST(test_default_backend, test_torchscript_addition_model)
     test_addition_model("neuropods/tests/test_data/torchscript_addition_model/");
 }
 
-// TODO(vip): enable once C++ support for torchscript string "tensors" (nested lists or tuples) lands
-// TEST(test_default_backend, test_torchscript_strings_model)
-// {
-//     // Test the TorchScript strings model
-//     test_strings_model("neuropods/tests/test_data/torchscript_strings_model/");
-// }
+TEST(test_default_backend, test_torchscript_strings_model)
+{
+    // Test the TorchScript strings model
+    test_strings_model("neuropods/tests/test_data/torchscript_strings_model/");
+}
 
 TEST(test_default_backend, test_tensorflow_addition_model)
 {

--- a/source/neuropods/tests/test_torchscript_backend.cc
+++ b/source/neuropods/tests/test_torchscript_backend.cc
@@ -9,3 +9,9 @@ TEST(test_models, test_torchscript_addition_model)
     // Test the TorchScript addition model using the native torchscript backend
     test_addition_model("neuropods/tests/test_data/torchscript_addition_model/", "TorchNeuropodBackend");
 }
+
+TEST(test_models, test_torchscript_strings_model)
+{
+    // Test the TorchScript strings model using the native torchscript backend
+    test_strings_model("neuropods/tests/test_data/torchscript_strings_model/", "TorchNeuropodBackend");
+}


### PR DESCRIPTION
TorchScript and PyTorch do not natively support string tensors. This PR implements 1D string tensors as lists and adds some tests.

This supersedes #39. Until we decide on a good solution for multidimensional string tensors in TorchScript, we will only have support for 1D string tensors.