### PR TITLE
Import cPickle from six.moves

### DIFF
--- a/source/neuropods/python/loader.py
+++ b/source/neuropods/python/loader.py
@@ -30,7 +30,7 @@ def load_neuropod(neuropod_path):
 
 if __name__ == '__main__':
     import argparse
-    import cPickle as pickle
+    from six.moves import cPickle as pickle
 
     parser = argparse.ArgumentParser(description='Load a model and run inference with provided sample data.')
     parser.add_argument('--neuropod-path', help='The path to a neuropod to load', required=True)

--- a/source/neuropods/python/utils/env_utils.py
+++ b/source/neuropods/python/utils/env_utils.py
@@ -5,7 +5,7 @@
 """
 Utilities for dealing with virtualenvs and pip
 """
-import cPickle as pickle
+from six.moves import cPickle as pickle
 import os
 import shutil
 import subprocess


### PR DESCRIPTION
`cPickle` doesn't exist in Python 3 any more. This makes the Neuropods python code not work in Python 3 environments.