### PR TITLE
Allow dynamic configuration of dependency versions

### DIFF
--- a/build/install_frameworks.py
+++ b/build/install_frameworks.py
@@ -1,0 +1,55 @@
+#
+# Uber, Inc. (c) 2019
+#
+
+# Installs the appropriate pip packages depending on the following env variables
+# NEUROPODS_IS_GPU
+# NEUROPODS_TORCH_VERSION
+# NEUROPODS_TENSORFLOW_VERSION
+import os
+import platform
+import subprocess
+import sys
+
+# The `or` pattern below handles empty strings and unset env variables
+# Using a default value only handles unset env variables
+REQUESTED_TF_VERSION = os.getenv("NEUROPODS_TENSORFLOW_VERSION") or "1.12.0"
+REQUESTED_TORCH_VERSION = os.getenv("NEUROPODS_TORCH_VERSION") or "1.1.0"
+IS_GPU = (os.getenv("NEUROPODS_IS_GPU") or None) is not None
+IS_MAC = platform.system() == "Darwin"
+
+def pip_install(args):
+    cmd = [sys.executable, "-m", "pip", "install"] + args
+    print "Running pip command: {}".format(cmd)
+    subprocess.check_call(cmd)
+
+def install_pytorch(version):
+    pip_args = []
+    if "dev" in version:
+        if IS_GPU:
+            pip_args += ["-f", "https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html"]
+        else:
+            pip_args += ["-f", "https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"]
+
+        pip_args += ["torch_nightly==" + version]
+    else:
+        pip_args += ["torch==" + version]
+
+    pip_install(pip_args)
+
+
+def install_tensorflow(version):
+    if "dev" in version:
+        package = "tf-nightly"
+    else:
+        package = "tensorflow"
+
+    if IS_GPU:
+        package += "-gpu"
+
+    pip_install([package + "==" + version])
+
+if __name__ == '__main__':
+    print "Installing tensorflow", REQUESTED_TF_VERSION, "and torch", REQUESTED_TORCH_VERSION
+    install_tensorflow(REQUESTED_TF_VERSION)
+    install_pytorch(REQUESTED_TORCH_VERSION)

--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -6,12 +6,8 @@ set -e
 pushd source/python
 pip install -U pip setuptools numpy
 python setup.py egg_info
-
-if [[ $(uname -s) == 'Darwin' ]]; then
-    # Only CPU torch packages are provided on Mac
-    cat neuropods.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-else
-    # Install torch compatible with CUDA 10.0
-    cat neuropods.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html
-fi
+cat neuropods.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install
 popd
+
+# Install the appropriate versions of torch and TF
+python ./build/install_frameworks.py

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -4,21 +4,6 @@
 # FROM ubuntu:16.04 as neuropod-base
 FROM nvidia/cuda:10.0-runtime-ubuntu16.04 as neuropod-base
 
-# Optional overrides used by the bazel build
-ARG NEUROPODS_TENSORFLOW_VERSION
-ARG NEUROPODS_TENSORFLOW_URL
-ARG NEUROPODS_TENSORFLOW_SHA256
-ARG NEUROPODS_LIBTORCH_VERSION
-ARG NEUROPODS_LIBTORCH_URL
-ARG NEUROPODS_LIBTORCH_SHA256
-
-ENV NEUROPODS_TENSORFLOW_VERSION=$NEUROPODS_TENSORFLOW_VERSION
-ENV NEUROPODS_TENSORFLOW_URL=$NEUROPODS_TENSORFLOW_URL
-ENV NEUROPODS_TENSORFLOW_SHA256=$NEUROPODS_TENSORFLOW_SHA256
-ENV NEUROPODS_LIBTORCH_VERSION=$NEUROPODS_LIBTORCH_VERSION
-ENV NEUROPODS_LIBTORCH_URL=$NEUROPODS_LIBTORCH_URL
-ENV NEUROPODS_LIBTORCH_SHA256=$NEUROPODS_LIBTORCH_SHA256
-
 # We use sudo in the build scripts
 RUN apt-get update && apt-get install -y sudo
 
