### PR TITLE
Bump Neuropod version to 0.1.0

### DIFF
--- a/source/neuropods/BUILD
+++ b/source/neuropods/BUILD
@@ -8,6 +8,7 @@ cc_library(
     name = "neuropods_hdrs",
     hdrs = [
         "neuropods.hh",
+        "version.hh",
     ],
     visibility = [
         "//visibility:public",
@@ -44,6 +45,7 @@ pkg_tar(
     srcs = [
         # Headers
         ":neuropods.hh",
+        ":version.hh",
     ],
     deps = [
         "//neuropods/internal:libneuropods_internal_hdrs",

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "neuropods/version.hh"
 #include "neuropods/backends/neuropod_backend.hh"
 #include "neuropods/internal/config_utils.hh"
 

--- a/source/neuropods/version.hh
+++ b/source/neuropods/version.hh
@@ -1,0 +1,19 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#pragma once
+
+namespace neuropods
+{
+
+constexpr int MAJOR_VERSION = 0;
+constexpr int MINOR_VERSION = 1;
+constexpr int PATCH_VERSION = 0;
+
+static_assert(MINOR_VERSION < 100, "The minor version must be less than 100");
+static_assert(PATCH_VERSION < 100, "The patch version must be less than 100");
+
+constexpr int VERSION = (MAJOR_VERSION * 100 + MINOR_VERSION) * 100 + PATCH_VERSION;
+
+} // namespace neuropods

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -9,7 +9,7 @@ REQUIRED_PACKAGES = [
 
 setup(
     name="neuropods",
-    version="0.0.1",
+    version="0.1.0",
     install_requires=REQUIRED_PACKAGES,
     packages=find_packages(),
 )


### PR DESCRIPTION
We'll start publishing a few release candidates over the next few weeks and then publish an official `v0.1.0` release