### PR TITLE
Remove name from NeuropodValue / NeuropodTensor

### DIFF
--- a/source/neuropods/backends/neuropod_backend.hh
+++ b/source/neuropods/backends/neuropod_backend.hh
@@ -20,12 +20,8 @@ namespace neuropods
 {
 
 // A map from a tensor name to a pointer to a NeuropodValue
-// This is the output type of `infer`
-// A map is provided for convenience
-using ValueMap = std::unordered_map<std::string, std::shared_ptr<NeuropodValue>>;
-
-// This is the input type to `infer`
-using ValueSet = std::unordered_set<std::shared_ptr<NeuropodValue>>;
+// This is the input and output type of `infer`
+using NeuropodValueMap = std::unordered_map<std::string, std::shared_ptr<NeuropodValue>>;
 
 // The interface that every neuropod backend implements
 class NeuropodBackend
@@ -37,7 +33,7 @@ public:
     virtual std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator() = 0;
 
     // Run inference
-    virtual std::unique_ptr<ValueMap> infer(const ValueSet &inputs) = 0;
+    virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs) = 0;
 };
 
 template<template <class> class TensorImpl>

--- a/source/neuropods/backends/python_bridge/numpy_neuropod_tensor.hh
+++ b/source/neuropods/backends/python_bridge/numpy_neuropod_tensor.hh
@@ -83,7 +83,7 @@ class NumpyNeuropodTensor : public TypedNeuropodTensor<T>, public NativeDataCont
 {
 public:
     // Allocate a numpy array
-    NumpyNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims) : TypedNeuropodTensor<T>(name, dims)
+    NumpyNeuropodTensor(const std::vector<int64_t> &dims) : TypedNeuropodTensor<T>(dims)
     {
         setup_numpy_if_needed();
 
@@ -105,8 +105,8 @@ public:
     };
 
     // Wrap existing memory
