### PR TITLE
Pin Bazel to v0.28.1 on Mac

### DIFF
--- a/build/install_system_deps.sh
+++ b/build/install_system_deps.sh
@@ -6,9 +6,16 @@ NEUROPODS_PYTHON_BINARY="${NEUROPODS_PYTHON_BINARY:-python}"
 
 if [[ $(uname -s) == 'Darwin' ]]; then
     # Install bazel
+    tmpdir=$(mktemp -d)
+    pushd $tmpdir
+    curl -sSL -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-installer-darwin-x86_64.sh
+    chmod +x ./bazel.sh
+    ./bazel.sh
+    popd
+    rm -rf $tmpdir
+
+    # Install libomp
     export HOMEBREW_NO_AUTO_UPDATE=1
-    brew tap bazelbuild/tap
-    brew install bazelbuild/tap/bazel
     brew install libomp
 else
     # Install pip and bazel dependencies


### PR DESCRIPTION
Bazel v0.29 was [released](https://github.com/bazelbuild/bazel/releases/tag/0.29.0) earlier today and it breaks github URL fetches on Mac:

```
INFO: Call stack for the definition of repository 'mklml_repo_darwin' which is a http_archive (rule definition at /private/var/tmp/_bazel_travis/7d69d9a2c8ff134794f64460038c7245/external/bazel_tools/tools/build_defs/repo/http.bzl:292:16):
 - /Users/travis/build/uber/neuropods/source/WORKSPACE:88:1
WARNING: Download from https://github.com/intel/mkl-dnn/releases/download/v0.19/mklml_mac_2019.0.5.20190502.tgz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 400 Bad Request
ERROR: An error occurred during the fetch of repository 'mklml_repo_darwin':
   java.io.IOException: Error downloading [https://github.com/intel/mkl-dnn/releases/download/v0.19/mklml_mac_2019.0.5.20190502.tgz] to /private/var/tmp/_bazel_travis/7d69d9a2c8ff134794f64460038c7245/external/mklml_repo_darwin/mklml_mac_2019.0.5.20190502.tgz: GET returned 400 Bad Request
ERROR: /private/var/tmp/_bazel_travis/7d69d9a2c8ff134794f64460038c7245/external/libtorch_repo/BUILD.bazel:27:1: @libtorch_repo//:libtorch depends on @mklml_repo_darwin//:mklml in repository @mklml_repo_darwin which failed to fetch. no such package '@mklml_repo_darwin//': java.io.IOException: Error downloading [https://github.com/intel/mkl-dnn/releases/download/v0.19/mklml_mac_2019.0.5.20190502.tgz] to /private/var/tmp/_bazel_travis/7d69d9a2c8ff134794f64460038c7245/external/mklml_repo_darwin/mklml_mac_2019.0.5.20190502.tgz: GET returned 400 Bad Request
ERROR: Analysis of target '//neuropods:libneuropods_libs' failed; build aborted: no such package '@mklml_repo_darwin//': java.io.IOException: Error downloading [https://github.com/intel/mkl-dnn/releases/download/v0.19/mklml_mac_2019.0.5.20190502.tgz] to /private/var/tmp/_bazel_travis/7d69d9a2c8ff134794f64460038c7245/external/mklml_repo_darwin/mklml_mac_2019.0.5.20190502.tgz: GET returned 400 Bad Request
```

Downgrading to 0.28.1 fixes the issue