### PR TITLE
validate neuropod_path is not a subdirectory of python_root

### DIFF
--- a/source/neuropods/python/backends/python/packager.py
+++ b/source/neuropods/python/backends/python/packager.py
@@ -137,6 +137,10 @@ def create_python_neuropod(
     # Copy the specified source code while preserving package paths
     for copy_spec in code_path_spec:
         python_root = copy_spec["python_root"]
+
+        if os.path.realpath(neuropod_path).startswith(os.path.realpath(python_root) + os.sep):
+            raise ValueError("`neuropod_path` cannot be a subdirectory of `python_root`")
+
         for dir_to_package in copy_spec["dirs_to_package"]:
             shutil.copytree(
                 os.path.join(python_root, dir_to_package),


### PR DESCRIPTION

@VivekPanyam 

encountered a odd edge case in packaging some models for michelangelo's inference tests,  in the case of a neuropod subdirectory of python root, the shutil.copytree() will just recursively copy the python dir and neuropod into copies of themselves until the OS errors out at some max depth.
