### PR TITLE
Remove LD_LIBRARY_PATH usage in tests

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2,7 +2,7 @@
 set -e
 pushd source
 
-# Set LD_LIBRARY_PATH
+# Set the build environment
 source ../build/set_build_env.sh
 
 # Build a wheel + install locally

--- a/build/set_build_env.sh
+++ b/build/set_build_env.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-# Add TF and torch to the LD_LIBRARY_PATH
-# This is so the tests can find the shared objects at runtime
-# TODO(vip): find a better way to do this
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/libtorch_repo/lib
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-source/external/tensorflow_repo/lib
-
 # Ignore ODR errors from ASAN
 # See https://github.com/google/sanitizers/wiki/AddressSanitizerOneDefinitionRuleViolation
 export ASAN_OPTIONS=detect_odr_violation=0

--- a/build/test.sh
+++ b/build/test.sh
@@ -2,7 +2,7 @@
 set -e
 pushd source
 
-# Set LD_LIBRARY_PATH
+# Set the build environment
 source ../build/set_build_env.sh
 
 # Run python tests

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -13,7 +13,7 @@ else
     nvidia-smi -L
 fi
 
-# Set LD_LIBRARY_PATH
+# Set the build environment
 source ../build/set_build_env.sh
 
 # Run python tests

--- a/source/bazel/copy_libs.bzl
+++ b/source/bazel/copy_libs.bzl
@@ -1,0 +1,47 @@
+def _copy_libs_impl(ctx):
+    # Get a list of the input files
+    in_files = ctx.files.libs
+
+    # Declare the output files
+    out_files = [ctx.actions.declare_file(f.basename) for f in in_files]
+
+    ctx.actions.run_shell(
+        # Input files visible to the action.
+        inputs = in_files,
+
+        # Output files that must be created by the action.
+        outputs = out_files,
+
+        # A progress message to display during the build
+        progress_message = "Copying libs for target %s" % ctx.attr.name,
+
+        # Copy all the input files to the output directory
+        command = "cp %s %s" %
+            (
+                " ".join([f.path for f in in_files]),
+                out_files[0].dirname
+            ),
+    )
+
+    # Tell bazel to make these files available at runtime
+    runfiles = ctx.runfiles(
+        files = out_files,
+        collect_default = True,
+    )
+
+    return [DefaultInfo(runfiles = runfiles)]
+
+copy_libs = rule(
+    implementation = _copy_libs_impl,
+    attrs = {
+        "libs": attr.label(
+            mandatory = True,
+            allow_files = True,
+            doc = "A filegroup containing the libs to copy",
+        ),
+    },
+    doc = """
+Copies all the files in a filegroup to the rule's directory and makes them available
+at runtime.
+""",
+)

--- a/source/deps/BUILD.libtorch
+++ b/source/deps/BUILD.libtorch
@@ -34,3 +34,21 @@ cc_library(
         "//conditions:default": [],
     }),
 )
+
+filegroup(
+    name = "libtorch_libs",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": [
+            "lib/libtorch.1.dylib",
+            "lib/libcaffe2.dylib",
+            "lib/libc10.dylib",
+        ],
+        "//conditions:default": [
+            "lib/libtorch.so.1",
+            "lib/libtorch.so",
+            "lib/libcaffe2.so",
+            "lib/libc10.so",
+            "lib/libgomp-8bba0e50.so.1",
+        ],
+    })
+)

--- a/source/deps/BUILD.tensorflow
+++ b/source/deps/BUILD.tensorflow
@@ -18,3 +18,11 @@ cc_import(
     interface_library = "lib/libtensorflow.so",
     system_provided = True,
 )
+
+filegroup(
+    name = "libtensorflow_libs",
+    srcs = [
+        "lib/libtensorflow.so",
+        "lib/libtensorflow_framework.so",
+    ]
+)

--- a/source/neuropods/backends/tensorflow/BUILD
+++ b/source/neuropods/backends/tensorflow/BUILD
@@ -2,6 +2,8 @@
 # Uber, Inc. (c) 2018
 #
 
