### PR TITLE
Add initial support for specifying devices

### DIFF
--- a/source/neuropods/python/backends/config_utils.py
+++ b/source/neuropods/python/backends/config_utils.py
@@ -23,14 +23,29 @@ ALLOWED_DTYPES = [
 ]
 
 
-def validate_tensor_spec(spec):
+def validate_tensor_spec(spec, no_device):
     """
     Validates a tensor spec
+
+    :param  no_device:  If a device should be specifed or not
     """
     for item in spec:
         name = item["name"]
         dtype = item["dtype"]
         shape = item["shape"]
+
+
+        if no_device:
+            if "device" in spec:
+                device = item["device"]
+                raise ValueError("A device should not be included in this spec! Found '{}'".format(device))
+        else:
+            if "device" not in item:
+                raise ValueError("A device was expected in this spec, but was not found.")
+
+            device = item["device"]
+            if device not in ["CPU", "GPU"]:
+                raise ValueError("{} is not an allowed device. Must either be 'CPU' or 'GPU'.".format(device))
 
         if dtype not in ALLOWED_DTYPES:
             raise ValueError("{} is not an allowed data type!".format(dtype))
@@ -67,26 +82,41 @@ def validate_neuropod_config(config):
             "Field 'platform' in config must be a string! Got value {} of type {}.".format(
                 platform, type(platform)))
 
-    validate_tensor_spec(config["input_spec"])
-    validate_tensor_spec(config["output_spec"])
+    # Input specs should have devices
+    validate_tensor_spec(config["input_spec"], no_device=False)
+
+    # Output specs should not have devices
+    validate_tensor_spec(config["output_spec"], no_device=True)
 
 
-def canonicalize_tensor_spec(spec):
+def canonicalize_tensor_spec(spec, default_device):
     """
     Converts the datatypes in a tensor spec to canonical versions
     (e.g. converts double to float64)
+
+    :param  spec:               A list of tensor specifications
+    :param  default_device:     The default device to use if one is not specified.
     """
+
     transformed = []
     for item in spec:
-        transformed.append({
+        canonical = {
             "name": item["name"],
             "dtype": np.dtype(item["dtype"]).name,
             "shape": item["shape"]
-        })
+        }
+
+        if default_device is not None:
+            canonical["device"] = default_device
+
+        if "device" in item:
+            canonical["device"] = item["device"]
+
+        transformed.append(canonical)
     return transformed
 
 
-def write_neuropod_config(neuropod_path, model_name, platform, input_spec, output_spec):
+def write_neuropod_config(neuropod_path, model_name, platform, input_spec, output_spec, default_input_device=None):
     """
     Creates the neuropod config file
 
@@ -94,19 +124,26 @@ def write_neuropod_config(neuropod_path, model_name, platform, input_spec, outpu
     :param  model_name:     The name of the model (e.g. "my_addition_model")
     :param  platform:       The model type (e.g. "python", "pytorch", "tensorflow", etc.)
 
-    :param  input_spec:     A list of dicts specifying the input to the model.
-                            Ex: [{"name": "x", "dtype": "float32", "shape": (None, )}]
+    :param  input_spec:     A list of dicts specifying the input to the model. These can optionally specify
+                            a device (either "CPU" or "GPU"). If not specified, the `default_input_device`
+                            will be used.
+                            Ex: [{"name": "x", "dtype": "float32", "shape": (None, ), "device": "GPU"}]
 
-    :param  output_spec:    A list of dicts specifying the output of the model.
+    :param  output_spec:    A list of dicts specifying the output of the model. These will always be moved to
+                            CPU after inference.
                             Ex: [{"name": "y", "dtype": "float32", "shape": (None, )}]
+
+    :param  default_input_device:   The default device that input tensors should be moved to before inference.
     """
     # TODO: Switch to prototext
     with open(os.path.join(neuropod_path, "config.json"), "w") as config_file:
         config = {
             "name": model_name,
             "platform": platform,
-            "input_spec": canonicalize_tensor_spec(input_spec),
-            "output_spec": canonicalize_tensor_spec(output_spec),
+            "input_spec": canonicalize_tensor_spec(input_spec, default_device=default_input_device),
+
+            # Outputs are always moved to CPU so we don't specify a device
+            "output_spec": canonicalize_tensor_spec(output_spec, default_device=None),
         }
 
         # Verify that the config is correct