-    NumpyNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
-        : TypedNeuropodTensor<T>(name, dims)
+    NumpyNeuropodTensor(const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
+        : TypedNeuropodTensor<T>(dims)
     {
         setup_numpy_if_needed();
 
@@ -137,8 +137,8 @@ public:
     };
 
     // Wrap an existing array
-    NumpyNeuropodTensor(const std::string &name, PyArrayObject *nparray)
-        : TypedNeuropodTensor<T>(name, get_dims_from_numpy(nparray))
+    NumpyNeuropodTensor(PyArrayObject *nparray)
+        : TypedNeuropodTensor<T>(get_dims_from_numpy(nparray))
     {
         py::handle<>       handle(reinterpret_cast<PyObject *>(nparray));
         py::numeric::array arr(handle);
@@ -183,15 +183,15 @@ class NumpyNeuropodTensor<std::string> : public TypedNeuropodTensor<std::string>
 {
 public:
     // Allocate a numpy array
-    NumpyNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
-        : TypedNeuropodTensor<std::string>(name, dims)
+    NumpyNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<std::string>(dims)
     {
         setup_numpy_if_needed();
     };
 
     // Wrap an existing array
-    NumpyNeuropodTensor(const std::string &name, PyArrayObject *nparray)
-        : TypedNeuropodTensor<std::string>(name, get_dims_from_numpy(nparray))
+    NumpyNeuropodTensor(PyArrayObject *nparray)
+        : TypedNeuropodTensor<std::string>(get_dims_from_numpy(nparray))
     {
         py::handle<>       handle(reinterpret_cast<PyObject *>(nparray));
         py::numeric::array arr(handle);

--- a/source/neuropods/backends/python_bridge/python_bridge.hh
+++ b/source/neuropods/backends/python_bridge/python_bridge.hh
@@ -46,7 +46,7 @@ public:
     ~PythonBridge();
 
     // Run inference
-    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/tensor_allocator.hh
+++ b/source/neuropods/backends/tensor_allocator.hh
@@ -22,8 +22,7 @@ public:
     virtual ~NeuropodTensorAllocator() {}
 
     // Allocate a tensor of a specific type
-    virtual std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                            const std::vector<int64_t> &input_dims,
+    virtual std::unique_ptr<NeuropodTensor> allocate_tensor(const std::vector<int64_t> &input_dims,
                                                             TensorType                  tensor_type)
         = 0;
 
@@ -32,8 +31,7 @@ public:
     // To support all the built-in backends, `data` should be aligned to 64 bytes.
     // `deleter` will be called with a pointer to `data` when the tensor is
     // deallocated
-    virtual std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
-                                                               const std::vector<int64_t> &input_dims,
+    virtual std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::vector<int64_t> &input_dims,
                                                                TensorType                  tensor_type,
                                                                void *                      data,
                                                                const Deleter &             deleter)
@@ -41,24 +39,22 @@ public:
 
     // Templated version of `allocate_tensor`
     template <typename T>
-    std::shared_ptr<TypedNeuropodTensor<T>> allocate_tensor(const std::string &node_name,
-                                                            const std::vector<int64_t> &input_dims)
+    std::shared_ptr<TypedNeuropodTensor<T>> allocate_tensor(const std::vector<int64_t> &input_dims)
     {
         std::shared_ptr<NeuropodTensor> tensor
-            = this->allocate_tensor(node_name, input_dims, get_tensor_type_from_cpp<T>());
+            = this->allocate_tensor(input_dims, get_tensor_type_from_cpp<T>());
 
         return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
     }
 
     // Templated version of `tensor_from_memory`
     template <typename T>
-    std::shared_ptr<TypedNeuropodTensor<T>>  tensor_from_memory(const std::string &         node_name,
-                                                                const std::vector<int64_t> &input_dims,
+    std::shared_ptr<TypedNeuropodTensor<T>>  tensor_from_memory(const std::vector<int64_t> &input_dims,
                                                                 T *                         data,
                                                                 const Deleter &             deleter)
     {
         std::shared_ptr<NeuropodTensor> tensor
-            = this->tensor_from_memory(node_name, input_dims, get_tensor_type_from_cpp<T>(), data, deleter);
+            = this->tensor_from_memory(input_dims, get_tensor_type_from_cpp<T>(), data, deleter);
 
         return std::dynamic_pointer_cast<TypedNeuropodTensor<T>>(tensor);
     }
@@ -69,20 +65,18 @@ template<template <class> class TensorImpl>
 class DefaultTensorAllocator : public NeuropodTensorAllocator
 {
 public:
-    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::string &         node_name,
-                                                    const std::vector<int64_t> &input_dims,
+    std::unique_ptr<NeuropodTensor> allocate_tensor(const std::vector<int64_t> &input_dims,
                                                     TensorType                  tensor_type)
     {
-        return make_tensor<TensorImpl>(tensor_type, node_name, input_dims);
+        return make_tensor<TensorImpl>(tensor_type, input_dims);
     }
 
-    std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::string &         node_name,
-                                                       const std::vector<int64_t> &input_dims,
+    std::unique_ptr<NeuropodTensor> tensor_from_memory(const std::vector<int64_t> &input_dims,
                                                        TensorType                  tensor_type,
                                                        void *                      data,
                                                        const Deleter &             deleter)
     {
-        return make_tensor_no_string<TensorImpl>(tensor_type, node_name, input_dims, data, deleter);
+        return make_tensor_no_string<TensorImpl>(tensor_type, input_dims, data, deleter);
     }
 };
 

--- a/source/neuropods/backends/tensorflow/tf_backend.hh
+++ b/source/neuropods/backends/tensorflow/tf_backend.hh
@@ -50,7 +50,7 @@ public:
     ~TensorflowNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/tensorflow/tf_tensor.hh
+++ b/source/neuropods/backends/tensorflow/tf_tensor.hh
@@ -49,8 +49,8 @@ class TensorflowNeuropodTensor : public TypedNeuropodTensor<T>, public NativeDat
 {
 public:
     // Allocate a TF tensor
-    TensorflowNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
-        : TypedNeuropodTensor<T>(name, dims),
+    TensorflowNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<T>(dims),
           tensor(TF_AllocateTensor(get_tf_type_from_neuropod_type(this->get_tensor_type()),
                                    dims.data(),
                                    dims.size(),
@@ -61,8 +61,8 @@ public:
     // Wrap existing memory
     // This data should be 64 byte aligned
     // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/allocator.h#L84
-    TensorflowNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
-        : TypedNeuropodTensor<T>(name, dims),
+    TensorflowNeuropodTensor(const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
+        : TypedNeuropodTensor<T>(dims),
           tensor(TF_NewTensor(get_tf_type_from_neuropod_type(this->get_tensor_type()),
                               dims.data(),
                               dims.size(),
@@ -75,8 +75,8 @@ public:
     }
 
     // Wrap an existing TF tensor
-    TensorflowNeuropodTensor(const std::string &name, TF_Tensor *tensor)
-        : TypedNeuropodTensor<T>(name, get_shape(tensor)),
+    TensorflowNeuropodTensor(TF_Tensor *tensor)
+        : TypedNeuropodTensor<T>(get_shape(tensor)),
           tensor(tensor)
     {
     }
@@ -109,14 +109,14 @@ class TensorflowNeuropodTensor<std::string> : public TypedNeuropodTensor<std::st
 {
 public:
     // Allocate a TF tensor
-    TensorflowNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
-        : TypedNeuropodTensor<std::string>(name, dims)
+    TensorflowNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<std::string>(dims)
     {
     }
 
     // Wrap an existing TF tensor
-    TensorflowNeuropodTensor(const std::string &name, TF_Tensor *tensor)
-        : TypedNeuropodTensor<std::string>(name, get_shape(tensor)), tensor(tensor)
+    TensorflowNeuropodTensor(TF_Tensor *tensor)
+        : TypedNeuropodTensor<std::string>(get_shape(tensor)), tensor(tensor)
     {
     }
 

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.cc
@@ -12,9 +12,9 @@ TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, std::
 TestNeuropodBackend::~TestNeuropodBackend() = default;
 
 // Run inference
-std::unique_ptr<ValueMap> TestNeuropodBackend::infer(const ValueSet &inputs)
+std::unique_ptr<NeuropodValueMap> TestNeuropodBackend::infer(const NeuropodValueMap &inputs)
 {
-    return stdx::make_unique<ValueMap>();
+    return stdx::make_unique<NeuropodValueMap>();
 }
 
 REGISTER_NEUROPOD_BACKEND(TestNeuropodBackend, "noop")

--- a/source/neuropods/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_backend.hh
@@ -22,6 +22,6 @@ public:
     ~TestNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 };
 } // namespace neuropods

--- a/source/neuropods/backends/test_backend/test_neuropod_tensor.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_tensor.hh
@@ -28,15 +28,15 @@ private:
     void *deleter_handle_;
 
 public:
-    TestNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims) : TypedNeuropodTensor<T>(name, dims)
+    TestNeuropodTensor(const std::vector<int64_t> &dims) : TypedNeuropodTensor<T>(dims)
     {
         data_ = malloc(this->get_num_elements() * sizeof(T));
         deleter_handle_ = nullptr;
     }
 
     // Wrap existing memory
-    TestNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
-        : TypedNeuropodTensor<T>(name, dims)
+    TestNeuropodTensor(const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
+        : TypedNeuropodTensor<T>(dims)
     {
         data_ = data;
         deleter_handle_ = register_deleter(deleter, data);
@@ -59,7 +59,7 @@ private:
     std::vector<std::string> data_;
 
 public:
-    TestNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims) : TypedNeuropodTensor<std::string>(name, dims)
+    TestNeuropodTensor(const std::vector<int64_t> &dims) : TypedNeuropodTensor<std::string>(dims)
     {
     }
 

--- a/source/neuropods/backends/torchscript/torch_backend.hh
+++ b/source/neuropods/backends/torchscript/torch_backend.hh
@@ -34,7 +34,7 @@ public:
     ~TorchNeuropodBackend();
 
     // Run inference
-    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/torchscript/torch_tensor.hh
+++ b/source/neuropods/backends/torchscript/torch_tensor.hh
@@ -66,22 +66,22 @@ class TorchNeuropodTensor : public TypedNeuropodTensor<T>, public NativeDataCont
 {
 public:
     // Allocate a torch tensor
-    TorchNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
-        : TypedNeuropodTensor<T>(name, dims),
+    TorchNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<T>(dims),
           tensor(torch::empty(dims, get_torch_type_from_neuropod_type(get_tensor_type_from_cpp<T>())))
     {
     }
 
     // Wrap existing memory
-    TorchNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
-        : TypedNeuropodTensor<T>(name, dims),
+    TorchNeuropodTensor(const std::vector<int64_t> &dims, void * data, const Deleter &deleter)
+        : TypedNeuropodTensor<T>(dims),
           tensor(torch::from_blob(data, dims, get_torch_deleter(deleter, data), get_torch_type_from_neuropod_type(get_tensor_type_from_cpp<T>())))
     {
     }
 
     // Wrap an existing torch tensor
-    TorchNeuropodTensor(const std::string &name, torch::Tensor tensor)
-        : TypedNeuropodTensor<T>(name, tensor.sizes().vec()), tensor(tensor)
+    TorchNeuropodTensor(torch::Tensor tensor)
+        : TypedNeuropodTensor<T>(tensor.sizes().vec()), tensor(tensor)
     {
     }
 
@@ -109,8 +109,8 @@ class TorchNeuropodTensor<std::string> : public TypedNeuropodTensor<std::string>
 {
 public:
     // Allocate a torch tensor
-    TorchNeuropodTensor(const std::string &name, const std::vector<int64_t> &dims)
-        : TypedNeuropodTensor<std::string>(name, dims),
+    TorchNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<std::string>(dims),
           list(at::ivalue::GenericList::create(std::vector<torch::jit::IValue>(get_num_elements())))
     {
         if (dims.size() != 1)
@@ -121,8 +121,8 @@ public:
     }
 
     // Wrap an existing torch tensor
-    TorchNeuropodTensor(const std::string &name, torch::jit::IValue tensor)
-        : TypedNeuropodTensor<std::string>(name, {static_cast<int64_t>(tensor.toGenericListRef().size())}),
+    TorchNeuropodTensor(torch::jit::IValue tensor)
+        : TypedNeuropodTensor<std::string>({static_cast<int64_t>(tensor.toGenericListRef().size())}),
           list(tensor.toGenericList())
     {
     }

--- a/source/neuropods/conversions/eigen.hh
+++ b/source/neuropods/conversions/eigen.hh
@@ -23,8 +23,7 @@ Eigen::Map<const Eigen::Matrix<_Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::R
     if (dims.size() > 2)
     {
         NEUROPOD_ERROR("Only tensors with rank of 1 or 2 are supported by this function. "
-                         "Tensor '"
-                      << tensor.get_name() << "' has rank of " << dims.size() << ".");
+                         "Tensor has rank of " << dims.size() << ".");
     }
 
     const auto rows = dims[0];
@@ -44,8 +43,7 @@ Eigen::Map<Eigen::Matrix<_Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajo
     if (dims.size() > 2)
     {
         NEUROPOD_ERROR("Only tensors with rank of 1 or 2 are supported by this function. "
-                         "Tensor '"
-                      << tensor.get_name() << "' has rank of " << dims.size() << ".");
+                         "Tensor has rank of " << dims.size() << ".");
     }
 
     const auto rows = dims[0];

--- a/source/neuropods/internal/neuropod_tensor.hh
+++ b/source/neuropods/internal/neuropod_tensor.hh
@@ -50,21 +50,13 @@ class TypedNeuropodTensor;
 class NeuropodValue
 {
 private:
-    // The name of this NeuropodValue
-    const std::string name_;
-
     // Whether or not this item is a tensor
     const bool is_tensor_;
 
 public:
-    NeuropodValue(const std::string &name, bool is_tensor) : name_(name), is_tensor_(is_tensor) {}
-
-    NeuropodValue(const std::string &name) : NeuropodValue(name, true) {}
+    NeuropodValue(bool is_tensor) : is_tensor_(is_tensor) {}
 
     virtual ~NeuropodValue() {}
-
-    // Get the name of this NeuropodValue
-    const std::string &get_name() const { return name_; }
 
     // Type-checked downcast to a NeuropodTensor
     NeuropodTensor *as_tensor();
@@ -82,7 +74,7 @@ protected:
     {
         if (!is_tensor_)
         {
-            NEUROPOD_ERROR("NeuropodValue with name " << name_ << " is expected to be a NeuropodTensor.");
+            NEUROPOD_ERROR("This NeuropodValue is expected to be a NeuropodTensor.");
         }
     }
 };
@@ -101,8 +93,8 @@ private:
 
 public:
     // Create a NeuropodTensor with a name and type
-    NeuropodTensor(const std::string &name, TensorType tensor_type, const std::vector<int64_t> dims)
-        : NeuropodValue(name), tensor_type_(tensor_type), dims_(dims)
+    NeuropodTensor(TensorType tensor_type, const std::vector<int64_t> dims)
+        : NeuropodValue(true), tensor_type_(tensor_type), dims_(dims)
     {
     }
 
@@ -112,7 +104,7 @@ public:
 
     friend std::ostream &operator<<(std::ostream &out, const NeuropodTensor &tensor)
     {
-        out << "NeuropodTensor '" << tensor.get_name() << "' with type ";
+        out << "NeuropodTensor with type ";
         out << tensor.get_tensor_type();
         out << " and shape (";
         for (const int64_t dim : tensor.get_dims())
@@ -191,7 +183,7 @@ protected:
 
         if (requested != actual)
         {
-            NEUROPOD_ERROR("Tried to downcast tensor \"" << get_name() << "\" of type " << actual
+            NEUROPOD_ERROR("Tried to downcast tensor of type " << actual
                << " to a TypedNeuropodTensor of type " << requested);
         }
     }
@@ -201,7 +193,7 @@ protected:
         const size_t rank = dims.size();
         if (rank != expected_rank)
         {
-            NEUROPOD_ERROR("Tensor '" << this->get_name() << " is expected to have rank of " << expected_rank
+            NEUROPOD_ERROR("Tensor is expected to have rank of " << expected_rank
                           << " while the actual rank is " << rank);
         }
     }
@@ -213,8 +205,8 @@ template <typename T>
 class TypedNeuropodTensor : public NeuropodTensor
 {
 public:
-    TypedNeuropodTensor(const std::string &name, const std::vector<int64_t> dims)
-        : NeuropodTensor(name, get_tensor_type_from_cpp<T>(), dims)
+    TypedNeuropodTensor(const std::vector<int64_t> dims)
+        : NeuropodTensor(get_tensor_type_from_cpp<T>(), dims)
     {
     }
 
@@ -362,8 +354,8 @@ template <>
 class TypedNeuropodTensor<std::string> : public NeuropodTensor
 {
 public:
-    TypedNeuropodTensor(const std::string &name, const std::vector<int64_t> dims)
-        : NeuropodTensor(name, STRING_TENSOR, dims)
+    TypedNeuropodTensor(const std::vector<int64_t> dims)
+        : NeuropodTensor(STRING_TENSOR, dims)
     {
     }
 

--- a/source/neuropods/neuropods.cc
+++ b/source/neuropods/neuropods.cc
@@ -40,7 +40,7 @@ Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBac
 
 Neuropod::~Neuropod() = default;
 
-std::unique_ptr<ValueMap> Neuropod::infer(const ValueSet &inputs)
+std::unique_ptr<NeuropodValueMap> Neuropod::infer(const NeuropodValueMap &inputs)
 {
     // TODO(vip): make sure that names in `inputs` are not repeated
     // Run inference
@@ -64,33 +64,30 @@ std::shared_ptr<NeuropodTensorAllocator> Neuropod::get_tensor_allocator()
 
 template <typename T>
 std::shared_ptr<TypedNeuropodTensor<T>> Neuropod::allocate_tensor(
-    const std::string &node_name,
     const std::vector<int64_t> &input_dims)
 {
-    return get_tensor_allocator()->allocate_tensor<T>(node_name, input_dims);
+    return get_tensor_allocator()->allocate_tensor<T>(input_dims);
 }
 
 template <typename T>
 std::shared_ptr<TypedNeuropodTensor<T>> Neuropod::tensor_from_memory(
-    const std::string &         node_name,
     const std::vector<int64_t> &input_dims,
     T *                         data,
     const Deleter &             deleter)
 {
-    return get_tensor_allocator()->tensor_from_memory(node_name, input_dims, data, deleter);
+    return get_tensor_allocator()->tensor_from_memory(input_dims, data, deleter);
 }
 
 // Instantiate the templates
 #define INIT_TEMPLATES_FOR_TYPE(CPP_TYPE, NEUROPOD_TYPE)                                                                          \
-    template std::shared_ptr<TypedNeuropodTensor<CPP_TYPE>> Neuropod::tensor_from_memory(const std::string &         node_name,   \
-                                                                                         const std::vector<int64_t> &input_dims,  \
+    template std::shared_ptr<TypedNeuropodTensor<CPP_TYPE>> Neuropod::tensor_from_memory(const std::vector<int64_t> &input_dims,  \
                                                                                          CPP_TYPE *                  data,        \
                                                                                          const Deleter &             deleter);
 
 
 #define INIT_STRING_TEMPLATES_FOR_TYPE(CPP_TYPE, NEUROPOD_TYPE)                             \
     template std::shared_ptr<TypedNeuropodTensor<CPP_TYPE>> Neuropod::allocate_tensor(      \
-        const std::string &node_name, const std::vector<int64_t> &input_dims);
+        const std::vector<int64_t> &input_dims);
 
 FOR_EACH_TYPE_MAPPING_EXCEPT_STRING(INIT_TEMPLATES_FOR_TYPE);
 FOR_EACH_TYPE_MAPPING_INCLUDING_STRING(INIT_STRING_TEMPLATES_FOR_TYPE);

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -64,7 +64,7 @@ public:
     ~Neuropod();
 
     // Run inference
-    std::unique_ptr<ValueMap> infer(const ValueSet &inputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 
     // Get the inputs and outputs of the loaded Neuropod
     const std::vector<TensorSpec> &get_inputs() const;
@@ -76,7 +76,6 @@ public:
     // Allocate a tensor of a certain shape and type
     template <typename T>
     std::shared_ptr<TypedNeuropodTensor<T>> allocate_tensor(
-        const std::string &node_name,
         const std::vector<int64_t> &input_dims);
 
     // Allocate a tensor of a certain shape and type with existing data
@@ -88,7 +87,6 @@ public:
     // To support all the built-in backends, `data` should be aligned to 64 bytes.
     template <typename T>
     std::shared_ptr<TypedNeuropodTensor<T>> tensor_from_memory(
-        const std::string &         node_name,
         const std::vector<int64_t> &input_dims,
         T *                         data,
         const Deleter &             deleter);

--- a/source/neuropods/tests/test_conversions_eigen.cc
+++ b/source/neuropods/tests/test_conversions_eigen.cc
@@ -15,7 +15,7 @@ class int32_tensor_fixture : public ::testing::Test
 public:
     int32_tensor_fixture()
     {
-        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {ROWS}, neuropods::INT32_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor({ROWS}, neuropods::INT32_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
@@ -43,7 +43,7 @@ class int32_matrix_fixture : public ::testing::Test
 public:
     int32_matrix_fixture()
     {
-        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_matrix", {ROWS, COLS}, neuropods::INT32_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor({ROWS, COLS}, neuropods::INT32_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
@@ -149,6 +149,6 @@ TEST_F(int32_matrix_fixture, const_untyped_vector_as_eigen_type_mismatch)
 
 TEST_F(int32_matrix_fixture, higher_rank)
 {
-    untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {5, 5, 5}, neuropods::INT32_TENSOR);
+    untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor({5, 5, 5}, neuropods::INT32_TENSOR);
     EXPECT_THROW(neuropods::as_eigen<int32_t>(*untyped_tensor), std::runtime_error);
 }

--- a/source/neuropods/tests/test_input_output.cc
+++ b/source/neuropods/tests/test_input_output.cc
@@ -60,20 +60,19 @@ TEST(test_allocate_tensor, add_tensors_and_validate)
     auto allocator = backend.get_tensor_allocator();
 
     // Allocate tensors
-    std::shared_ptr<neuropods::NeuropodTensor> a_ten = allocator->allocate_tensor("a", a_shape, neuropods::INT32_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> a_ten = allocator->allocate_tensor(a_shape, neuropods::INT32_TENSOR);
     a_ten->as_typed_tensor<int32_t>()->copy_from(a_data);
 
-    std::shared_ptr<neuropods::NeuropodTensor> b_ten = allocator->allocate_tensor("b", b_shape, neuropods::INT64_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> b_ten = allocator->allocate_tensor(b_shape, neuropods::INT64_TENSOR);
     b_ten->as_typed_tensor<int64_t>()->copy_from(b_data);
 
-    std::shared_ptr<neuropods::NeuropodTensor> c_ten = allocator->allocate_tensor("c", c_shape, neuropods::FLOAT_TENSOR);
+    std::shared_ptr<neuropods::NeuropodTensor> c_ten = allocator->allocate_tensor(c_shape, neuropods::FLOAT_TENSOR);
     c_ten->as_typed_tensor<float>()->copy_from(c_data, 4);
 
     // Wrap existing data
     // TODO(vip): Refactor this test. It's bad practice to have an empty deleter
     // The created tensor should be responsible for deallocating the memory
     std::shared_ptr<neuropods::NeuropodTensor> d_ten = allocator->tensor_from_memory(
-        "d",
         d_shape,
         neuropods::DOUBLE_TENSOR,
         const_cast<double *>(d_data),
@@ -113,6 +112,6 @@ TEST(test_allocate_tensor, add_tensors_and_validate)
 // {
 //     neuropods::NeuropodInputBuilder builder(std::make_shared<neuropods::TestNeuropodBackend>());
 //
-//     builder.allocate_tensor<int8_t>("a", {10});
-//     EXPECT_THROW(builder.allocate_tensor<int8_t>("a", {10}), std::runtime_error);
+//     builder.allocate_tensor<int8_t>({10});
+//     EXPECT_THROW(builder.allocate_tensor<int8_t>({10}), std::runtime_error);
 // }

--- a/source/neuropods/tests/test_internal_neuropod_tensor.cc
+++ b/source/neuropods/tests/test_internal_neuropod_tensor.cc
@@ -16,7 +16,7 @@ class uint8_tensor_fixture : public ::testing::Test
 public:
     uint8_tensor_fixture()
     {
-        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor("test_tensor", {EXPECTED_SIZE}, neuropods::UINT8_TENSOR);
+        untyped_tensor       = test_backend_.get_tensor_allocator()->allocate_tensor({EXPECTED_SIZE}, neuropods::UINT8_TENSOR);
         const_untyped_tensor = untyped_tensor.get();
 
         tensor       = untyped_tensor->as_typed_tensor<uint8_t>();
@@ -43,7 +43,7 @@ class uint8_scalar_fixture : public ::testing::Test
 public:
     uint8_scalar_fixture()
     {
-        untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor("test_scalar", {1}, neuropods::UINT8_TENSOR);
+        untyped_tensor = test_backend_.get_tensor_allocator()->allocate_tensor({1}, neuropods::UINT8_TENSOR);
         untyped_tensor->as_scalar<uint8_t>() = 42;
         const_untyped_tensor                 = untyped_tensor.get();
         tensor                               = untyped_tensor->as_typed_tensor<uint8_t>();
@@ -63,17 +63,17 @@ TEST(test_stream_operator, untyped_tensor)
 {
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
-    const auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
+    const auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({3}, neuropods::UINT8_TENSOR);
     ss << *untyped_tensor;
 
-    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor 'tensor1'"));
+    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor"));
 }
 
 TEST(test_stream_operator, typed_tensor)
 {
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
-    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {3}, neuropods::UINT8_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({3}, neuropods::UINT8_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<uint8_t>();
 
@@ -82,7 +82,7 @@ TEST(test_stream_operator, typed_tensor)
     typed_tensor[2] = 12;
 
     ss << typed_tensor;
-    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor 'tensor1'"));
+    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor"));
     EXPECT_THAT(ss.str(), HasSubstr("[10, 11, 12]"));
 }
 
@@ -91,7 +91,7 @@ TEST(test_stream_operator, typed_float_tensor)
     std::stringstream              ss;
     neuropods::TestNeuropodBackend test_backend;
     constexpr int                  TENSOR_SIZE = 8;
-    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<float>();
 
@@ -101,7 +101,7 @@ TEST(test_stream_operator, typed_float_tensor)
     }
 
     ss << typed_tensor;
-    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor 'tensor1'"));
+    EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor"));
     EXPECT_THAT(ss.str(), HasSubstr("[0.5, 1.5, 2.5 ... 5.5, 6.5, 7.5]"));
 }
 
@@ -109,7 +109,7 @@ TEST(test_typed_neuropod_tensor, downcast_failulre)
 {
     neuropods::TestNeuropodBackend test_backend;
     constexpr int                  TENSOR_SIZE = 8;
-    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor("tensor1", {TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
+    auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     EXPECT_THROW(untyped_tensor->as_typed_tensor<int8_t>(), std::runtime_error);
 }

--- a/source/neuropods/tests/test_utils.hh
+++ b/source/neuropods/tests/test_utils.hh
@@ -35,21 +35,21 @@ void test_addition_model(neuropods::Neuropod &neuropod, bool copy_mem)
         const float y_data[] = {7, 8, 9, 10};
         const float target[] = {8, 10, 12, 14};
 
-        neuropods::ValueSet input_data;
+        neuropods::NeuropodValueMap input_data;
 
         if (copy_mem)
         {
             // Allocate the tensors
-            auto x_ten = neuropod.allocate_tensor<float>("x", shape);
-            auto y_ten = neuropod.allocate_tensor<float>("y", shape);
+            auto x_ten = neuropod.allocate_tensor<float>(shape);
+            auto y_ten = neuropod.allocate_tensor<float>(shape);
 
             // Copy the input data
             x_ten->copy_from(x_data, 4);
             y_ten->copy_from(y_data, 4);
 
             // Add it to the inputs for inference
-            input_data.insert(x_ten);
-            input_data.insert(y_ten);
+            input_data["x"] = x_ten;
+            input_data["y"] = y_ten;
         }
         else
         {
@@ -68,12 +68,8 @@ void test_addition_model(neuropods::Neuropod &neuropod, bool copy_mem)
             };
 
             // Create tensors by wrapping existing data
-            auto x_ten = neuropod.tensor_from_memory("x", shape, const_cast<float *>(x_data_aligned), deleter);
-            auto y_ten = neuropod.tensor_from_memory("y", shape, const_cast<float *>(y_data_aligned), deleter);
-
-            // Add it to the inputs for inference
-            input_data.insert(x_ten);
-            input_data.insert(y_ten);
+            input_data["x"] = neuropod.tensor_from_memory(shape, const_cast<float *>(x_data_aligned), deleter);
+            input_data["y"] = neuropod.tensor_from_memory(shape, const_cast<float *>(y_data_aligned), deleter);
         }
 
         // Run inference
@@ -134,15 +130,18 @@ void test_strings_model(neuropods::Neuropod &neuropod)
     std::vector<std::string>       target = {"apple sauce", "banana pudding", "carrot cake"};
 
     // Allocate tensors
-    auto x_ten = neuropod.allocate_tensor<std::string>("x", shape);
-    auto y_ten = neuropod.allocate_tensor<std::string>("y", shape);
+    auto x_ten = neuropod.allocate_tensor<std::string>(shape);
+    auto y_ten = neuropod.allocate_tensor<std::string>(shape);
 
     // Set the data
     x_ten->set(x_data);
     y_ten->set(y_data);
 
     // Run inference
-    const auto output_data = neuropod.infer({x_ten, y_ten});
+    const auto output_data = neuropod.infer({
+        {"x", x_ten},
+        {"y", y_ten}
+    });
 
     // Get the data in the output tensor
     const std::vector<std::string> out_vector = output_data->at("out")


### PR DESCRIPTION
Remove `name` from NeuropodValue. This is done for a few reasons:
- Currently, a map from a name to `NeuropodValue` stores redundant information (because the name is the key of the map but is also stored in the value)
- None of the underlying DL frameworks store names in tensors
- Currently, the input and output types of `infer` don't match (unordered_set vs unordered_map)

By removing name information from `NeuropodValue`, we can use maps everywhere without storing redundant information.