### PR TITLE
Add buildkite and refactor build scripts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,26 @@
+steps:
+  # Build and push the image
+  - label: ":docker: Build"
+    agents:
+      queue: private-builders
+    plugins:
+      - docker-compose:
+          build: test-base
+          config: docker-compose.test.yml
+          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+          push-retries: 5
+    retry:
+      automatic: true
+
+  # Wait until the build is complete
+  - wait
+
+  # Run the tests
+  - label: ":docker: Test"
+    agents:
+      queue: private-default
+    command: build/test.sh
+    plugins:
+      - docker-compose:
+          run: test-base
+          config: docker-compose.test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ install:
 script:
   # This builds both the C++ and python versions and runs tests
   - ./build/build.sh
+  - ./build/test.sh

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,19 +2,13 @@
 set -e
 pushd source
 
-# Run python tests
-pushd python
-python -m unittest discover --verbose neuropods/tests
+# Set LD_LIBRARY_PATH
+source ../build/set_build_env.sh
 
 # Build a wheel + install locally
+pushd python
 python setup.py bdist_wheel && pip install dist/*.whl
 popd
-
-# Add TF and torch to the LD_LIBRARY_PATH
-# This is so the tests can find the shared objects at runtime
-# TODO(vip): find a better way to do this
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/libtorch_repo/lib
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/tensorflow_repo/lib
 
 # Build the native code
 bazel build //...:all
@@ -31,6 +25,4 @@ if [[ $(uname -s) == 'Linux' ]]; then
         diff -I '^#.*' ../build/allowed_deps.txt -
 fi
 
-# Run native tests
-bazel test --cache_test_results=no --test_output=errors //...
 popd

--- a/build/docker_build.sh
+++ b/build/docker_build.sh
@@ -8,12 +8,12 @@ set -e
 mkdir -p /tmp/neuropod_docker_cache
 
 # Build the image
-docker build -f build/neuropods.dockerfile -t neuropods .
+docker build --target neuropod-base -f build/neuropods.dockerfile -t neuropods .
 
 if [[ "$1" == "-i" ]]; then
     # Run interactively
     docker run --rm -it -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash
 else
     # Build and test Neuropods
-    docker run --rm -v /tmp/neuropod_docker_cache:/root/.cache neuropods build/build.sh
+    docker run --rm -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash -c "build/build.sh;build/test.sh"
 fi

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -1,6 +1,7 @@
-# This image builds Neuropods and runs the python and C++ tests
+# This image builds Neuropods and runs the Python and C++ tests
 
-FROM ubuntu:16.04
+# To only install deps (and skip build and tests), pass `--target neuropod-base` to docker build
+FROM ubuntu:16.04 as neuropod-base
 
 # Optional overrides used by the bazel build
 ARG NEUROPODS_TENSORFLOW_VERSION
@@ -39,5 +40,11 @@ RUN /usr/src/build/install_python_deps.sh
 # Copy the rest of the code in
 COPY . /usr/src
 
-# Build and test
-# See build/docker_build.sh
+# Build
+# To only build (and skip tests), pass `--target neuropod-build` to docker build
+FROM neuropod-base as neuropod-build
+RUN /usr/src/build/build.sh
+
+# Test
+FROM neuropod-build
+RUN /usr/src/build/test.sh

--- a/build/set_build_env.sh
+++ b/build/set_build_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Add TF and torch to the LD_LIBRARY_PATH
+# This is so the tests can find the shared objects at runtime
+# TODO(vip): find a better way to do this
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/libtorch_repo/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/tensorflow_repo/lib

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+pushd source
+
+# Set LD_LIBRARY_PATH
+source ../build/set_build_env.sh
+
+# Run python tests
+pushd python
+python -m unittest discover --verbose neuropods/tests
+popd
+
+# Run native tests
+bazel test --cache_test_results=no --test_output=errors //...
+popd

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,8 @@
+version: '2.3'
+services:
+  test-base:
+    build:
+      context: .
+      dockerfile: build/neuropods.dockerfile
+      target: neuropod-build
+    privileged: true


### PR DESCRIPTION
Adding Buildkite to prepare for GPU tests in CI.

Current coverage:
 - Mac (Travis CI)
 - Ubuntu 16.04 (Travis CI)
 - Ubuntu 16.04 in Docker (Buildkite)