### PR TITLE
save test data for validation in other environments

### DIFF
--- a/source/neuropods/python/backends/keras/packager.py
+++ b/source/neuropods/python/backends/keras/packager.py
@@ -16,7 +16,8 @@ def create_keras_neuropod(
         input_spec=None,
         output_spec=None,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        persist_test_data=True):
     """
     Packages a Keras model as a neuropod package. Currently, only the TensorFlow backend is supported.
 
@@ -72,6 +73,8 @@ def create_keras_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+
+    :param  persist_test_data:  Optionally saves the test data within the packaged neuropod. default True.
     """
     if input_spec is None:
         input_spec = infer_keras_input_spec(model, node_name_mapping)
@@ -116,7 +119,8 @@ def create_keras_neuropod(
         input_spec=input_spec,
         output_spec=output_spec,
         test_input_data=test_input_data,
-        test_expected_out=test_expected_out
+        test_expected_out=test_expected_out,
+        persist_test_data=persist_test_data,
     )
 
 

--- a/source/neuropods/python/backends/python/packager.py
+++ b/source/neuropods/python/backends/python/packager.py
@@ -7,7 +7,7 @@ import json
 import shutil
 
 from neuropods.backends import config_utils
-from neuropods.utils.eval_utils import load_and_test_neuropod
+from neuropods.utils.eval_utils import save_test_data, load_and_test_neuropod
 
 
 def create_python_neuropod(
@@ -23,7 +23,8 @@ def create_python_neuropod(
         test_expected_out=None,
         test_deps=[],
         test_virtualenv=None,
-        skip_virtualenv=False):
+        skip_virtualenv=False,
+        persist_test_data=True):
     """
     Packages arbitrary python code as a neuropod package.
 
@@ -108,6 +109,8 @@ def create_python_neuropod(
                                 If not specified, a new temporary virtualenv is created.
 
     :param  skip_virtualenv:    If set to true, runs the test locally instead of in a virtualenv
+
+    :param  persist_test_data:  Optionally save the test data within the packaged neuropod. default True.
     """
     try:
         # Create the neuropod folder
@@ -160,6 +163,8 @@ def create_python_neuropod(
         }, config_file)
 
     if test_input_data is not None:
