### PR TITLE
Refactor PythonBridge bazel dependencies

### DIFF
--- a/source/deps/BUILD.boost
+++ b/source/deps/BUILD.boost
@@ -21,7 +21,4 @@ cc_library(
         "."
     ],
     visibility = ["//visibility:public"],
-    deps = [
-        "@python_repo//:python",
-    ],
 )

--- a/source/deps/BUILD.python
+++ b/source/deps/BUILD.python
@@ -18,5 +18,6 @@ cc_library(
     includes = [
         "include/python{PYTHON_VERSION}"
     ],
+    defines = ["PYTHON_VERSION={PYTHON_VERSION}"],
     visibility = ["//visibility:public"],
 )

--- a/source/neuropods/backends/python_bridge/python_bridge.cc
+++ b/source/neuropods/backends/python_bridge/python_bridge.cc
@@ -44,6 +44,20 @@ bool maybe_initialize()
         return false;
     }
 
+    #ifndef __APPLE__
+    // This binary is already linked against `libpython`; the dlopen just
+    // promotes it to RTLD_GLOBAL.
+    #define STR_HELPER(x) #x
+    #define STR(x) STR_HELPER(x)
+    #define PYTHON_LIB_NAME "libpython" STR(PYTHON_VERSION) ".so"
+    void *libpython = dlopen(PYTHON_LIB_NAME, RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
+
+    if (libpython == nullptr)
+    {
+        NEUROPOD_ERROR("Failed to promote libpython to RTLD_GLOBAL. Error from dlopen: " << dlerror());
+    }
+    #endif
+
     // If we have a virtualenv, use it
     if (auto venv_path = std::getenv("VIRTUAL_ENV"))
     {


### PR DESCRIPTION
This PR removes the python dependency from the boost bazel target. It also adds a fix to the PythonBridge to ensure that it works properly in the absence of boost python