### PR TITLE
Add python bindings and tests for the native Neuropod interface

### DIFF
--- a/build/set_build_env.sh
+++ b/build/set_build_env.sh
@@ -14,3 +14,6 @@ export ASAN_OPTIONS=detect_odr_violation=0
 # Set the ASAN symbolizer path
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 export ASAN_SYMBOLIZER_PATH=`pwd`/bazel-source/external/llvm_toolchain/bin/llvm-symbolizer
+
+# So the python tests can find the native bindings
+export PYTHONPATH=`pwd`/bazel-bin/neuropods/bindings

--- a/build/test.sh
+++ b/build/test.sh
@@ -8,6 +8,9 @@ source ../build/set_build_env.sh
 # Run python tests
 pushd python
 python -m unittest discover --verbose neuropods/tests
+
+# Test the native bindings
+NEUROPODS_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropods/tests
 popd
 
 # Run native tests

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -20,8 +20,14 @@ source ../build/set_build_env.sh
 pushd python
 python -m unittest discover --verbose neuropods/tests
 
+# Test the native bindings
+NEUROPODS_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropods/tests
+
 # Run GPU only python tests
 python -m unittest discover --verbose neuropods/tests -p gpu_test*.py
+
+# Run GPU only python tests with native bindings
+NEUROPODS_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropods/tests -p gpu_test*.py
 popd
 
 # Run native tests

--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -68,6 +68,15 @@ http_archive(
     strip_prefix = "boost_1_54_0",
 )
 
+http_archive(
+    name = "pybind11_repo",
+    build_file = "@//deps:BUILD.pybind11",
+    sha256 = "c62073cd8d4f9209ad64092279e757f5fd83327a5b17a72c04fd0fea27d0d593",
+    type = "zip",
+    url = "https://github.com/pybind/pybind11/archive/v2.2.4.zip",
+    strip_prefix = "pybind11-2.2.4",
+)
+
 python_repository(
     name = "python_repo",
     build_file = "@//deps:BUILD.python",

--- a/source/deps/BUILD.pybind11
+++ b/source/deps/BUILD.pybind11
@@ -1,0 +1,21 @@
+#
+# Uber, Inc. (c) 2019
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "pybind11",
+    hdrs = glob([
+        "include/pybind11/**",
+    ]),
+    includes = [
+        "include"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@python_repo//:python",
+    ],
+)

--- a/source/neuropods/bindings/BUILD
+++ b/source/neuropods/bindings/BUILD
@@ -1,0 +1,17 @@
+#
+# Uber, Inc. (c) 2019
+#
+
+cc_binary(
+    name = "neuropods_native.so",
+    srcs = [
+        "python_bindings.cc",
+        "//neuropods:libneuropods.so",
+    ],
+    deps = [
+        "//neuropods/internal:neuropod_tensor",
+        "//neuropods:neuropods_hdrs",
+        "@pybind11_repo//:pybind11",
+    ],
+    linkshared = True,
+)

