### PR TITLE
Add a NeuropodTensorAllocator interface

### DIFF
--- a/source/neuropods/backends/BUILD
+++ b/source/neuropods/backends/BUILD
@@ -8,6 +8,7 @@ cc_library(
     name = "neuropod_backend",
     srcs = [],
     hdrs = [
+        "tensor_allocator.hh",
         "neuropod_backend.hh",
     ],
     visibility = [

--- a/source/neuropods/backends/tensor_allocator.hh
+++ b/source/neuropods/backends/tensor_allocator.hh
@@ -1,0 +1,89 @@
+//
+// Uber, Inc. (c) 2018
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "neuropods/internal/deleter.hh"
+#include "neuropods/internal/neuropod_tensor.hh"
+#include "neuropods/internal/tensor_types.hh"
+
+namespace neuropods
+{
+
+// An base class used to allocate tensors
+class NeuropodTensorAllocator
+{
+public:
+    virtual ~NeuropodTensorAllocator() {}
+
+    // Allocate a tensor of a specific type
+    virtual std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
+                                                            const std::vector<int64_t> &input_dims,
+                                                            TensorType                  tensor_type)
+        = 0;
+
+    // Allocate a tensor of a specific type and wrap existing memory.
+    // Note: Some backends may have specific alignment requirements (e.g. tensorflow).
+    // To support all the built-in backends, `data` should be aligned to 64 bytes.
+    // `deleter` will be called with a pointer to `data` when the tensor is
+    // deallocated
+    virtual std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
+                                                               const std::vector<int64_t> &input_dims,
+                                                               TensorType                  tensor_type,
+                                                               void *                      data,
+                                                               const Deleter &             deleter)
+        = 0;
+
+    // Templated version of `allocate_tensor`
+    template <typename T>
+    std::shared_ptr<TypedNeuropodTensor<T>> allocate_tensor(const std::string &node_name,
+                                                            const std::vector<int64_t> &input_dims)
+    {
+        std::shared_ptr<NeuropodTensor> tensor
+            = this->allocate_tensor(node_name, input_dims, get_tensor_type_from_cpp<T>());
+
+        return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
+    }
+
+    // Templated version of `tensor_from_memory`
+    template <typename T>
+    std::shared_ptr<TypedNeuropodTensor<T>>  tensor_from_memory(const std::string &         node_name,
+                                                                const std::vector<int64_t> &input_dims,
+                                                                T *                         data,
+                                                                const Deleter &             deleter)
+    {
+        std::shared_ptr<NeuropodTensor> tensor
+            = this->tensor_from_memory(node_name, input_dims, get_tensor_type_from_cpp<T>(), data, deleter);
+
+        return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
+    }
+};
+
+// A default allocator
+template<template <class> class TensorImpl>
+class DefaultTensorAllocator : public NeuropodTensorAllocator
+{
+public:
+    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
+                                                    const std::vector<int64_t> &input_dims,
+                                                    TensorType                  tensor_type)
+    {
+        return make_tensor<TensorImpl>(tensor_type, node_name, input_dims);
+    }
+
+    std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
+                                                       const std::vector<int64_t> &input_dims,
+                                                       TensorType                  tensor_type,
+                                                       void *                      data,
+                                                       const Deleter &             deleter)
+    {
+        return make_tensor_no_string<TensorImpl>(tensor_type, node_name, input_dims, data, deleter);
+    }
+};
+
+} // namespace neuropods

--- a/source/neuropods/neuropods.cc
+++ b/source/neuropods/neuropods.cc
@@ -57,15 +57,17 @@ const std::vector<TensorSpec> &Neuropod::get_outputs() const
     return model_config_->outputs;
 }
 
+std::shared_ptr<NeuropodTensorAllocator> Neuropod::get_tensor_allocator()
+{
+    return backend_->get_tensor_allocator();
+}
+
 template <typename T>
 std::shared_ptr<TypedNeuropodTensor<T>> Neuropod::allocate_tensor(
     const std::string &node_name,
     const std::vector<int64_t> &input_dims)
 {
-    std::shared_ptr<NeuropodTensor> tensor
-        = backend_->allocate_tensor(node_name, input_dims, get_tensor_type_from_cpp<T>());
-
-    return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
+    return get_tensor_allocator()->allocate_tensor<T>(node_name, input_dims);
 }
 
 template <typename T>
@@ -75,10 +77,7 @@ std::shared_ptr<TypedNeuropodTensor<T>> Neuropod::tensor_from_memory(
     T *                         data,
     const Deleter &             deleter)
 {
-    std::shared_ptr<NeuropodTensor> tensor
-        = backend_->tensor_from_memory(node_name, input_dims, get_tensor_type_from_cpp<T>(), data, deleter);
-
-    return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
+    return get_tensor_allocator()->tensor_from_memory(node_name, input_dims, data, deleter);
 }
 
 // Instantiate the templates

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -71,6 +71,9 @@ public:
     const std::vector<TensorSpec> &get_inputs() const;
     const std::vector<TensorSpec> &get_outputs() const;
 
