### PR TITLE
Upload releases on tagged builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.11.0-torch-1.1.0-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py2.7)"
     agents:
@@ -22,6 +25,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.13.1-torch-1.2.0-py2.7)"
     agents:
@@ -31,6 +37,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.13.1-torch-1.2.0-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7)"
     agents:
@@ -40,6 +49,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.11.0-torch-1.1.0-py3)"
     agents:
@@ -49,6 +61,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.11.0-torch-1.1.0-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py3)"
     agents:
@@ -58,6 +73,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.13.1-torch-1.2.0-py3)"
     agents:
@@ -67,6 +85,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.13.1-torch-1.2.0-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3)"
     agents:
@@ -76,6 +97,9 @@ steps:
       - docker-compose:
           run: test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.11.0-torch-1.1.0-py2.7)"
     agents:
@@ -85,6 +109,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.11.0-torch-1.1.0-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py2.7)"
     agents:
@@ -94,6 +121,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.13.1-torch-1.2.0-py2.7)"
     agents:
@@ -103,6 +133,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.13.1-torch-1.2.0-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7)"
     agents:
@@ -112,6 +145,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.11.0-torch-1.1.0-py3)"
     agents:
@@ -121,6 +157,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.11.0-torch-1.1.0-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py3)"
     agents:
@@ -130,6 +169,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.12.0-torch-1.2.0.dev20190601-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.13.1-torch-1.2.0-py3)"
     agents:
@@ -139,6 +181,9 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.13.1-torch-1.2.0-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3)"
     agents:
@@ -148,5 +193,8 @@ steps:
       - docker-compose:
           run: test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3
           config: docker-compose.test.yml
+          env:
+            - BUILDKITE_TAG
+            - GH_UPLOAD_TOKEN
 
 

--- a/build/allowed_deps.txt
+++ b/build/allowed_deps.txt
@@ -9,7 +9,6 @@
  0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
  0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
- 0x0000000000000001 (NEEDED)             Shared library: [libneuropods.so]
  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]

--- a/build/build.sh
+++ b/build/build.sh
@@ -13,6 +13,11 @@ popd
 # Build the native code
 bazel build "$@" //...:all
 
+# Build the packages if we need to (at least one of these are not empty)
+if [[ ! -z "${NEUROPODS_DO_PACKAGE}${BUILDKITE_TAG}${TRAVIS_TAG}" ]]; then
+    bazel build "$@" //neuropods:packages
+fi
+
 if [[ $(uname -s) == 'Linux' ]]; then
     # Copy the build artificts into a dist folder
     mkdir -p /tmp/neuropod_dist && \

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -47,6 +47,8 @@ services:
       context: .
       dockerfile: build/neuropods.dockerfile
       target: neuropod-build
+      args:
+        NEUROPODS_DO_PACKAGE: "true"
     privileged: true
 
   test-gpu:
@@ -134,6 +136,9 @@ for platform, py_version, framework_version in itertools.product(PLATFORMS, PY_V
         "      - docker-compose:\n",
         "          run: {}\n".format(variant_name),
         "          config: docker-compose.test.yml\n",
+        "          env:\n",
+        "            - BUILDKITE_TAG\n",
+        "            - GH_UPLOAD_TOKEN\n",
         "\n",
         ])
 

--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -4,7 +4,7 @@ set -e
 # Install deps for the python interface
 # (the -f flag tells pip where to find the torch nightly builds)
 pushd source/python
-pip install -U pip setuptools numpy coverage
+pip install -U pip setuptools numpy coverage requests
 python setup.py egg_info
 cat neuropods.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install
 popd

--- a/build/neuropods.dockerfile
+++ b/build/neuropods.dockerfile
@@ -55,6 +55,12 @@ RUN echo "import coverage; coverage.process_startup()" > \
 # Copy the rest of the code in
 COPY . /usr/src
 
+# Whether we should generate release packages
+# We don't do this by default because packaging torch and TF can take a bit of time
+# (packages are built if this is not empty)
+ARG NEUROPODS_DO_PACKAGE
+ENV NEUROPODS_DO_PACKAGE=$NEUROPODS_DO_PACKAGE
+
 # Build
 # To only build (and skip tests), pass `--target neuropod-build` to docker build
 FROM neuropod-base as neuropod-build

--- a/build/test.sh
+++ b/build/test.sh
@@ -16,3 +16,6 @@ popd
 # Run native tests
 python ../build/run_cpp_tests.py
 popd
+
+# Maybe upload a release
+python build/upload_release.py

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -33,3 +33,6 @@ popd
 # Run native tests
 python ../build/run_cpp_tests.py
 popd
+
+# Maybe upload a release
+python build/upload_release.py