--- a/source/neuropods/bindings/python_bindings.cc
+++ b/source/neuropods/bindings/python_bindings.cc
@@ -1,0 +1,150 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include "neuropods/internal/neuropod_tensor.hh"
+#include "neuropods/neuropods.hh"
+
+namespace neuropods
+{
+
+namespace py = pybind11;
+
+namespace
+{
+
+struct create_array_visitor : public NeuropodTensorVisitor<py::array>
+{
+    template <typename T>
+    py::array operator()(TypedNeuropodTensor<T> *tensor, std::shared_ptr<NeuropodValue> &value) const
+    {
+        auto dims = tensor->get_dims();
+        auto data = tensor->get_raw_data_ptr();
+
+        // Make sure we don't deallocate the tensor until the numpy array is deallocated
+        auto deleter = [value](void * unused) {};
+        auto deleter_handle = register_deleter(deleter, nullptr);
+        auto capsule = py::capsule(deleter_handle, [](void * handle) { run_deleter(handle); });
+        return py::array_t<T>(dims, data, capsule);
+    }
+
+    py::array operator()(TypedNeuropodTensor<std::string> *tensor, std::shared_ptr<NeuropodValue> &value) const
+    {
+        return py::array(py::cast(tensor->get_data_as_vector()));
+    }
+};
+
+py::array tensor_to_numpy(std::shared_ptr<NeuropodValue> value)
+{
+    return value->as_tensor()->apply_visitor(create_array_visitor{}, value);
+}
+
+TensorType get_array_type(py::array &array)
+{
+#define IS_INSTANCE_CHECK(cpp_type, neuropod_type) \
+    if (py::isinstance<py::array_t<cpp_type>>(array)) return neuropod_type;
+
+    FOR_EACH_TYPE_MAPPING_EXCEPT_STRING(IS_INSTANCE_CHECK)
+
+    // Strings need to be handled separately because `py::isinstance` does not do
+    // what we want in this case.
+    if (array.dtype().kind() == 'S')
+    {
+        return STRING_TENSOR;
+    }
+
+    NEUROPOD_ERROR("Unsupported array type in python bindings: " << array.dtype().kind())
+}
+
+std::shared_ptr<NeuropodTensor> tensor_from_string_numpy(NeuropodTensorAllocator &allocator, py::array &array, std::vector<int64_t> &shape)
+{
+    // Unfortunately, for strings, we need to copy all the data in the tensor
+    auto tensor = allocator.allocate_tensor<std::string>(shape);
+    int max_len = array.itemsize();
+    int numel   = tensor->get_num_elements();
+
+    // Get a pointer to the underlying data
+    char *data = static_cast<char *>(array.mutable_data());
+
+    std::vector<std::string> out;
+    std::string              chars_to_strip("\0", 1);
+    for (int i = 0; i < numel * max_len; i += max_len)
+    {
+        std::string item(data + i, max_len);
+
+        // Remove null padding at the end
+        item.erase(item.find_last_not_of(chars_to_strip) + 1);
+        out.emplace_back(item);
+    }
+
+    // This potentially does another copy (depending on the backend)
+    tensor->set(out);
+
+    return tensor;
+}
+
+std::shared_ptr<NeuropodTensor> tensor_from_numpy(NeuropodTensorAllocator &allocator, py::array array)
+{
+    // TODO(vip): Make sure it's contiguous and aligned
+    auto ndims = array.ndim();
+    auto dims  = array.shape();
+    auto dtype = get_array_type(array);
+    auto data  = array.mutable_data();
+
+    // Capture the array in our deleter so it doesn't get deallocated
+    // until we're done
+    auto deleter = [array](void *unused) {};
+
+    // Create a vector with the shape info
+    std::vector<int64_t> shape(&dims[0], &dims[ndims]);
+
+    if (dtype != STRING_TENSOR)
+    {
+        // Wrap the data from the numpy array
+        return allocator.tensor_from_memory(shape, dtype, data, deleter);
+    }
+    else
+    {
+        return tensor_from_string_numpy(allocator, array, shape);
+    }
+}
+
+py::dict infer(Neuropod &neuropod, py::dict &inputs_dict)
+{
+    // Convert from a py::dict of numpy arrays to an unordered_map of `NeuropodTensor`s
+    auto allocator = neuropod.get_tensor_allocator();
+    NeuropodValueMap inputs;
+    for (auto item : inputs_dict)
+    {
+        inputs[item.first.cast<std::string>()] = tensor_from_numpy(*allocator, item.second.cast<py::array>());
+    }
+
+    // Run inference
+    auto outputs = neuropod.infer(inputs);
+
+    // Convert the outputs to a python dict of numpy arrays
+    py::dict out;
+    for (auto &item : *outputs)
+    {
+        out[item.first.c_str()] = tensor_to_numpy(item.second);
+    }
+
+    return out;
+}
+
+} // namespace
+
+PYBIND11_MODULE(neuropods_native, m) {
+    py::class_<Neuropod>(m, "Neuropod")
+        .def(py::init<const std::string &>())
+        .def(py::init<const std::string &, const std::unordered_map<std::string, std::string> &>())
+        .def(py::init<const std::string &, const std::string &>())
+        .def("infer", &infer);
+
+}
+
+} // namespace neuropods

--- a/source/neuropods/python/loader.py
+++ b/source/neuropods/python/loader.py
@@ -36,9 +36,12 @@ if __name__ == '__main__':
     parser.add_argument('--neuropod-path', help='The path to a neuropod to load', required=True)
     parser.add_argument('--input-pkl-path', help='The path to sample input data for the model', required=True)
     parser.add_argument('--output-pkl-path', help='Where to write the output of the model', default=None)