@@ -124,6 +161,12 @@ def read_neuropod_config(neuropod_path):
     """
     with open(os.path.join(neuropod_path, "config.json"), "r") as config_file:
         config = json.load(config_file)
+
+        # Set devices on tensors without devices to ensure backwards compatibility
+        config["input_spec"] = canonicalize_tensor_spec(config["input_spec"], default_device="GPU")
+
+        # Outputs are always moved to CPU
+        config["output_spec"] = canonicalize_tensor_spec(config["output_spec"], default_device=None)
 
         # Verify that the config is correct
         validate_neuropod_config(config)

--- a/source/neuropods/python/backends/keras/packager.py
+++ b/source/neuropods/python/backends/keras/packager.py
@@ -16,7 +16,8 @@ def create_keras_neuropod(
         input_spec=None,
         output_spec=None,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        default_input_device="GPU"):
     """
     Packages a Keras model as a neuropod package. Currently, only the TensorFlow backend is supported.
 
@@ -40,9 +41,11 @@ def create_keras_neuropod(
                                 is set to `None`, no validation is done on the shape. If shape is a tuple, the
                                 dimensions of the input are validated against that tuple.  A value of
                                 `None` for any of the dimensions means that dimension will not be checked.
-                                `dtype` can be any valid numpy datatype string.
+                                `dtype` can be any valid numpy datatype string. These can optionally specify
+                                a device (either "CPU" or "GPU"). If not specified, the `default_input_device`
+                                will be used.
                                 Ex: [
-                                    {"name": "x", "dtype": "float32", "shape": (None,)},
+                                    {"name": "x", "dtype": "float32", "shape": (None,), "device": "GPU"},
                                     {"name": "y", "dtype": "float32", "shape": (None,)},
                                 ]
 
@@ -72,6 +75,9 @@ def create_keras_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+
+    :param  default_input_device:   The default device that input tensors should be moved to before inference. If
+                                    `input_spec` is not provided, all input tensors are moved to this device.
     """
     if input_spec is None:
         input_spec = infer_keras_input_spec(model, node_name_mapping)
@@ -116,7 +122,8 @@ def create_keras_neuropod(
         input_spec=input_spec,
         output_spec=output_spec,
         test_input_data=test_input_data,
-        test_expected_out=test_expected_out
+        test_expected_out=test_expected_out,
+        default_input_device=default_input_device
     )
 
 

--- a/source/neuropods/python/backends/python/packager.py
+++ b/source/neuropods/python/backends/python/packager.py
@@ -23,7 +23,8 @@ def create_python_neuropod(
         test_expected_out=None,
         test_deps=[],
         test_virtualenv=None,
-        skip_virtualenv=False):
+        skip_virtualenv=False,
+        default_input_device="GPU"):
     """
     Packages arbitrary python code as a neuropod package.
 
@@ -72,9 +73,11 @@ def create_python_neuropod(
                                 is set to `None`, no validation is done on the shape. If shape is a tuple, the
                                 dimensions of the input are validated against that tuple.  A value of
                                 `None` for any of the dimensions means that dimension will not be checked.
-                                `dtype` can be any valid numpy datatype string.
+                                `dtype` can be any valid numpy datatype string. These can optionally specify
+                                a device (either "CPU" or "GPU"). If not specified, the `default_input_device`
+                                will be used.
                                 Ex: [
-                                    {"name": "x", "dtype": "float32", "shape": (None,)},
+                                    {"name": "x", "dtype": "float32", "shape": (None,), "device": "GPU"},
                                     {"name": "y", "dtype": "float32", "shape": (None,)},
                                 ]
 
@@ -108,6 +111,7 @@ def create_python_neuropod(
                                 If not specified, a new temporary virtualenv is created.
 
     :param  skip_virtualenv:    If set to true, runs the test locally instead of in a virtualenv
+    :param  default_input_device:   The default device that input tensors should be moved to before inference.
     """
     try:
         # Create the neuropod folder
@@ -122,6 +126,7 @@ def create_python_neuropod(
         platform="python",
         input_spec=input_spec,
         output_spec=output_spec,
+        default_input_device=default_input_device
     )
 
     neuropod_data_path = os.path.join(neuropod_path, "0", "data")

--- a/source/neuropods/python/backends/tensorflow/packager.py
+++ b/source/neuropods/python/backends/tensorflow/packager.py
@@ -21,7 +21,8 @@ def create_tensorflow_neuropod(
         graph_def=None,
         init_op_names=None,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        default_input_device="GPU"):
     """
     Packages a TensorFlow model as a neuropod package.
 
@@ -40,9 +41,11 @@ def create_tensorflow_neuropod(
                                 is set to `None`, no validation is done on the shape. If shape is a tuple, the
                                 dimensions of the input are validated against that tuple.  A value of
                                 `None` for any of the dimensions means that dimension will not be checked.
-                                `dtype` can be any valid numpy datatype string.
+                                `dtype` can be any valid numpy datatype string. These can optionally specify
+                                a device (either "CPU" or "GPU"). If not specified, the `default_input_device`
+                                will be used.
                                 Ex: [
-                                    {"name": "x", "dtype": "float32", "shape": (None,)},
+                                    {"name": "x", "dtype": "float32", "shape": (None,), "device": "GPU"},
                                     {"name": "y", "dtype": "float32", "shape": (None,)},
                                 ]
 
@@ -79,6 +82,7 @@ def create_tensorflow_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+    :param  default_input_device:   The default device that input tensors should be moved to before inference.
     """
     try:
         # Create the neuropod folder
@@ -97,6 +101,7 @@ def create_tensorflow_neuropod(
         platform="tensorflow",
         input_spec=input_spec,
         output_spec=output_spec,
+        default_input_device=default_input_device
     )
 
     # Create a folder to store the model

--- a/source/neuropods/python/backends/torchscript/packager.py
+++ b/source/neuropods/python/backends/torchscript/packager.py
@@ -16,7 +16,8 @@ def create_torchscript_neuropod(
         input_spec,
         output_spec,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        default_input_device="GPU"):
     """
     Packages a TorchScript model as a neuropod package.
 
@@ -35,9 +36,11 @@ def create_torchscript_neuropod(
                                 is set to `None`, no validation is done on the shape. If shape is a tuple, the
                                 dimensions of the input are validated against that tuple.  A value of
                                 `None` for any of the dimensions means that dimension will not be checked.
-                                `dtype` can be any valid numpy datatype string.
+                                `dtype` can be any valid numpy datatype string. These can optionally specify
+                                a device (either "CPU" or "GPU"). If not specified, the `default_input_device`
+                                will be used.
                                 Ex: [
-                                    {"name": "x", "dtype": "float32", "shape": (None,)},
+                                    {"name": "x", "dtype": "float32", "shape": (None,), "device": "GPU"},
                                     {"name": "y", "dtype": "float32", "shape": (None,)},
                                 ]
 
@@ -63,6 +66,7 @@ def create_torchscript_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+    :param  default_input_device:   The default device that input tensors should be moved to before inference.
     """
     try:
         # Create the neuropod folder
@@ -77,6 +81,7 @@ def create_torchscript_neuropod(
         platform="torchscript",
         input_spec=input_spec,
         output_spec=output_spec,
+        default_input_device=default_input_device
     )
 
     # Create a folder to store the model

--- a/source/neuropods/python/tests/test_config_utils.py
+++ b/source/neuropods/python/tests/test_config_utils.py
@@ -12,7 +12,7 @@ def get_valid_config():
         "name": "addition_model",
         "platform": "tensorflow",
         "input_spec": [
-            {"name": "x", "dtype": "float32", "shape": (None, 2, "some_symbol")},
+            {"name": "x", "dtype": "float32", "shape": (None, 2, "some_symbol"), "device": "GPU"},
         ],
         "output_spec": [
             {"name": "y", "dtype": "float32", "shape": (None, 2, "some_symbol")},
@@ -30,16 +30,22 @@ class TestSpecValidation(unittest.TestCase):
     def test_canonicalize_tensor_spec(self):
         INPUT = [
             {"name": "x", "dtype": "string", "shape": (None, 2, "some_symbol")},
-            {"name": "y", "dtype": "double", "shape": (None, 2)},
+            {"name": "y", "dtype": "double", "shape": (None, 2), "device": "CPU"},
         ]
 
         TARGET = [
-            {"name": "x", "dtype": "string", "shape": (None, 2, "some_symbol")},
-            {"name": "y", "dtype": "float64", "shape": (None, 2)},
+            {"name": "x", "dtype": "string", "shape": (None, 2, "some_symbol"), "device": "GPU"},
+            {"name": "y", "dtype": "float64", "shape": (None, 2), "device": "CPU"},
         ]
 
-        self.assertSpecsEqual(TARGET, canonicalize_tensor_spec(TARGET))
-        self.assertSpecsEqual(TARGET, canonicalize_tensor_spec(INPUT))
+        TARGET_NO_DEFAULT = [
+            {"name": "x", "dtype": "string", "shape": (None, 2, "some_symbol")},
+            {"name": "y", "dtype": "float64", "shape": (None, 2), "device": "CPU"},
+        ]
+
+        self.assertSpecsEqual(TARGET, canonicalize_tensor_spec(TARGET, default_device="CPU"))
+        self.assertSpecsEqual(TARGET, canonicalize_tensor_spec(INPUT, default_device="GPU"))
+        self.assertSpecsEqual(TARGET_NO_DEFAULT, canonicalize_tensor_spec(INPUT, default_device=None))
 
     def test_validate_neuropod_config(self):
         validate_neuropod_config(get_valid_config())
@@ -54,6 +60,13 @@ class TestSpecValidation(unittest.TestCase):
     def test_validate_neuropod_config_invalid_platform(self):
         config = get_valid_config()
         config["platform"] = 5
+
+        with self.assertRaises(ValueError):
+            validate_neuropod_config(config)
+
+    def test_validate_neuropod_config_invalid_spec_device(self):
+        config = get_valid_config()
+        config["input_spec"][0]["device"] = "TPU"
 
         with self.assertRaises(ValueError):
             validate_neuropod_config(config)

--- a/source/neuropods/python/tests/test_keras_packaging.py
+++ b/source/neuropods/python/tests/test_keras_packaging.py
@@ -10,6 +10,7 @@ from tensorflow.keras.models import Model
 import unittest
 from testpath.tempdir import TemporaryDirectory
 
+from neuropods.backends.config_utils import canonicalize_tensor_spec
 from neuropods.backends.keras.packager import create_keras_neuropod, \
     infer_keras_input_spec, infer_keras_output_spec
 from neuropods.loader import load_neuropod
@@ -78,11 +79,19 @@ class TestKerasPackaging(unittest.TestCase):
     def test_input_spec_inference(self):
         # Test whether addition model's input spec is inferred correctly
         inferred_spec = infer_keras_input_spec(create_keras_addition_model())
+
+        # Canonicalize the spec before comparing
+        inferred_spec = canonicalize_tensor_spec(inferred_spec, default_device="GPU")
+
         self.assertEquals(get_addition_model_spec()['input_spec'], inferred_spec)
 
     def test_output_spec_inference(self):
         # Test whether addition model's output spec is inferred correctly
         inferred_spec = infer_keras_output_spec(create_keras_addition_model())
+
+        # Canonicalize the spec before comparing
+        inferred_spec = canonicalize_tensor_spec(inferred_spec, default_device=None)
+
         self.assertEquals(get_addition_model_spec()['output_spec'], inferred_spec)
 
 

--- a/source/neuropods/python/tests/test_randomify.py
+++ b/source/neuropods/python/tests/test_randomify.py
@@ -33,7 +33,7 @@ class TestSpecValidation(unittest.TestCase):
         cls.tmpdir = mkdtemp()
 
         neuropod_path = os.path.join(cls.tmpdir, 'test_stub_neuropod')
-        randomify_neuropod(neuropod_path, input_spec, output_spec)
+        randomify_neuropod(neuropod_path, input_spec, output_spec, default_input_device="GPU")
         neuropod = load_neuropod(neuropod_path)
         cls.neuropod = neuropod
 

--- a/source/neuropods/python/tests/test_tensorflow_packaging.py
+++ b/source/neuropods/python/tests/test_tensorflow_packaging.py
@@ -87,6 +87,7 @@ class TestTensorflowPackaging(unittest.TestCase):
             input_spec=[
                 {"name": "x", "dtype": "float32", "shape": ()},
             ],
+            default_input_device="GPU",
             output_spec=[
                 {"name": "out", "dtype": "float32", "shape": ()},
             ],

--- a/source/neuropods/python/tests/utils.py
+++ b/source/neuropods/python/tests/utils.py
@@ -16,9 +16,9 @@ def get_addition_model_spec(do_fail=False):
 
     return dict(
         input_spec=[
-            {"name": "x", "dtype": "float32", "shape": ("batch_size",)},
-            {"name": "y", "dtype": "float32", "shape": ("batch_size",)},
-            {"name": "optional", "dtype": "string", "shape": ("batch_size",)},
+            {"name": "x", "dtype": "float32", "shape": ("batch_size",), "device": "GPU"},
+            {"name": "y", "dtype": "float32", "shape": ("batch_size",), "device": "GPU"},
+            {"name": "optional", "dtype": "string", "shape": ("batch_size",), "device": "GPU"},
         ],
         output_spec=[
             {"name": "out", "dtype": "float32", "shape": ("batch_size",)},
@@ -46,9 +46,10 @@ def get_string_concat_model_spec(do_fail=False):
 
     return dict(
         input_spec=[
-            {"name": "x", "dtype": "string", "shape": ("batch_size",)},
-            {"name": "y", "dtype": "string", "shape": ("batch_size",)},
+            {"name": "x", "dtype": "string", "shape": ("batch_size",), "device": "CPU"},
+            {"name": "y", "dtype": "string", "shape": ("batch_size",), "device": "CPU"},
         ],
+        default_input_device="CPU",
         output_spec=[
             {"name": "out", "dtype": "string", "shape": ("batch_size",)},
         ],

--- a/source/neuropods/python/utils/randomify.py
+++ b/source/neuropods/python/utils/randomify.py
@@ -79,7 +79,7 @@ def _random_from_output_spec(output_spec, output_prefix='OUTPUT_API'):
     return node_name_mapping
 
 
-def randomify_neuropod(output_path, input_spec, output_spec):
+def randomify_neuropod(output_path, input_spec, output_spec, **kwargs):
     """Uses neuropod input and output specs to automatically generate a neuropod package that complies to the spec and
     produces random outputs.
 
@@ -107,6 +107,7 @@ def randomify_neuropod(output_path, input_spec, output_spec):
         node_name_mapping=node_name_mapping,
         input_spec=input_spec,
         output_spec=output_spec,
+        **kwargs
     )
 
     return output_path


### PR DESCRIPTION
This adds scaffolding for specifying devices for individual tensors in the input/output specs (along with default values for the entire model).

Future PRs will use this information to run models on the appropriate devices.

At packaging time, a user can specify either `CPU` or `GPU`. At runtime, `GPU` will be converted to a specific device depending on the visible GPUs specified at runtime.

If no GPUs are specified at runtime, the library will attempt to run the model on CPU, otherwise all tensors marked as `GPU` will be moved to the specified GPU.