### PR TITLE
Fix a memory leak and add the ability to build with ASAN

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,7 @@ python setup.py bdist_wheel && pip install dist/*.whl
 popd
 
 # Build the native code
-bazel build //...:all
+bazel build "$@" //...:all
 
 if [[ $(uname -s) == 'Linux' ]]; then
     # Copy the build artificts into a dist folder

--- a/build/docker_build.sh
+++ b/build/docker_build.sh
@@ -15,5 +15,5 @@ if [[ "$1" == "-i" ]]; then
     docker run --rm -it -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash
 else
     # Build and test Neuropods
-    docker run --rm -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash -c "build/build.sh;build/test.sh"
+    docker run --rm -v /tmp/neuropod_docker_cache:/root/.cache neuropods /bin/bash -c "build/build.sh $@; build/test.sh $@"
 fi

--- a/build/set_build_env.sh
+++ b/build/set_build_env.sh
@@ -6,3 +6,11 @@ set -e
 # TODO(vip): find a better way to do this
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/libtorch_repo/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/tensorflow_repo/lib
+
+# Ignore ODR errors from ASAN
+# See https://github.com/google/sanitizers/wiki/AddressSanitizerOneDefinitionRuleViolation
+export ASAN_OPTIONS=detect_odr_violation=0
+
+# Set the ASAN symbolizer path
+# See https://clang.llvm.org/docs/AddressSanitizer.html
+export ASAN_SYMBOLIZER_PATH=`pwd`/bazel-source/external/llvm_toolchain/bin/llvm-symbolizer

--- a/build/test.sh
+++ b/build/test.sh
@@ -11,5 +11,5 @@ python -m unittest discover --verbose neuropods/tests
 popd
 
 # Run native tests
-bazel test --cache_test_results=no --test_output=errors //...
+bazel test --cache_test_results=no --test_output=errors "$@" //...
 popd

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -25,5 +25,5 @@ python -m unittest discover --verbose neuropods/tests -p gpu_test*.py
 popd
 
 # Run native tests
-bazel test --cache_test_results=no --test_output=errors //...
+bazel test --cache_test_results=no --test_output=errors "$@" //...
 popd

--- a/source/.bazelrc
+++ b/source/.bazelrc
@@ -12,3 +12,6 @@ build --cxxopt='-D_GLIBCXX_USE_CXX11_ABI=0'
 
 # Disable strict python version checking added in Bazel 0.27
 build --extra_toolchains=@bazel_tools//tools/python:autodetecting_toolchain_nonstrict
+
+# Use ASAN
+build:asan -c dbg --copt='-fsanitize=address' --copt='-fno-omit-frame-pointer' --linkopt='-fsanitize=address' --test_env=ASAN_OPTIONS --test_env=ASAN_SYMBOLIZER_PATH

--- a/source/neuropods/backends/test_backend/test_neuropod_tensor.hh
+++ b/source/neuropods/backends/test_backend/test_neuropod_tensor.hh
@@ -31,7 +31,7 @@ public:
     TestNeuropodTensor(const std::vector<int64_t> &dims) : TypedNeuropodTensor<T>(dims)
     {
         data_ = malloc(this->get_num_elements() * sizeof(T));
-        deleter_handle_ = nullptr;
+        deleter_handle_ = register_deleter([](void * data) { free(data); }, data_);
     }
 
     // Wrap existing memory


### PR DESCRIPTION
Adds the ability to build with AddressSanitizer by passing `--config=asan` to the bazel build and test commands.

This can also be done in docker by running `./build/docker_build.sh --config=asan`

An ASAN build will be added to CI once the remaining memory issues are cleaned up