### PR TITLE
Make python/pytorch neuropod loading more robust

### DIFF
--- a/source/neuropods/python/tests/test_python_isolation.py
+++ b/source/neuropods/python/tests/test_python_isolation.py
@@ -1,0 +1,81 @@
+#
+# Uber, Inc. (c) 2018
+#
+
+import numpy as np
+import os
+import shutil
+import unittest
+from tempfile import mkdtemp
+from testpath.tempdir import TemporaryDirectory
+
+from neuropods.loader import load_neuropod
+from neuropods.packagers import create_python_neuropod
+from neuropods.tests.utils import get_addition_model_spec, check_addition_model
+
+DUMMY_MODEL_SOURCE = """
+import numpy as np
+
+def model(x):
+    return {{
+        "out": np.array([{}], dtype=np.float32)
+    }}
+
+def get_model(_):
+    return model
+"""
+
+
+class TestPythonIsolation(unittest.TestCase):
+    def package_dummy_model(self, test_dir, target):
+        neuropod_path = os.path.join(test_dir, "test_neuropod")
+        model_code_dir = os.path.join(test_dir, "model_code")
+        os.makedirs(model_code_dir)
+
+        with open(os.path.join(model_code_dir, "dummy_model.py"), "w") as f:
+            f.write(DUMMY_MODEL_SOURCE.format(target))
+
+        # `create_python_neuropod` runs inference with the test data immediately
+        # after creating the neuropod. Raises a ValueError if the model output
+        # does not match the expected output.
+        create_python_neuropod(
+            neuropod_path=neuropod_path,
+            model_name="dummy_model",
+            data_paths=[],
+            code_path_spec=[{
+                "python_root": model_code_dir,
+                "dirs_to_package": [
+                    ""  # Package everything in the python_root
+                ],
+            }],
+            entrypoint_package="dummy_model",
+            entrypoint="get_model",
+            test_deps=['numpy'],
+            # This runs the test in the current process instead of in a new virtualenv
+            # We are using this to ensure the test will work even if the CI environment
+            # is restrictive
+            skip_virtualenv=True,
+            input_spec=[{"name": "x", "dtype": "float32", "shape": (1,)}],
+            output_spec=[{"name": "out", "dtype": "float32", "shape": (1,)}],
+            test_input_data={"x": np.array([0.0], dtype=np.float32)},
+            test_expected_out={"out": np.array([target], dtype=np.float32)},
+        )
+
+        return neuropod_path
+
+    def test_model_isolation(self):
+        # Test that we can correctly load two different models with the same entrypoint in the same process
+        with TemporaryDirectory() as test_dir1:
+            with TemporaryDirectory() as test_dir2:
+                path1 = self.package_dummy_model(test_dir1, 1.0)
+                path2 = self.package_dummy_model(test_dir2, 2.0)
+
+                with load_neuropod(path1) as n1:
+                    with load_neuropod(path2) as n2:
+                        input_data = {"x": np.array([0], dtype=np.float32)}
+                        self.assertEqual(n1.infer(input_data)["out"][0], 1.0)
+                        self.assertEqual(n2.infer(input_data)["out"][0], 2.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/source/neuropods/python/tests/utils.py
+++ b/source/neuropods/python/tests/utils.py
@@ -66,24 +66,24 @@ def check_addition_model(neuropod_path):
     Validate that the inputs and outputs of the loaded neuropod match
     the problem spec
     """
-    neuropod = load_neuropod(neuropod_path, load_custom_ops=False)
-    target = get_addition_model_spec()
+    with load_neuropod(neuropod_path, load_custom_ops=False) as neuropod:
+        target = get_addition_model_spec()
 
-    # Validate that the specs match
-    check_specs_match(neuropod.inputs, target["input_spec"])
-    check_specs_match(neuropod.outputs, target["output_spec"])
+        # Validate that the specs match
+        check_specs_match(neuropod.inputs, target["input_spec"])
+        check_specs_match(neuropod.outputs, target["output_spec"])
 
 def check_strings_model(neuropod_path):
     """
     Validate that the inputs and outputs of the loaded neuropod match
     the problem spec
     """
-    neuropod = load_neuropod(neuropod_path, load_custom_ops=False)
-    target = get_string_concat_model_spec()
+    with load_neuropod(neuropod_path, load_custom_ops=False) as neuropod:
+        target = get_string_concat_model_spec()
 
-    # Validate that the specs match
-    check_specs_match(neuropod.inputs, target["input_spec"])
-    check_specs_match(neuropod.outputs, target["output_spec"])
+        # Validate that the specs match
+        check_specs_match(neuropod.inputs, target["input_spec"])
+        check_specs_match(neuropod.outputs, target["output_spec"])
 
 def check_specs_match(specs, targets):
     """


### PR DESCRIPTION
## Previous process

Previously, the process for loading a python neuropod looked like this:

1) Check that the `entrypoint_package` is not importable
2) Add the neuropod code dir to the pythonpath
3) Import the `entrypoint_package`
4) Run the `entrypoint` function

This leads to issues when two neuropods contain the same packages. For example, if both `neuropod_a` and `neuropod_b` contain `my.package.some_utility` (which they use internally),

```
a = load_neuropod("/path/to/neuropod_a")
b = load_neuropod("/path/to/neuropod_b")
```

will actually cause `b` to use `my.package.some_utility` from `neuropod_a`.

This can cause models to silently use the wrong code (or break if the code is not compatible between versions).

Another downside is that you can't load two neuropods with the same `entrypoint_package`

One "real" use case for this is running two versions of a model in the same process to compare them.

## New process

To make this more robust, we're effectively namespacing the code in each neuropod. The process is now:

At initialization:
1) Create a temp dir (referred to as `SYMLINKS_DIR` below) and add it to the pythonpath

When loading a neuropod:
1) Generate a UUID
2) Symlink the code directory inside the neuropod to `SYMLINKS_DIR/{uuid}`
3) Import `{uuid}.{entrypoint_package}`
4) Run the `entrypoint` function

At process exit:
1) Remove all the symlinks in `SYMLINKS_DIR` and delete the directory


This turns `my.package.some_utility` into something like:
 - `a5741112_9259_438a_b2c1_101092f5e42d.my.package.some_utility` for `neuropod_a`
 - `3f4823d8_6fe9_468a_8254_9a754a10b5cb.my.package.some_utility` for `neuropod_b`

so the packages won't conflict.