+        if persist_test_data:
+            save_test_data(neuropod_path, test_input_data, test_expected_out)
         # Load and run the neuropod to make sure that packaging worked correctly
         # Throws a ValueError if the output doesn't match the expected output (if specified)
         load_and_test_neuropod(

--- a/source/neuropods/python/backends/tensorflow/packager.py
+++ b/source/neuropods/python/backends/tensorflow/packager.py
@@ -8,7 +8,7 @@ import shutil
 import tensorflow as tf
 
 from neuropods.backends import config_utils
-from neuropods.utils.eval_utils import load_and_test_neuropod
+from neuropods.utils.eval_utils import save_test_data, load_and_test_neuropod
 
 
 def create_tensorflow_neuropod(
@@ -21,7 +21,8 @@ def create_tensorflow_neuropod(
         graph_def=None,
         init_op_names=None,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        persist_test_data=True):
     """
     Packages a TensorFlow model as a neuropod package.
 
@@ -79,6 +80,8 @@ def create_tensorflow_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+
+    :param  persist_test_data:  Optionally saves the test data within the packaged neuropod. default True.
     """
     try:
         # Create the neuropod folder
@@ -124,6 +127,8 @@ def create_tensorflow_neuropod(
         }, config_file)
 
     if test_input_data is not None:
+        if persist_test_data:
+            save_test_data(neuropod_path, test_input_data, test_expected_out)
         # Load and run the neuropod to make sure that packaging worked correctly
         # Throws a ValueError if the output doesn't match the expected output (if specified)
         load_and_test_neuropod(

--- a/source/neuropods/python/backends/torchscript/packager.py
+++ b/source/neuropods/python/backends/torchscript/packager.py
@@ -6,7 +6,7 @@ import os
 import torch
 
 from neuropods.backends import config_utils
-from neuropods.utils.eval_utils import load_and_test_neuropod
+from neuropods.utils.eval_utils import save_test_data, load_and_test_neuropod
 
 
 def create_torchscript_neuropod(
@@ -16,7 +16,8 @@ def create_torchscript_neuropod(
         input_spec,
         output_spec,
         test_input_data=None,
-        test_expected_out=None):
+        test_expected_out=None,
+        persist_test_data=True):
     """
     Packages a TorchScript model as a neuropod package.
 
@@ -63,6 +64,8 @@ def create_torchscript_neuropod(
                                 Ex: {
                                     "out": np.arange(5) + np.arange(5)
                                 }
+
+    :param  persist_test_data:  Optionally saves the test data within the packaged neuropod. default True.
     """
     try:
         # Create the neuropod folder
@@ -88,6 +91,8 @@ def create_torchscript_neuropod(
     torch.jit.save(module, model_path)
 
     if test_input_data is not None:
+        if persist_test_data:
+            save_test_data(neuropod_path, test_input_data, test_expected_out)
         # Load and run the neuropod to make sure that packaging worked correctly
         # Throws a ValueError if the output doesn't match the expected output (if specified)
         load_and_test_neuropod(

--- a/source/neuropods/python/tests/test_eval_utils.py
+++ b/source/neuropods/python/tests/test_eval_utils.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+from testpath.tempdir import TemporaryDirectory
+
+from neuropods.utils.eval_utils import save_test_data, load_test_data
+
+
+class TestEvalUtil(unittest.TestCase):
+    def test_save_load_test_data(self):
+        with TemporaryDirectory() as test_dir:
+            neuropod_path = os.path.join(test_dir, "test_neuropod")
+            os.mkdir(neuropod_path)
+
+            test_input = { "x": 3, "y": 4 }
+            test_expected_output = { "out": 7 }
+
+            save_test_data(neuropod_path, test_input, test_expected_output)
+            test_data = load_test_data(neuropod_path)
+            self.assertEquals(test_input, test_data["test_input"])
+            self.assertEquals(test_expected_output, test_data["test_output"])

--- a/source/neuropods/python/utils/eval_utils.py
+++ b/source/neuropods/python/utils/eval_utils.py
@@ -3,11 +3,16 @@
 #
 
 import logging
+import os
+import pickle
+
 import numpy as np
 from testpath.tempdir import TemporaryDirectory
 
 from neuropods.loader import load_neuropod
 from neuropods.utils.env_utils import create_virtualenv, eval_in_virtualenv
+
+TEST_DATA_FILENAME = "test_data.pkl"
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +79,34 @@ def load_and_test_neuropod(neuropod_path, test_input_data, test_expected_out=Non
     else:
         # We don't have any expected output so print a summary
         print_output_summary(out)
+
+
+def save_test_data(neuropod_path, test_input_data, test_expected_out):
+    """
+    Saves the neuropods model's test data to a pickle file in the neuropod data directory
+
+    :param neuropod_path: the path of the neuropod model
+    :param test_input_data: a dictionary of expected input feature values
+    :param test_expected_out: a dictionary of expected output feature values
+    :return: None
+    """
+    test_data = {
+        "test_input": test_input_data,
+        "test_output": test_expected_out
+    }
+    with open(os.path.join(neuropod_path, TEST_DATA_FILENAME), "wb") as test_data_file:
+        pickle.dump(test_data, test_data_file)
+
+def load_test_data(neuropod_path):
+    """
+    Loads the neuropods model's test data from the data directory
+
+    :param neuropod_path: the path of the neuropod model
+    :return: dict or None
+    """
+    try:
+        with open(os.path.join(neuropod_path, TEST_DATA_FILENAME), "rb") as test_data_file:
+            return pickle.load(test_data_file)
+    except IOError as err:
+        logger.warn("load_test_data IOError {}".format(err))
+        return None


### PR DESCRIPTION
right now the test data in the neuropod packager args seems to be discarded after it is run.  I'd like to serialize it for reuse.  When we load packaged ML models in different environments, we want to run test data through it again before marking them ready,   e.g. at inference server build time, or as production health check.   The model archiving in Michelangelo typically saves this data alongside the models for those purposes.