@@ -33,7 +18,17 @@ RUN /usr/src/build/install_system_deps.sh
 # Copy the python code into the image
 RUN mkdir -p /usr/src/source/python /usr/src/source/neuropods/python
 COPY build/install_python_deps.sh /usr/src/build/install_python_deps.sh
+COPY build/install_frameworks.py /usr/src/build/install_frameworks.py
 COPY source/python /usr/src/source/python
+
+# Optional overrides
+ARG NEUROPODS_TENSORFLOW_VERSION
+ARG NEUROPODS_TORCH_VERSION
+ARG NEUROPODS_IS_GPU
+
+ENV NEUROPODS_TENSORFLOW_VERSION=$NEUROPODS_TENSORFLOW_VERSION
+ENV NEUROPODS_TORCH_VERSION=$NEUROPODS_TORCH_VERSION
+ENV NEUROPODS_IS_GPU=$NEUROPODS_IS_GPU
 
 # Install python dependencies
 RUN /usr/src/build/install_python_deps.sh

--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -22,17 +22,11 @@ llvm_toolchain(
 libtorch_repository(
     name = "libtorch_repo",
     build_file = "@//deps:BUILD.libtorch",
-    default_version = "1.1.0",
-    linux_sha = "c863a0073ff4c7b6feb958799c7dc3202b3449e86ff1cec9c85c7da9d1fe0218",
-    mac_sha = "2db31f6c7e69ea9142396d8ed0a7ad70dde2a9993cc8c23cc48c03ffeea13f0f",
 )
 
 tensorflow_repository(
     name = "tensorflow_repo",
     build_file = "@//deps:BUILD.tensorflow",
-    default_version = "1.12.0",
-    linux_sha = "fd473e2ef72a446421f627aebe90479b92495965c26843034625677a14d8d64f",
-    mac_sha = "0f77844966cfe8053eaa74f2b6bc5fecfddac070e4be49bd96ad70d5210dd8cc",
 )
 
 http_archive(

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -1,36 +1,30 @@
 # https://docs.bazel.build/versions/master/skylark/repository_rules.html
 def _impl(repository_ctx):
-    if repository_ctx.os.environ.get("NEUROPODS_LIBTORCH_URL"):
-        download_url = repository_ctx.os.environ["NEUROPODS_LIBTORCH_URL"]
-        download_sha = repository_ctx.os.environ.get("NEUROPODS_LIBTORCH_SHA256", '')
+    # The `or` pattern below handles empty strings and unset env variables
+    # Using a default value only handles unset env variables
+    version = repository_ctx.os.environ.get("NEUROPODS_TORCH_VERSION") or "1.1.0"
+    IS_MAC  = repository_ctx.os.name.startswith("mac")
+    IS_GPU  = (repository_ctx.os.environ.get("NEUROPODS_IS_GPU") or None) != None
+
+    download_url = "https://download.pytorch.org/libtorch"
+    if "dev" in version:
+        download_url += "/nightly"
+
+    if IS_GPU:
+        # Cuda 10
+        download_url += "/cu100"
     else:
-        version = repository_ctx.os.environ.get("NEUROPODS_LIBTORCH_VERSION", "") or repository_ctx.attr.default_version
-        download_base = "https://download.pytorch.org/libtorch"
-        if "dev" in version:
-            download_base += "/nightly"
+        download_url += "/cpu"
 
-        if repository_ctx.os.name.startswith("mac"):
-            download_url = download_base + "/cpu/libtorch-macos-" + version + ".zip"
-        else:
-            download_url = download_base + "/cpu/libtorch-shared-with-deps-" + version + ".zip"
-        download_sha = ''
+    if IS_MAC:
+        download_url += "/libtorch-macos-" + version + ".zip"
+    else:
+        download_url += "/libtorch-shared-with-deps-" + version + ".zip"
 
-        if repository_ctx.attr.default_version == version:
-            # If we're using the default version, use the default sha
-            if repository_ctx.os.name.startswith("mac"):
-                download_sha = repository_ctx.attr.mac_sha
-            else:
-                download_sha = repository_ctx.attr.linux_sha
-
-
-
-    repository_ctx.download_and_extract(download_url, sha256=download_sha, stripPrefix="libtorch")
+    repository_ctx.download_and_extract(download_url, stripPrefix="libtorch")
     repository_ctx.symlink(repository_ctx.path(Label(repository_ctx.attr.build_file)), "BUILD.bazel")
 
 libtorch_repository = repository_rule(
     implementation=_impl,
     local=True,
-    attrs={"build_file": attr.string(mandatory=True),
-           "default_version": attr.string(mandatory=True),
-           "linux_sha": attr.string(),
-           "mac_sha": attr.string()})
+    attrs={"build_file": attr.string(mandatory=True)})

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -1,31 +1,28 @@
 # https://docs.bazel.build/versions/master/skylark/repository_rules.html
 def _impl(repository_ctx):
-    if repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_URL"):
-        download_url = repository_ctx.os.environ["NEUROPODS_TENSORFLOW_URL"]
-        download_sha = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_SHA256", '')
+    # The `or` pattern below handles empty strings and unset env variables
+    # Using a default value only handles unset env variables
+    version = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_VERSION") or "1.12.0"
+    IS_MAC  = repository_ctx.os.name.startswith("mac")
+    IS_GPU  = (repository_ctx.os.environ.get("NEUROPODS_IS_GPU") or None) != None
+
+    # TODO(vip): find libtensorflow nightly builds
+    download_url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-"
+
+    if IS_GPU:
+        download_url += "gpu"
     else:
-        version = repository_ctx.os.environ.get("NEUROPODS_TENSORFLOW_VERSION", "") or repository_ctx.attr.default_version
-        if repository_ctx.os.name.startswith("mac"):
-            download_url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-" + version + ".tar.gz"
-        else:
-            download_url = "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-" + version + ".tar.gz"
-        download_sha = ''
+        download_url += "cpu"
 
-        if repository_ctx.attr.default_version == version:
-            # If we're using the default version, use the default sha
-            if repository_ctx.os.name.startswith("mac"):
-                download_sha = repository_ctx.attr.mac_sha
-            else:
-                download_sha = repository_ctx.attr.linux_sha
+    if IS_MAC:
+        download_url += "-darwin-x86_64-" + version + ".tar.gz"
+    else:
+        download_url += "-linux-x86_64-" + version + ".tar.gz"
 
-
-    repository_ctx.download_and_extract(download_url, sha256=download_sha)
+    repository_ctx.download_and_extract(download_url)
     repository_ctx.symlink(repository_ctx.path(Label(repository_ctx.attr.build_file)), "BUILD.bazel")
 
 tensorflow_repository = repository_rule(
     implementation=_impl,
     local=True,
-    attrs={"build_file": attr.string(mandatory=True),
-           "default_version": attr.string(mandatory=True),
-           "linux_sha": attr.string(),
-           "mac_sha": attr.string()})
+    attrs={"build_file": attr.string(mandatory=True)})

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -7,15 +7,9 @@ REQUIRED_PACKAGES = [
     "six"
 ]
 
-EXTRA_REQUIRE = {
-    "tensorflow": ["tensorflow==1.12.0"],
-    "torch": ["torch==1.1.0"],
-}
-
 setup(
     name="neuropods",
     version="0.0.1",
     install_requires=REQUIRED_PACKAGES,
-    extras_require=EXTRA_REQUIRE,
     packages=find_packages(),
 )


### PR DESCRIPTION
This PR allows us to easily set torch and TF library packages/URLs for both python and C++ by setting the following three env variables:

```
NEUROPODS_IS_GPU
NEUROPODS_TORCH_VERSION
NEUROPODS_TENSORFLOW_VERSION
```

This will let us start to build and test against multiple versions of dependencies in CI