### PR TITLE
Add NeuropodValue base type

### DIFF
--- a/source/neuropods/backends/neuropod_backend.hh
+++ b/source/neuropods/backends/neuropod_backend.hh
@@ -19,13 +19,13 @@
 namespace neuropods
 {
 
-// A map from a tensor name to a pointer to a NeuropodTensor
+// A map from a tensor name to a pointer to a NeuropodValue
 // This is the output type of `infer`
 // A map is provided for convenience
-using TensorMap = std::unordered_map<std::string, std::shared_ptr<NeuropodTensor>>;
+using ValueMap = std::unordered_map<std::string, std::shared_ptr<NeuropodValue>>;
 
 // This is the input type to `infer`
-using TensorSet = std::unordered_set<std::shared_ptr<NeuropodTensor>>;
+using ValueSet = std::unordered_set<std::shared_ptr<NeuropodValue>>;
 
 // The interface that every neuropod backend implements
 class NeuropodBackend
@@ -37,7 +37,7 @@ public:
     virtual std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator() = 0;
 
     // Run inference
-    virtual std::unique_ptr<TensorMap> infer(const TensorSet &inputs) = 0;
+    virtual std::unique_ptr<ValueMap> infer(const ValueSet &inputs) = 0;
 };
 
 template<template <class> class TensorImpl>

