### PR TITLE
Add SHA256s for the TF and libtorch deps

### DIFF
--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -7,12 +7,14 @@ libtorch_repository(
     name = "libtorch_repo",
     build_file = "@//deps:BUILD.libtorch",
     default_version = "1.0.0.dev20190318",
+    default_sha = "6e59041708bf7438f9e5d4e1dbf6fbb4dc53aacae3f198f5d626e0ef0d5b4e19",
 )
 
 tensorflow_repository(
     name = "tensorflow_repo",
     build_file = "@//deps:BUILD.tensorflow",
     default_version = "1.12.0",
+    default_sha = "fd473e2ef72a446421f627aebe90479b92495965c26843034625677a14d8d64f",
 )
 
 http_archive(

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -11,6 +11,10 @@ def _impl(repository_ctx):
             download_url = "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-" + version + ".zip"
         download_sha = ''
 
+        if repository_ctx.attr.default_version == version:
+            # If we're using the default version, use the default sha
+            download_sha = repository_ctx.attr.default_sha
+
     repository_ctx.download_and_extract(download_url, sha256=download_sha, stripPrefix="libtorch")
     repository_ctx.symlink(repository_ctx.path(Label(repository_ctx.attr.build_file)), "BUILD.bazel")
 
@@ -18,4 +22,5 @@ libtorch_repository = repository_rule(
     implementation=_impl,
     local=True,
     attrs={"build_file": attr.string(mandatory=True),
-           "default_version": attr.string(mandatory=True)})
+           "default_version": attr.string(mandatory=True),
+           "default_sha": attr.string()})

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -11,6 +11,10 @@ def _impl(repository_ctx):
             download_url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-" + version + ".tar.gz"
         download_sha = ''
 
+        if repository_ctx.attr.default_version == version:
+            # If we're using the default version, use the default sha
+            download_sha = repository_ctx.attr.default_sha
+
     repository_ctx.download_and_extract(download_url, sha256=download_sha)
     repository_ctx.symlink(repository_ctx.path(Label(repository_ctx.attr.build_file)), "BUILD.bazel")
 
@@ -18,4 +22,5 @@ tensorflow_repository = repository_rule(
     implementation=_impl,
     local=True,
     attrs={"build_file": attr.string(mandatory=True),
-           "default_version": attr.string(mandatory=True)})
+           "default_version": attr.string(mandatory=True),
+           "default_sha": attr.string()})


### PR DESCRIPTION
If we don't specify sha256 values, Bazel redownloads TF and libtorch on every build.

This PR adds default sha256 values matching the default versions of these libraries