### PR TITLE
Move model_config ownership to NeuropodBackend

### DIFF
--- a/source/neuropods/backends/python_bridge/python_bridge.cc
+++ b/source/neuropods/backends/python_bridge/python_bridge.cc
@@ -63,8 +63,9 @@ void maybe_register_python_shutdown()
 } // namespace
 
 PythonBridge::PythonBridge(const std::string &             neuropod_path,
-                           std::unique_ptr<ModelConfig> &  model_config,
+                           std::unique_ptr<ModelConfig>    model_config,
                            const std::vector<std::string> &python_path_additions)
+     : NeuropodBackend(std::move(model_config))
 {
     try
     {
@@ -73,7 +74,7 @@ PythonBridge::PythonBridge(const std::string &             neuropod_path,
         {
             setenv("PYTHONHOME", venv_path, true);
         }
- 
+
         // Register python shutdown
         maybe_register_python_shutdown();
 

--- a/source/neuropods/backends/python_bridge/python_bridge.hh
+++ b/source/neuropods/backends/python_bridge/python_bridge.hh
@@ -33,6 +33,9 @@ std::vector<std::string> get_default_python_path()
 class PythonBridge : public NeuropodBackendWithDefaultAllocator<NumpyNeuropodTensor>
 {
 private:
+    // The neuropod model config
+    std::unique_ptr<ModelConfig> model_config_;
+
     py::object main_module_;
     py::object main_namespace_;
 
@@ -40,7 +43,7 @@ private:
 
 public:
     PythonBridge(const std::string &             neuropod_path,
-                 std::unique_ptr<ModelConfig> &  model_config,
+                 std::unique_ptr<ModelConfig>    model_config,
                  const std::vector<std::string> &python_path_additions = get_default_python_path());
 
     ~PythonBridge();

--- a/source/neuropods/backends/tensorflow/tf_backend.cc
+++ b/source/neuropods/backends/tensorflow/tf_backend.cc
@@ -95,8 +95,9 @@ TF_Output get_graph_node_from_name(const std::string &node_name_with_index, cons
 
 } // namespace
 
-TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &           neuropod_path,
-                                                     std::unique_ptr<ModelConfig> &model_config)
+TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &          neuropod_path,
+                                                     std::unique_ptr<ModelConfig> model_config)
+     : NeuropodBackend(std::move(model_config))
 {
     // Get the graph path and load the graph
     load_graph(get_graph_path(neuropod_path));
@@ -105,7 +106,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &        
     setup_node_mapping(neuropod_path, node_name_mapping_);
 
     // Get a list of the output nodes
-    for (const auto &output : model_config->outputs)
+    for (const auto &output : model_config_->outputs)
     {
         output_names_.emplace_back(output.name);
     }

--- a/source/neuropods/backends/tensorflow/tf_backend.hh
+++ b/source/neuropods/backends/tensorflow/tf_backend.hh
@@ -51,7 +51,7 @@ private:
     std::vector<std::string> output_names_;
 
 public:
-    explicit TensorflowNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
+    explicit TensorflowNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> model_config);
 
     ~TensorflowNeuropodBackend();
 

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.cc
@@ -10,7 +10,11 @@ namespace neuropods
 {
 
 TestNeuropodBackend::TestNeuropodBackend() {}
-TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config) {}
+TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> model_config)
+     : NeuropodBackend(std::move(model_config))
+{
+}
+
 TestNeuropodBackend::~TestNeuropodBackend() = default;
 
 // Run inference

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.hh
@@ -18,7 +18,7 @@ class TestNeuropodBackend : public NeuropodBackendWithDefaultAllocator<TestNeuro
 {
 public:
     TestNeuropodBackend();
-    TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
+    TestNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> model_config);
     ~TestNeuropodBackend();
 
     // Run inference

--- a/source/neuropods/backends/torchscript/torch_backend.cc
+++ b/source/neuropods/backends/torchscript/torch_backend.cc
@@ -46,8 +46,9 @@ std::string get_graph_path(const std::string &neuropod_path)
 
 } // namespace
 
-TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config)
-    : model_(load_model_from_path(get_graph_path(neuropod_path)))
+TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> model_config)
+    : NeuropodBackend(std::move(model_config)),
+      model_(load_model_from_path(get_graph_path(neuropod_path)))
 {
 }
 

--- a/source/neuropods/backends/torchscript/torch_backend.hh
+++ b/source/neuropods/backends/torchscript/torch_backend.hh
@@ -26,7 +26,7 @@ private:
     std::shared_ptr<torch::jit::script::Module> model_;
 
 public:
-    TorchNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> &model_config);
+    TorchNeuropodBackend(const std::string &neuropod_path, std::unique_ptr<ModelConfig> model_config);
 
     ~TorchNeuropodBackend();
 

--- a/source/neuropods/internal/backend_registration.hh
+++ b/source/neuropods/internal/backend_registration.hh
@@ -18,16 +18,16 @@ namespace neuropods
 class NeuropodBackend;
 
 // A function that takes in a path to a neuropod and returns a pointer to a NeuropodBackend
-typedef std::unique_ptr<NeuropodBackend> (*BackendFactoryFunction)(const std::string &           neuropod_path,
-                                                                   std::unique_ptr<ModelConfig> &config);
+typedef std::unique_ptr<NeuropodBackend> (*BackendFactoryFunction)(const std::string &          neuropod_path,
+                                                                   std::unique_ptr<ModelConfig> config);
 
 // A template to create a factory for any backend
 // This is used in the macro below
 template <typename T>
-std::unique_ptr<NeuropodBackend> createNeuropodBackend(const std::string &           neuropod_path,
-                                                       std::unique_ptr<ModelConfig> &config)
+std::unique_ptr<NeuropodBackend> createNeuropodBackend(const std::string &          neuropod_path,
+                                                       std::unique_ptr<ModelConfig> config)
 {
-    return stdx::make_unique<T>(neuropod_path, config);
+    return stdx::make_unique<T>(neuropod_path, std::move(config));
 }
 
 // Register a backend for a set of specific types

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -20,9 +20,6 @@ namespace neuropods
 class Neuropod
 {
 private:
-    // The neuropod model config
-    std::unique_ptr<ModelConfig> model_config_;
-
     // The backend used to load and run the neuropod
     std::shared_ptr<NeuropodBackend> backend_;
 
@@ -61,14 +58,21 @@ public:
     //   auto proxy = std::make_shared<NeuropodGRPCProxy>(neuropod_path, some_remote_config, ...);
     //   Neuropod neuropod(proxy);
     //
-    Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBackend> backend);
+    Neuropod(std::shared_ptr<NeuropodBackend> backend);
 
     ~Neuropod();
 
     // Run inference
     std::unique_ptr<TensorStore> infer(const std::unordered_set<std::shared_ptr<NeuropodTensor>> &inputs);
 
-    // Get the inputs and outputs of the loaded Neuropod
+
+    // Returns true if the neuropod has input and output specs specified
+    bool has_input_and_output_spec() const;
+
+    // Get the inputs and outputs of the loaded Neuropod if any
+    // Throws an error if the if the input and output specs of the model
+    // were not specified
+    // Check `has_input_and_output_spec()` before calling these methods
     const std::vector<TensorSpec> &get_inputs() const;
     const std::vector<TensorSpec> &get_outputs() const;
 


### PR DESCRIPTION
This PR lets us start to support loading models that don't have a corresponding ModelConfig (e.g. models that were not exported using our `create_*_neuropod` functions).

This allows users to decide whether they want to use Neuropod packaging (along with other features like the model interface definition, packaging time tests, shape/type checking, etc) instead of forcing them to.

This also lets us quickly convert inference code to use Neuropods without making any changes to the model export code.

Note: this is a breaking change