+    parser.add_argument('--use-native', help=('Use the native bindings to run the model. This option can currently '
+                                              'only be used when running from the `source/python` directory within '
+                                              'the Neuropods source tree.'), default=False, action='store_true')
     args = parser.parse_args()
 
-    with load_neuropod(args.neuropod_path) as model:
+    def run_model(model):
         # Load the input data
         with open(args.input_pkl_path, 'rb') as pkl:
             input_data = pickle.load(pkl)
@@ -49,3 +52,25 @@ if __name__ == '__main__':
         if args.output_pkl_path is not None:
             with open(args.output_pkl_path, 'wb') as pkl:
                 pickle.dump(out, pkl)
+
+    if args.use_native:
+        import os
+        from neuropods_native import Neuropod as NeuropodNative
+        # We need to override the default backend lookup paths to point to the shared objects in
+        # the bazel bin directory
+        # TODO(vip): Do this in a place that only affects the tests
+        DEFAULT_BACKEND_OVERRIDES = {
+            "tensorflow": "../bazel-bin/neuropods/backends/tensorflow/libneuropod_tensorflow_backend.so",
+            "python": "../bazel-bin/neuropods/backends/python_bridge/libneuropod_pythonbridge_backend.so",
+            "pytorch": "../bazel-bin/neuropods/backends/python_bridge/libneuropod_pythonbridge_backend.so",
+            "torchscript": "../bazel-bin/neuropods/backends/torchscript/libneuropod_torchscript_backend.so",
+        }
+
+        if not os.path.isdir("../bazel-bin"):
+            raise ValueError("The `--use-native` option can currently only be used when running from the `source/python` directory within the Neuropods source tree. "
+                             "Please also ensure that the native libraries have been built before using this flag.")
+        model = NeuropodNative(args.neuropod_path, DEFAULT_BACKEND_OVERRIDES)
+        run_model(model)
+    else:
+        with load_neuropod(args.neuropod_path) as model:
+            run_model(model)

--- a/source/neuropods/python/utils/env_utils.py
+++ b/source/neuropods/python/utils/env_utils.py
@@ -46,6 +46,24 @@ def eval_in_virtualenv(neuropod_path, input_data, venv_path):
     :param  input_data      A pickleable dict containing sample input to the model
     :param  venv_path       The path to a virtualenv to run the model in
     """
+    return eval_in_new_process(
+        neuropod_path,
+        input_data,
+        os.path.join(venv_path, 'bin', 'python'),
+        env={"PYTHONPATH": os.path.join(venv_path, "neuropod_test_libs")}
+    )
+
+def eval_in_new_process(neuropod_path, input_data, binary_path="python", extra_args=[], **kwargs):
+    """
+    Loads and runs a neuropod model in a separate process with specified input data.
+
+    Raises a CalledProcessError if there was an error evaluating the neuropod
+
+    :param  neuropod_path   The path to the neuropod to load
+    :param  input_data      A pickleable dict containing sample input to the model
+    :param  binary_path     The binary to run. Defaults to "python"
+    :param  extra_args      Optional extra command line args to provide
+    """
     with TemporaryDirectory() as tmpdir:
         _, input_filepath = mkstemp(dir=tmpdir)
         with open(input_filepath, 'wb') as input_pkl:
@@ -53,11 +71,11 @@ def eval_in_virtualenv(neuropod_path, input_data, venv_path):
 
         _, output_filepath = mkstemp(dir=tmpdir)
 
-        subprocess.check_call([os.path.join(venv_path, 'bin', 'python'), '-m', 'neuropods.loader',
+        subprocess.check_call([binary_path, '-m', 'neuropods.loader',
                                '--neuropod-path', neuropod_path,
                                '--input-pkl-path', input_filepath,
                                '--output-pkl-path', output_filepath,
-                               ], env={"PYTHONPATH": os.path.join(venv_path, "neuropod_test_libs")})
+                               ] + extra_args, **kwargs)
 
         with open(output_filepath, 'rb') as output_pkl:
             return pickle.load(output_pkl)


### PR DESCRIPTION
Adds python bindings for the native Neuropod interface and runs all the python tests against the native code.

#98 and #99 need to land first in order for these tests to pass.

This PR helps us ensure that the Python and C++ interfaces stay at parity going forward.