### PR TITLE
Add SHA256 values for the default Torch/TF deps in the bazel build

### DIFF
--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -59,7 +59,13 @@ def _impl(repository_ctx):
     else:
         download_url += "/libtorch-shared-with-deps-" + version + ".zip"
 
-    repository_ctx.download_and_extract(download_url, stripPrefix="libtorch")
+    # To prevent redownloading Torch during local development, we'll
+    # provide a sha256 value for the default build
+    sha256 = ""
+    if download_url == "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.1.0.zip":
+        sha256 = "c863a0073ff4c7b6feb958799c7dc3202b3449e86ff1cec9c85c7da9d1fe0218"
+
+    repository_ctx.download_and_extract(download_url, stripPrefix="libtorch", sha256=sha256)
 
     # Generate a build file based on the template
     repository_ctx.template(

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -19,7 +19,13 @@ def _impl(repository_ctx):
     else:
         download_url += "-linux-x86_64-" + version + ".tar.gz"
 
-    repository_ctx.download_and_extract(download_url)
+    # To prevent redownloading TF during local development, we'll
+    # provide a sha256 value for the default build
+    sha256 = ""
+    if download_url == "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.12.0.tar.gz":
+        sha256 = "fd473e2ef72a446421f627aebe90479b92495965c26843034625677a14d8d64f"
+
+    repository_ctx.download_and_extract(download_url, sha256=sha256)
     repository_ctx.symlink(repository_ctx.path(Label(repository_ctx.attr.build_file)), "BUILD.bazel")
 
 tensorflow_repository = repository_rule(


### PR DESCRIPTION
This prevents Bazel from redownloading torch and TF on every build.

In the future, we should add SHA256s for default builds on all platforms (i.e. Mac, Linux CPU, Linux GPU)