### PR TITLE
Pin Bazel to v0.28.1 on Linux

### DIFF
--- a/build/install_system_deps.sh
+++ b/build/install_system_deps.sh
@@ -18,20 +18,19 @@ if [[ $(uname -s) == 'Darwin' ]]; then
     export HOMEBREW_NO_AUTO_UPDATE=1
     brew install libomp
 else
-    # Install pip and bazel dependencies
-    sudo apt-get update
-    sudo apt-get install -y openjdk-8-jdk curl wget
-
-    # Add bazel sources
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-    curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-
-    # Install bazel and python dev
-    sudo apt-get update
-    sudo apt-get install -y bazel ${NEUROPODS_PYTHON_BINARY}-dev ${NEUROPODS_PYTHON_BINARY}-pip
-
+    # Install bazel deps, pip, and python dev
     # Install g++-4.8 for TensorFlow custom op builds
-    sudo apt-get install -y g++-4.8
+    sudo apt-get update
+    sudo apt-get install -y pkg-config zip g++ zlib1g-dev unzip python3 curl wget ${NEUROPODS_PYTHON_BINARY}-dev ${NEUROPODS_PYTHON_BINARY}-pip g++-4.8
+
+    # Install bazel
+    tmpdir=$(mktemp -d)
+    pushd $tmpdir
+    curl -sSL -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-installer-linux-x86_64.sh
+    chmod +x ./bazel.sh
+    sudo ./bazel.sh
+    popd
+    rm -rf $tmpdir
 fi
 
 # Run a bazel command to extract the bazel installation


### PR DESCRIPTION
Bazel v1.0.0 was [released](https://github.com/bazelbuild/bazel/releases/tag/1.0.0) earlier today and it breaks the Linux build.

We previously pinned Bazel to v0.28.1 on Mac (#140). This PR does the same on Linux.