+load("//bazel:copy_libs.bzl", "copy_libs")
+
 cc_binary(
     name = "libneuropod_tensorflow_backend.so",
     srcs = [
@@ -15,7 +17,7 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
-    linkopts = ["-Wl,-rpath ."],
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
     visibility = [
         "//neuropods:__subpackages__",
     ],
@@ -24,5 +26,13 @@ cc_binary(
         "//neuropods/internal:deleter",
         "@tensorflow_repo//:tensorflow_c_hdrs",
         "@tensorflow_repo//:libtensorflow",
+    ],
+    data = [
+        ":copy_libtensorflow",
     ]
+)
+
+copy_libs(
+    name = "copy_libtensorflow",
+    libs = "@tensorflow_repo//:libtensorflow_libs"
 )

--- a/source/neuropods/backends/torchscript/BUILD
+++ b/source/neuropods/backends/torchscript/BUILD
@@ -2,6 +2,8 @@
 # Uber, Inc. (c) 2018
 #
 
+load("//bazel:copy_libs.bzl", "copy_libs")
+
 cc_binary(
     name = "libneuropod_torchscript_backend.so",
     srcs = [
@@ -14,7 +16,7 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
-    linkopts = ["-Wl,-rpath ."],
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
     visibility = [
         "//neuropods:__subpackages__",
     ],
@@ -23,5 +25,13 @@ cc_binary(
         "//neuropods/internal:deleter",
         "@libtorch_repo//:libtorch_hdrs",
         "@libtorch_repo//:libtorch",
+    ],
+    data = [
+        ":copy_libtorch",
     ]
+)
+
+copy_libs(
+    name = "copy_libtorch",
+    libs = "@libtorch_repo//:libtorch_libs"
 )

--- a/source/neuropods/tests/BUILD
+++ b/source/neuropods/tests/BUILD
@@ -49,10 +49,10 @@ cc_test(
     srcs = [
         "test_torchscript_backend.cc",
         "//neuropods:libneuropods.so",
-        "//neuropods/backends/torchscript:libneuropod_torchscript_backend.so",
     ],
     deps = [
         ":neuropods_test_utils",
+        "//neuropods/backends/torchscript:libneuropod_torchscript_backend.so",
     ],
 )
 
@@ -61,10 +61,10 @@ cc_test(
     srcs = [
         "test_tensorflow_backend.cc",
         "//neuropods:libneuropods.so",
-        "//neuropods/backends/tensorflow:libneuropod_tensorflow_backend.so",
     ],
     deps = [
         ":neuropods_test_utils",
+        "//neuropods/backends/tensorflow:libneuropod_tensorflow_backend.so",
     ],
 )
 

--- a/source/neuropods/tests/test_default_backend.cc
+++ b/source/neuropods/tests/test_default_backend.cc
@@ -4,16 +4,6 @@
 
 #include "test_utils.hh"
 
-// We need to override the default backend lookup paths
-// Modifying the RPATH doesn't work on Linux because Bazel symlinks all the objects
-// into the test directory
-const std::unordered_map<std::string, std::string> default_backend_overrides = {
-    {"tensorflow", "./neuropods/backends/tensorflow/libneuropod_tensorflow_backend.so"},
-    {"python", "./neuropods/backends/python_bridge/libneuropod_pythonbridge_backend.so"},
-    {"pytorch", "./neuropods/backends/python_bridge/libneuropod_pythonbridge_backend.so"},
-    {"torchscript", "./neuropods/backends/torchscript/libneuropod_torchscript_backend.so"},
-};
-
 TEST(test_default_backend, test_pytorch_addition_model)
 {
     // Test the PyTorch addition model

--- a/source/neuropods/tests/test_tensorflow_backend.cc
+++ b/source/neuropods/tests/test_tensorflow_backend.cc
@@ -4,6 +4,8 @@
 
 #include "neuropods/tests/test_utils.hh"
 
+LOAD_BACKEND("tensorflow")
+
 TEST(test_models, test_tensorflow_addition_model)
 {
     // Test the TensorFlow addition model using the native TensorFlow backend

--- a/source/neuropods/tests/test_torchscript_backend.cc
+++ b/source/neuropods/tests/test_torchscript_backend.cc
@@ -4,6 +4,8 @@
 
 #include "test_utils.hh"
 
+LOAD_BACKEND("torchscript")
+
 TEST(test_models, test_torchscript_addition_model)
 {
     // Test the TorchScript addition model using the native torchscript backend


### PR DESCRIPTION
Cleans up some tech debt in tests. This is also a prerequisite to building/testing with multiple versions of backends + cleaner packaging and releases