+    // Returns a tensor allocator that can allocate tensors compatible with this neuropod
+    std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator();
+
     // Allocate a tensor of a certain shape and type
     template <typename T>
     std::shared_ptr<TypedNeuropodTensor<T>> allocate_tensor(

--- a/source/neuropods/tests/test_conversions_eigen.cc
+++ b/source/neuropods/tests/test_conversions_eigen.cc
@@ -15,7 +15,7 @@ class int32_tensor_fixture : public ::testing::Test
 public:
     int32_tensor_fixture()
     {
-        untyped_tensor       = test_backend_.allocate_tensor("test_tensor", {ROWS}, neuropods::INT32_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {ROWS}, neuropods::INT32_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
@@ -43,7 +43,7 @@ class int32_matrix_fixture : public ::testing::Test
 public:
     int32_matrix_fixture()
     {
-        untyped_tensor       = test_backend_.allocate_tensor("test_matrix", {ROWS, COLS}, neuropods::INT32_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_matrix", {ROWS, COLS}, neuropods::INT32_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
@@ -149,6 +149,6 @@ TEST_F(int32_matrix_fixture, const_untyped_vector_as_eigen_type_mismatch)
 
 TEST_F(int32_matrix_fixture, higher_rank)
 {
-    untyped_tensor = test_backend_.allocate_tensor("test_tensor", {5, 5, 5}, neuropods::INT32_TENSOR);
+    untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {5, 5, 5}, neuropods::INT32_TENSOR);
     EXPECT_THROW(neuropods::as_eigen<int32_t>(*untyped_tensor), std::runtime_error);
 }

--- a/source/neuropods/tests/test_input_output.cc
+++ b/source/neuropods/tests/test_input_output.cc
@@ -57,21 +57,22 @@ void check_vectors_eq(const std::vector<T> &a, const std::vector<T> &b)
 TEST(test_allocate_tensor, add_tensors_and_validate)
 {
     neuropods::TestNeuropodBackend backend;
+    auto allocator = backend.get_tensor_allocator();
 
     // Allocate tensors
-    std::shared_ptr<neuropods::NeuropodTensor> a_ten = backend.allocate_tensor("a", a_shape, neuropods::INT32_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> a_ten = allocator->allocate_tensor("a", a_shape, neuropods::INT32_TENSOR);
     a_ten->as_typed_tensor<int32_t>()->copy_from(a_data);
 
-    std::shared_ptr<neuropods::NeuropodTensor> b_ten = backend.allocate_tensor("b", b_shape, neuropods::INT64_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> b_ten = allocator->allocate_tensor("b", b_shape, neuropods::INT64_TENSOR);
     b_ten->as_typed_tensor<int64_t>()->copy_from(b_data);
 
-    std::shared_ptr<neuropods::NeuropodTensor> c_ten = backend.allocate_tensor("c", c_shape, neuropods::FLOAT_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> c_ten = allocator->allocate_tensor("c", c_shape, neuropods::FLOAT_TENSOR);
     c_ten->as_typed_tensor<float>()->copy_from(c_data, 4);
 
     // Wrap existing data
     // TODO(vip): Refactor this test. It's bad practice to have an empty deleter
     // The created tensor should be responsible for deallocating the memory
-    std::shared_ptr<neuropods::NeuropodTensor> d_ten = backend.tensor_from_memory(
+    std::shared_ptr<neuropods::NeuropodTensor> d_ten = allocator->tensor_from_memory(
         "d",
         d_shape,
         neuropods::DOUBLE_TENSOR,

--- a/source/neuropods/tests/test_internal_neuropod_tensor.cc
+++ b/source/neuropods/tests/test_internal_neuropod_tensor.cc
@@ -16,7 +16,7 @@ class uint8_tensor_fixture : public ::testing::Test
 public:
     uint8_tensor_fixture()
     {
-        untyped_tensor       = test_backend_.allocate_tensor("test_tensor", {EXPECTED_SIZE}, neuropods::UINT8_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {EXPECTED_SIZE}, neuropods::UINT8_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<uint8_t>();
@@ -43,7 +43,7 @@ class uint8_scalar_fixture : public ::testing::Test
 public:
     uint8_scalar_fixture()
     {
-        untyped_tensor = test_backend_.allocate_tensor("test_scalar", {1}, neuropods::UINT8_TENSOR);
+        untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor("test_scalar", {1}, neuropods::UINT8_TENSOR);
         untyped_tensor->as_scalar<uint8_t>() = 42;
         const_untyped_tensor                 = untyped_tensor.get();
         tensor                               = untyped_tensor->as_typed_tensor<uint8_t>();
@@ -63,7 +63,7 @@ TEST(test_stream_operator, untyped_tensor)
 {
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
-    const auto untyped_tensor = test_backend.allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
+    const auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
     ss << *untyped_tensor;
 
     EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor 'tensor1'"));
@@ -73,7 +73,7 @@ TEST(test_stream_operator, typed_tensor)
 {
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
-    auto untyped_tensor = test_backend.allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<uint8_t>();
 
@@ -91,7 +91,7 @@ TEST(test_stream_operator, typed_float_tensor)
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
     constexpr int                  TENSOR_SIZE = 8;
-    auto untyped_tensor = test_backend.allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<float>();
 
@@ -109,7 +109,7 @@ TEST(test_typed_neuropod_tensor, downcast_failulre)
 {
     neuropods::TestNeuropodBackend test_backend;
     constexpr int                  TENSOR_SIZE = 8;
-    auto untyped_tensor = test_backend.allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     EXPECT_THROW(untyped_tensor->as_typed_tensor<int8_t>(), std::runtime_error);
 }


### PR DESCRIPTION
This allows users to allocate `NeuropodTensors` without creating a `Neuropod` or a `NeuropodBackend`.