### PR TITLE
Add accessors to TypedNeuropodTensor

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,7 @@ python setup.py bdist_wheel && pip install dist/*.whl
 popd
 
 # Build the native code
-bazel build "$@" //...:all
+bazel build -c opt "$@" //...:all
 
 if [[ $(uname -s) == 'Linux' ]]; then
     # Copy the build artificts into a dist folder

--- a/source/neuropods/internal/BUILD
+++ b/source/neuropods/internal/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "neuropod_tensor.cc",
     ],
     hdrs = [
+        "tensor_accessor.hh",
         "neuropod_tensor.hh",
         "tensor_types.hh",
         "type_macros.hh",

--- a/source/neuropods/internal/neuropod_tensor.cc
+++ b/source/neuropods/internal/neuropod_tensor.cc
@@ -7,6 +7,38 @@
 namespace neuropods
 {
 
+namespace
+{
+
+std::vector<int64_t> compute_strides(const std::vector<int64_t> &dims)
+{
+    // To compute strides from the dimensions, we want to do the following:
+    // For an index i, if i is the last element:
+    //     strides[i] = 1
+    // else
+    //     strides[i] = product(dims[i + 1:])
+    std::vector<int64_t> out(dims.size());
+
+    int64_t running_product = 1;
+    for (int i = out.size() - 1; i >= 0; i--)
+    {
+        // Set the stride
+        out[i] = running_product;
+
+        // Update the running product
+        running_product *= dims[i];
+    }
+
+    return out;
+}
+
+} // namespace
+
+NeuropodTensor::NeuropodTensor(TensorType tensor_type, const std::vector<int64_t> dims)
+    : NeuropodValue(true), tensor_type_(tensor_type), dims_(dims), strides_(compute_strides(dims))
+{
+}
+
 NeuropodTensor *NeuropodValue::as_tensor()
 {
     assure_tensor();

--- a/source/neuropods/internal/tensor_accessor.hh
+++ b/source/neuropods/internal/tensor_accessor.hh
@@ -1,0 +1,54 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#pragma once
+
+namespace neuropods
+{
+
+// Inspired by https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/TensorAccessor.h
+template <typename T, size_t N>
+class TensorAccessor
+{
+private:
+    T * data_;
+    const int64_t * strides_;
+
+public:
+    TensorAccessor(T * data, const int64_t *strides)
+        : data_(data), strides_(strides)
+    {}
+
+    TensorAccessor<T, N - 1> operator[](int64_t i) {
+        return TensorAccessor<T, N - 1>(this->data_ + this->strides_[0] * i, this->strides_ + 1);
+    }
+
+    const TensorAccessor<T, N - 1> operator[](int64_t i) const {
+        return TensorAccessor<T, N - 1>(this->data_ + this->strides_[0] * i, this->strides_ + 1);
+    }
+};
+
+// Specialization for base case
+template <typename T>
+class TensorAccessor<T, 1>
+{
+private:
+    T * data_;
+    const int64_t * strides_;
+
+public:
+    TensorAccessor(T * data, const int64_t *strides)
+        : data_(data), strides_(strides)
+    {}
+
+    T & operator[](int64_t i) {
+        return this->data_[i];
+    }
+
+    const T & operator[](int64_t i) const {
+        return this->data_[i];
+    }
+};
+
+} // namespace neuropods

--- a/source/neuropods/tests/BUILD
+++ b/source/neuropods/tests/BUILD
@@ -115,6 +115,20 @@ cc_test(
 )
 
 cc_test(
+    name = "test_accessor",
+    srcs = [
+        "test_accessor.cc",
+        "//neuropods:libneuropods.so",
+        "//neuropods/backends/test_backend:libneuropod_test_backend.so",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropods/backends/test_backend:test_backend_hdrs",
+        "//neuropods:neuropods_hdrs",
+    ],
+)
+
+cc_test(
     name = "test_internal_neuropod_tensor",
     srcs = [
         "test_internal_neuropod_tensor.cc",

--- a/source/neuropods/tests/test_accessor.cc
+++ b/source/neuropods/tests/test_accessor.cc
@@ -1,0 +1,80 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include "gtest/gtest.h"
+#include "neuropods/neuropods.hh"
+#include "neuropods/backends/test_backend/test_neuropod_backend.hh"
+
+#include <chrono>
+
+namespace
+{
+
+template<typename Resolution, typename T>
+float time_lambda(size_t warmup, size_t iterations, T fn)
+{
+    std::vector<size_t> times;
+
+    for (int i = 0; i < warmup + iterations; i++)
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        fn();
+
+        auto end = std::chrono::high_resolution_clock::now();
+
+        // Ignore the warmup period
+        if (i > warmup)
+        {
+            times.emplace_back(std::chrono::duration_cast<Resolution>(end - start).count());
+        }
+    }
+
+    return std::accumulate(times.begin(), times.end(), 0.0) / times.size();
+}
+
+
+} // namespace
+
+TEST(test_accessor_timing, test_accessor_timing)
+{
+    // Test that the config is valid
+    neuropods::TestNeuropodBackend backend;
+    auto allocator = backend.get_tensor_allocator();
+
+    auto tensor1 = allocator->allocate_tensor<float>({3, 5});
+    auto tensor2 = allocator->allocate_tensor<float>({3, 5});
+
+    auto accessor = tensor1->accessor<2>();
+    auto data_ptr = tensor2->get_raw_data_ptr();
+
+    auto native_time = time_lambda<std::chrono::nanoseconds>(100, 1000, [data_ptr]() {
+        float * curr = data_ptr;
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                curr[i * 5 + j] = i * 5 + j;
+            }
+        }
+    });
+
+    auto accessor_time = time_lambda<std::chrono::nanoseconds>(100, 1000, [&accessor]() {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                accessor[i][j] = i * 5 + j;
+            }
+        }
+    });
+
+    // Make sure that tensor 1 and tensor 2 are equal
+    EXPECT_EQ(memcmp(tensor1->get_raw_data_ptr(), tensor2->get_raw_data_ptr(), tensor1->get_num_elements() * sizeof(float)), 0);
+
+    std::cout << "Native loop time (nanoseconds): " << native_time << ". Accessor time (nanoseconds): " << accessor_time << std::endl;
+
+    // Note: we're being generous to avoid flakiness on CI
+    EXPECT_LE(accessor_time, native_time * 5);
+}


### PR DESCRIPTION
This PR adds accessors for efficient access to data in tensors.

Inspired by accessors in libtorch (https://pytorch.org/cppdocs/notes/tensor_basics.html#efficient-access-to-tensor-elements)