--- a/source/neuropods/backends/python_bridge/python_bridge.cc
+++ b/source/neuropods/backends/python_bridge/python_bridge.cc
@@ -113,13 +113,13 @@ PythonBridge::PythonBridge(const std::string &             neuropod_path,
 PythonBridge::~PythonBridge() = default;
 
 // Run inference
-std::unique_ptr<TensorMap> PythonBridge::infer(const TensorSet &inputs)
+std::unique_ptr<ValueMap> PythonBridge::infer(const ValueSet &inputs)
 {
     try
     {
         // Populate a dict mapping input names to values
         py::dict model_inputs;
-        for (const std::shared_ptr<NeuropodTensor> &tensor : inputs)
+        for (const auto &tensor : inputs)
         {
             model_inputs[tensor->get_name()]
                 = std::dynamic_pointer_cast<NativeDataContainer<py::object>>(tensor)->get_native_data();
@@ -138,7 +138,7 @@ std::unique_ptr<TensorMap> PythonBridge::infer(const TensorSet &inputs)
         py::dict model_outputs = py::extract<py::dict>(locals["model_outputs"]);
 
         // Convert from numpy to `NeuropodTensor`s
-        auto     to_return = stdx::make_unique<TensorMap>();
+        auto     to_return = stdx::make_unique<ValueMap>();
         py::list out_keys  = model_outputs.keys();
         for (int i = 0; i < py::len(out_keys); i++)
         {

--- a/source/neuropods/backends/python_bridge/python_bridge.hh
+++ b/source/neuropods/backends/python_bridge/python_bridge.hh
@@ -46,7 +46,7 @@ public:
     ~PythonBridge();
 
     // Run inference
-    std::unique_ptr<TensorMap> infer(const TensorSet &inputs);
+    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/tensorflow/tf_backend.cc
+++ b/source/neuropods/backends/tensorflow/tf_backend.cc
@@ -162,7 +162,7 @@ void TensorflowNeuropodBackend::load_graph(const std::string &graph_path)
 }
 
 // Run inference
-std::unique_ptr<TensorMap> TensorflowNeuropodBackend::infer(const TensorSet &inputs)
+std::unique_ptr<ValueMap> TensorflowNeuropodBackend::infer(const ValueSet &inputs)
 {
     std::vector<std::string> output_node_names;
 
@@ -179,7 +179,7 @@ std::unique_ptr<TensorMap> TensorflowNeuropodBackend::infer(const TensorSet &inp
     std::vector<TF_Tensor *> input_values;
 
     // Loop through all the input tensors and setup the inputs
-    for (const std::shared_ptr<NeuropodTensor> &tensor : inputs)
+    for (const auto &tensor : inputs)
     {
         const auto  input_name = node_name_mapping_.at(tensor->get_name());
         const auto &input_data
@@ -223,7 +223,7 @@ std::unique_ptr<TensorMap> TensorflowNeuropodBackend::infer(const TensorSet &inp
 
 
     // Read the outputs
-    auto to_return = stdx::make_unique<TensorMap>();
+    auto to_return = stdx::make_unique<ValueMap>();
     for (size_t i = 0; i < output_names_.size(); ++i)
     {
         const auto &output_name   = output_names_[i];

--- a/source/neuropods/backends/tensorflow/tf_backend.hh
+++ b/source/neuropods/backends/tensorflow/tf_backend.hh
@@ -50,7 +50,7 @@ public:
     ~TensorflowNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<TensorMap> infer(const TensorSet &inputs);
+    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.cc
@@ -12,9 +12,9 @@ TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, std::
 TestNeuropodBackend::~TestNeuropodBackend() = default;
 
 // Run inference
-std::unique_ptr<TensorMap> TestNeuropodBackend::infer(const TensorSet &inputs)
+std::unique_ptr<ValueMap> TestNeuropodBackend::infer(const ValueSet &inputs)
 {
-    return stdx::make_unique<TensorMap>();
+    return stdx::make_unique<ValueMap>();
 }
 
 REGISTER_NEUROPOD_BACKEND(TestNeuropodBackend, "noop")

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.hh
@@ -22,6 +22,6 @@ public:
     ~TestNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<TensorMap> infer(const TensorSet &inputs);
+    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
 };
 } // namespace neuropods

--- a/source/neuropods/backends/torchscript/torch_backend.cc
+++ b/source/neuropods/backends/torchscript/torch_backend.cc
@@ -58,7 +58,7 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &torchscript_model_
 TorchNeuropodBackend::~TorchNeuropodBackend() = default;
 
 // Run inference
-std::unique_ptr<TensorMap> TorchNeuropodBackend::infer(const TensorSet &inputs)
+std::unique_ptr<ValueMap> TorchNeuropodBackend::infer(const ValueSet &inputs)
 {
     torch::NoGradGuard guard;
 
@@ -68,7 +68,7 @@ std::unique_ptr<TensorMap> TorchNeuropodBackend::infer(const TensorSet &inputs)
 
     // Define the vector of inputs and add the inputs
     std::vector<torch::jit::IValue> torch_inputs(schema.arguments().size());
-    for (const std::shared_ptr<NeuropodTensor> &tensor : inputs)
+    for (const auto &tensor : inputs)
     {
         const auto  input_name = tensor->get_name();
         const auto &input_data = get_ivalue_from_torch_tensor(tensor);
@@ -88,7 +88,7 @@ std::unique_ptr<TensorMap> TorchNeuropodBackend::infer(const TensorSet &inputs)
     c10::IValue result = model_->forward(torch_inputs);
 
     // Get outputs
-    auto to_return = stdx::make_unique<TensorMap>();
+    auto to_return = stdx::make_unique<ValueMap>();
 
     const auto &outputs_dict = result.toGenericDict()->elements();
     for (const auto &elem : outputs_dict)

--- a/source/neuropods/backends/torchscript/torch_backend.hh
+++ b/source/neuropods/backends/torchscript/torch_backend.hh
@@ -34,7 +34,7 @@ public:
     ~TorchNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<TensorMap> infer(const TensorSet &inputs);
+    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/torchscript/torch_tensor.hh
+++ b/source/neuropods/backends/torchscript/torch_tensor.hh
@@ -179,7 +179,7 @@ public:
 };
 
 // Utility function to get an IValue from a torch tensor
-torch::jit::IValue get_ivalue_from_torch_tensor(const std::shared_ptr<NeuropodTensor> &tensor)
+torch::jit::IValue get_ivalue_from_torch_tensor(const std::shared_ptr<NeuropodValue> &tensor)
 {
     return std::dynamic_pointer_cast<NativeDataContainer<torch::jit::IValue>>(tensor)->get_native_data();
 }

--- a/source/neuropods/internal/BUILD
+++ b/source/neuropods/internal/BUILD
@@ -35,6 +35,9 @@ cc_library(
 
 cc_library(
     name = "neuropod_tensor",
+    srcs = [
+        "neuropod_tensor.cc",
+    ],
     hdrs = [
         "neuropod_tensor.hh",
         "tensor_types.hh",

--- a/source/neuropods/internal/neuropod_tensor.cc
+++ b/source/neuropods/internal/neuropod_tensor.cc
@@ -1,0 +1,40 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include "neuropods/internal/neuropod_tensor.hh"
+
+namespace neuropods
+{
+
+NeuropodTensor *NeuropodValue::as_tensor() {
+    assure_tensor();
+    return dynamic_cast<NeuropodTensor *>(this);
+}
+
+const NeuropodTensor *NeuropodValue::as_tensor() const {
+    assure_tensor();
+    return dynamic_cast<const NeuropodTensor *>(this);
+}
+
+
+template <typename T>
+TypedNeuropodTensor<T> *NeuropodValue::as_typed_tensor()
+{
+    return this->as_tensor()->as_typed_tensor<T>();
+}
+
+template <typename T>
+const TypedNeuropodTensor<T> *NeuropodValue::as_typed_tensor() const
+{
+    return this->as_tensor()->as_typed_tensor<T>();
+}
+
+
+#define INIT_TEMPLATES_FOR_TYPE(CPP_TYPE, NEUROPOD_TYPE)                                    \
+    template TypedNeuropodTensor<CPP_TYPE> * NeuropodValue::as_typed_tensor();              \
+    template const TypedNeuropodTensor<CPP_TYPE> * NeuropodValue::as_typed_tensor() const;
+
+FOR_EACH_TYPE_MAPPING_INCLUDING_STRING(INIT_TEMPLATES_FOR_TYPE);
+
+} // namespace neuropods

--- a/source/neuropods/neuropods.cc
+++ b/source/neuropods/neuropods.cc
@@ -40,9 +40,9 @@ Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBac
 
 Neuropod::~Neuropod() = default;
 
-std::unique_ptr<TensorMap> Neuropod::infer(const TensorSet &inputs)
+std::unique_ptr<ValueMap> Neuropod::infer(const ValueSet &inputs)
 {
-    // TODO(vip): make sure that tensor names in `inputs` are not repeated
+    // TODO(vip): make sure that names in `inputs` are not repeated
     // Run inference
     return backend_->infer(inputs);
 }

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -64,7 +64,7 @@ public:
     ~Neuropod();
 
     // Run inference
-    std::unique_ptr<TensorMap> infer(const TensorSet &inputs);
+    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
 
     // Get the inputs and outputs of the loaded Neuropod
     const std::vector<TensorSpec> &get_inputs() const;

--- a/source/neuropods/tests/test_utils.hh
+++ b/source/neuropods/tests/test_utils.hh
@@ -35,7 +35,7 @@ void test_addition_model(neuropods::Neuropod &neuropod, bool copy_mem)
         const float y_data[] = {7, 8, 9, 10};
         const float target[] = {8, 10, 12, 14};
 
-        std::unordered_set<std::shared_ptr<neuropods::NeuropodTensor>> input_data;
+        neuropods::ValueSet input_data;
 
         if (copy_mem)
         {
@@ -84,7 +84,7 @@ void test_addition_model(neuropods::Neuropod &neuropod, bool copy_mem)
                                                            ->as_typed_tensor<float>()
                                                            ->get_data_as_vector();
 
-        const std::vector<int64_t> out_shape  = output_data->at("out")->get_dims();
+        const std::vector<int64_t> out_shape  = output_data->at("out")->as_tensor()->get_dims();
 
         // Check that the output data matches
         EXPECT_EQ(out_vector.size(), 4);
@@ -149,7 +149,7 @@ void test_strings_model(neuropods::Neuropod &neuropod)
                                                            ->as_typed_tensor<std::string>()
                                                            ->get_data_as_vector();
 
-    const std::vector<int64_t>     out_shape  = output_data->at("out")->get_dims();
+    const std::vector<int64_t>     out_shape  = output_data->at("out")->as_tensor()->get_dims();
 
     // Check that the output data matches
     EXPECT_EQ(out_vector.size(), 3);


### PR DESCRIPTION
This lets us start to support use cases where
1. The user knows they're using a specific DL framework and
2. They want to pass non-tensor types to that framework

For example we can build a child of `NeuropodValue` that lets us pass `IValues` to TorchScript