### PR TITLE
Use a self-contained LLVM toolchain to build Neuropods

### DIFF
--- a/build/allowed_deps.txt
+++ b/build/allowed_deps.txt
@@ -10,6 +10,7 @@
  0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
  0x0000000000000001 (NEEDED)             Shared library: [libneuropods.so]
+ 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [libpython2.7.so.1.0]
  0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
  0x0000000000000001 (NEEDED)             Shared library: [libtensorflow.so]

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,15 +2,6 @@
 set -e
 pushd source
 
-if [[ $(uname -s) == 'Linux' ]]; then
-    # We need to build with gcc 4.9 to work with the default libtorch
-    GCC_VERSION=4.9
-    echo "Building with CC ${CC:=/usr/bin/gcc-${GCC_VERSION}}"
-    echo "Building with CXX ${CXX:=/usr/bin/g++-${GCC_VERSION}}"
-    export CC
-    export CXX
-fi
-
 # Run python tests
 pushd python
 python -m unittest discover --verbose neuropods/tests

--- a/build/docker_build.sh
+++ b/build/docker_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Builds neuropods and runs tests in a docker container
+# Uses a temporary directory to preserve the bazel cache between builds
+
+# Create the cache folder if it doesn't exist
+mkdir -p /tmp/neuropod_docker_cache
+
+# Build the image
+docker build -f build/neuropods.dockerfile -t neuropods .
+
+if [[ "$1" == "-i" ]]; then
+    # Run interactively
+    docker run --rm -it -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash
+else
+    # Build and test Neuropods
+    docker run --rm -v /tmp/neuropod_docker_cache:/root/.cache neuropods build/build.sh
+fi

--- a/build/install_system_deps.sh
+++ b/build/install_system_deps.sh
@@ -10,7 +10,7 @@ if [[ $(uname -s) == 'Darwin' ]]; then
 else
     # Install pip and bazel dependencies
     sudo apt-get update
-    sudo apt-get install -y openjdk-8-jdk curl wget gcc-4.9 g++-4.9 gcc-4.8 g++-4.8 python-pip
+    sudo apt-get install -y openjdk-8-jdk curl wget python-pip
 
     # Add bazel sources
     echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -2,10 +2,6 @@
 
 FROM ubuntu:16.04
 
-# Set the GCC version used for this build
-ARG GCC_VERSION=4.9
-ENV CC=/usr/bin/gcc-${GCC_VERSION} CXX=/usr/bin/g++-${GCC_VERSION}
-
 # Optional overrides used by the bazel build
 ARG NEUROPODS_TENSORFLOW_VERSION
 ARG NEUROPODS_TENSORFLOW_URL
@@ -45,4 +41,4 @@ RUN /usr/src/build/install_python_deps.sh
 COPY . /usr/src
 
 # Build and test
-RUN /usr/src/build/build.sh
+# See build/docker_build.sh

--- a/source/.bazelrc
+++ b/source/.bazelrc
@@ -1,2 +1,11 @@
 # Pass python virtual envs through to the test runner
 build --test_env=VIRTUAL_ENV
+
+# Use an internal toolchain to isolate the build from system libraries
+build --crosstool_top=@llvm_toolchain//:toolchain
+
+# Use C++11
+build --cxxopt='-std=c++11'
+
+# We need this to be compatible with libtorch
+build --cxxopt='-D_GLIBCXX_USE_CXX11_ABI=0'

--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -3,6 +3,22 @@ load("//bazel:python.bzl", "python_repository")
 load("//bazel:tensorflow.bzl", "tensorflow_repository")
 load("//bazel:libtorch.bzl", "libtorch_repository")
 
+# Use an internal LLVM toolchain instead of the system one
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    strip_prefix = "bazel-toolchain-64bb7aa409c384fb9a35f331adb31658f08eb8bb",
+    sha256 = "939b5b58b56946fe38deab6e9f65817a557a5d7a93d2b933b4716ff2cf1e0527",
+    url = "https://github.com/grailbio/bazel-toolchain/archive/64bb7aa409c384fb9a35f331adb31658f08eb8bb.tar.gz",
+    patches = ["@//bazel:toolchain.patch"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "6.0.0",
+)
+
 libtorch_repository(
     name = "libtorch_repo",
     build_file = "@//deps:BUILD.libtorch",

--- a/source/bazel/toolchain.patch
+++ b/source/bazel/toolchain.patch
@@ -1,0 +1,24 @@
+--- toolchain/cc_toolchain_config.bzl.tpl	2019-06-05 00:58:14.681677976 +0000
++++ toolchain/cc_toolchain_config.bzl.tpl	2019-06-05 01:00:20.133676223 +0000
+@@ -136,9 +136,9 @@
+             "-fuse-ld=lld",
+             # The linker has no way of knowing if there are C++ objects; so we always link C++ libraries.
+             "-L%{toolchain_path_prefix}/lib",
+-            "-l:libc++.a",
+-            "-l:libc++abi.a",
+-            "-l:libunwind.a",
++            # Build with libstdc++ on linux
++            "-lstdc++",
++            "-lgcc_s",
+             # Compiler runtime features.
+             "-rtlib=compiler-rt",
+             # To support libunwind.
+@@ -262,7 +261,7 @@
+             ),
+             flag_set(
+                 actions = all_cpp_compile_actions,
+-                flag_groups = [flag_group(flags = ["-std=c++17", "-stdlib=libc++"])],
++                flag_groups = [flag_group(flags = ["-std=c++11", "-stdlib=libstdc++" if ctx.attr.cpu == "k8" else "-stdlib=libc++"])],
+             ),
+         ],
+     )


### PR DESCRIPTION
This PR adds a self-contained LLVM toolchain to the Bazel build. A major benefit of this is better isolation from system libraries on users' computers. This also removes the need for users to have specific versions of a compiler preinstalled (e.g. GCC 4.9).