### PR TITLE
Pin numpy to a version that still supports python 2

### DIFF
--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 REQUIRED_PACKAGES = [
-    "numpy",
+    "numpy<1.17.0",
     "testpath",
     "future",
     "six"


### PR DESCRIPTION
Per https://github.com/numpy/numpy/releases/tag/v1.17.0rc1, support for python 2.7 has been dropped. We need to pin a version pre-1.17 for now 