--- a/build/upload_release.py
+++ b/build/upload_release.py
@@ -1,0 +1,91 @@
+#
+# Uber, Inc. (c) 2019
+#
+
+import glob
+import os
+import platform
+import subprocess
+import sys
+import requests
+
+# The `or` pattern below handles empty strings and unset env variables
+# Using a default value only handles unset env variables
+# TODO(vip): Don't duplicate this between install_frameworks.py and upload_release.py
+REQUESTED_TF_VERSION = os.getenv("NEUROPODS_TENSORFLOW_VERSION") or "1.12.0"
+REQUESTED_TORCH_VERSION = os.getenv("NEUROPODS_TORCH_VERSION") or "1.1.0"
+IS_GPU = (os.getenv("NEUROPODS_IS_GPU") or None) is not None
+CUDA_VERSION = os.getenv("NEUROPODS_CUDA_VERSION") or "10.0"
+IS_MAC = platform.system() == "Darwin"
+
+GIT_TAG = os.getenv("TRAVIS_TAG", os.getenv("BUILDKITE_TAG"))
+PYTHON_VERSION = "{}{}".format(sys.version_info.major, sys.version_info.minor)
+GH_UPLOAD_TOKEN = os.getenv("GH_UPLOAD_TOKEN")
+
+def upload():
+    release_id = get_release_id(GIT_TAG)
+    platform = "libneuropods-{gpustring}-{os}-{tag}".format(
+        gpustring="gpu-cuda-{}".format(CUDA_VERSION) if IS_GPU else "cpu",
+        os="macos" if IS_MAC else "linux",
+        tag=GIT_TAG,
+    )
+
+    # Only upload the main library on one build (because we don't need to upload once per backend version)
+    if PYTHON_VERSION == "27" and REQUESTED_TF_VERSION == "1.12.0":
+        upload_package("source/bazel-bin/neuropods/libneuropods.tar.gz", release_id, "{}.tar.gz".format(platform))
+
+    # Only upload these on the python 2.7 jobs (because we don't need to upload them twice)
+    if PYTHON_VERSION == "27":
+        upload_package("source/bazel-bin/neuropods/backends/tensorflow/neuropod_tensorflow_backend.tar.gz", release_id, "{}-tensorflow-{}-backend.tar.gz".format(platform, REQUESTED_TF_VERSION))
+        upload_package("source/bazel-bin/neuropods/backends/torchscript/neuropod_torchscript_backend.tar.gz", release_id, "{}-torchscript-{}-backend.tar.gz".format(platform, REQUESTED_TORCH_VERSION))
+
+    # Only upload the python backend for one build per platform
+    if REQUESTED_TF_VERSION == "1.12.0":
+        # Upload the pythonbridge backend
+        upload_package("source/bazel-bin/neuropods/backends/python_bridge/neuropod_pythonbridge_backend.tar.gz", release_id, "{}-python-{}-backend.tar.gz".format(platform, PYTHON_VERSION))
+
+    # The python package is the same across platforms so we'll only upload for one platform
+    if REQUESTED_TF_VERSION == "1.12.0" and not IS_GPU and not IS_MAC:
+        # Upload the wheel
+        whl_path = glob.glob('source/python/dist/*.whl')[0]
+        fname = os.path.basename(whl_path)
+        upload_package(whl_path, release_id, fname, content_type="application/zip")
+
+def get_release_id(tag_name):
+    # https://api.github.com/repos/uber/neuropods/releases/tags/{tag_name}
+    release_id = requests.get(
+        'https://api.github.com/repos/uber/neuropods/releases/tags/{}'.format(tag_name),
+        headers={"Authorization": "token {}".format(GH_UPLOAD_TOKEN)},
+    ).json()["id"]
+    print("Release ID: {}".format(release_id))
+    return release_id
+
+def upload_package(local_path, release_id, asset_filename, content_type="application/gzip"):
+    # POST https://uploads.github.com/repos/uber/neuropods/releases/{release_id}/assets?name={asset_filename}
+    print("Uploading {}...".format(asset_filename))
+    with open(local_path, 'rb') as f:
+        r = requests.post(
+            "https://uploads.github.com/repos/uber/neuropods/releases/{}/assets?name={}".format(release_id, asset_filename),
+            headers={
+                "Authorization": "token {}".format(GH_UPLOAD_TOKEN),
+                "Content-Type": content_type,
+            },
+            data=f
+        )
+
+        if r.status_code != 201:
+            print("Error uploading", r.json())
+            raise ValueError("Error uploading {}. Got message: {}".format(asset_filename, r.json()["message"]))
+
+
+if __name__ == '__main__':
+    if not GIT_TAG or not GH_UPLOAD_TOKEN:
+        # Don't upload if we don't have a tag or token
+        pass
+    elif os.getenv("TRAVIS_TAG") is not None and not IS_MAC:
+        # Don't push releases from linux on Travis
+        # (buildkite pushes all the linux releases)
+        pass
+    else:
+        print("Uploading packages...")
+        upload()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,8 @@ services:
       context: .
       dockerfile: build/neuropods.dockerfile
       target: neuropod-build
+      args:
+        NEUROPODS_DO_PACKAGE: "true"
     privileged: true
 
   test-gpu:

--- a/source/neuropods/BUILD
+++ b/source/neuropods/BUILD
@@ -23,6 +23,7 @@ cc_binary(
     name = "libneuropods.so",
     linkshared = True,
     linkstatic = True,
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
     srcs = [
         "neuropods.cc",
     ],
@@ -56,11 +57,7 @@ pkg_tar(
     name = "libneuropods_libs",
     package_dir = "lib/",
     srcs = [
-        # Libs
         ":libneuropods.so",
-        "//neuropods/backends/python_bridge:libneuropod_pythonbridge_backend.so",
-        "//neuropods/backends/torchscript:libneuropod_torchscript_backend.so",
-        "//neuropods/backends/tensorflow:libneuropod_tensorflow_backend.so",
     ]
 )
 
@@ -71,4 +68,14 @@ pkg_tar(
         ":libneuropods_hdrs",
         ":libneuropods_libs",
     ]
+)
+
+filegroup(
+    name = "packages",
+    tags = ["manual"],
+    srcs = [
+        "//neuropods/backends/python_bridge:neuropod_pythonbridge_backend",
+        "//neuropods/backends/torchscript:neuropod_torchscript_backend",
+        "//neuropods/backends/tensorflow:neuropod_tensorflow_backend",
+    ],
 )

--- a/source/neuropods/backends/python_bridge/BUILD
+++ b/source/neuropods/backends/python_bridge/BUILD
@@ -2,6 +2,8 @@
 # Uber, Inc. (c) 2018
 #
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
 cc_binary(
     name = "libneuropod_pythonbridge_backend.so",
     srcs = [
@@ -12,7 +14,7 @@ cc_binary(
     linkshared = True,
     linkstatic = True,
     linkopts = [
-        "-Wl,-rpath .",
+        "-Wl,-rpath,$$ORIGIN",
         "-ldl",
     ],
     visibility = [
@@ -23,5 +25,17 @@ cc_binary(
         "//neuropods/backends/test_backend:test_backend_hdrs",
         "//neuropods/bindings:bindings",
         "//neuropods/internal:deleter",
+    ],
+)
+
+pkg_tar(
+    name = "neuropod_pythonbridge_backend",
+    srcs = [
+        ":libneuropod_pythonbridge_backend.so",
+    ],
+    tags = ["manual"],
+    extension = "tar.gz",
+    visibility = [
+        "//visibility:public",
     ],
 )

--- a/source/neuropods/backends/tensorflow/BUILD
+++ b/source/neuropods/backends/tensorflow/BUILD
@@ -2,6 +2,7 @@
 # Uber, Inc. (c) 2018
 #
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//bazel:copy_libs.bzl", "copy_libs")
 
 cc_binary(
@@ -35,4 +36,17 @@ cc_binary(
 copy_libs(
     name = "copy_libtensorflow",
     libs = "@tensorflow_repo//:libtensorflow_libs"
+)
+
+pkg_tar(
+    name = "neuropod_tensorflow_backend",
+    srcs = [
+        ":libneuropod_tensorflow_backend.so",
+        "@tensorflow_repo//:libtensorflow_libs",
+    ],
+    tags = ["manual"],
+    extension = "tar.gz",
+    visibility = [
+        "//visibility:public",
+    ],
 )

--- a/source/neuropods/backends/torchscript/BUILD
+++ b/source/neuropods/backends/torchscript/BUILD
@@ -2,6 +2,7 @@
 # Uber, Inc. (c) 2018
 #
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//bazel:copy_libs.bzl", "copy_libs")
 
 cc_binary(
@@ -35,4 +36,17 @@ cc_binary(
 copy_libs(
     name = "copy_libtorch",
     libs = "@libtorch_repo//:libtorch_libs"
+)
+
+pkg_tar(
+    name = "neuropod_torchscript_backend",
+    srcs = [
+        ":libneuropod_torchscript_backend.so",
+        "@libtorch_repo//:libtorch_libs",
+    ],
+    tags = ["manual"],
+    extension = "tar.gz",
+    visibility = [
+        "//visibility:public",
+    ],
 )

--- a/source/neuropods/multiprocess/BUILD
+++ b/source/neuropods/multiprocess/BUILD
@@ -82,6 +82,7 @@ cc_binary(
         "//neuropods:libneuropods.so",
     ],
     linkstatic = True,
+    linkopts = ["-Wl,-rpath,$$ORIGIN"],
     visibility = [
         "//neuropods:__subpackages__",
     ],


### PR DESCRIPTION
This PR causes CI builds for GitHub releases to automatically build and attach assets to the release.

It uses secrets set in Buildkite and Travis config in order to upload the assets once the build and tests are complete.

![image](https://user-images.githubusercontent.com/1181904/65087756-be5ced80-d96b-11e9-9d35-45592d6ae6f9.png)
