### PR TITLE
Add some more checks to the TF packaging code

### DIFF
--- a/source/neuropods/backends/tensorflow/tf_backend.cc
+++ b/source/neuropods/backends/tensorflow/tf_backend.cc
@@ -66,7 +66,8 @@ void setup_node_mapping_and_init_ops(std::istream &                             
     }
 }
 
-// Get a graph node given a node name of the format `name:index`. Namespaces are supported as well
+// Get a graph node given a node name of the format `name:index`. Namespaces are supported as well.
+// If the index is 0, ":0" optional.
 // Ex: `some_namespace/input:0`
 TF_Output get_graph_node_from_name(const std::string &node_name_with_index, const TF_GraphPtr &graph_)
 {
@@ -75,7 +76,11 @@ TF_Output get_graph_node_from_name(const std::string &node_name_with_index, cons
     const auto node_name = node_name_with_index.substr(0, colon_pos);
 
     // The index of the output for the specified op
-    const auto node_index = node_name_with_index.substr(colon_pos + 1);
+    int node_index = 0;
+    if (colon_pos != std::string::npos)
+    {
+        node_index = std::stoi(node_name_with_index.substr(colon_pos + 1));
+    }
 
     TF_Operation *oper = TF_GraphOperationByName(graph_.get(), node_name.c_str());
     if (!oper)
@@ -84,7 +89,7 @@ TF_Output get_graph_node_from_name(const std::string &node_name_with_index, cons
     }
     // TensorFlow uses TF_Output everywhere, including input placeholders
     // Operations can have several outputs, they are indexed started from 0
-    return TF_Output{oper, std::stoi(node_index)};
+    return TF_Output{oper, node_index};
 }
 
 } // namespace

--- a/source/neuropods/python/backends/tensorflow/executor.py
+++ b/source/neuropods/python/backends/tensorflow/executor.py
@@ -40,6 +40,12 @@ class TensorflowNeuropodExecutor(NeuropodExecutor):
 
             # Get the node name mapping and store it
             self.node_name_mapping = model_config["node_name_mapping"]
+
+            # Make sure every node in the mapping ends with `:index`
+            for k, v in self.node_name_mapping.items():
+                if ":" not in v:
+                    self.node_name_mapping[k] = v + ":0"
+
             init_op_names = model_config["init_op_names"]
 
         # Setup the graph from the definition

--- a/source/neuropods/python/tests/test_keras_packaging.py
+++ b/source/neuropods/python/tests/test_keras_packaging.py
@@ -28,9 +28,8 @@ def create_keras_addition_model(node_name_mapping=None):
 
     x = Input(batch_shape=(None,), name=node_name_mapping['x'])
     y = Input(batch_shape=(None,), name=node_name_mapping['y'])
-    optional = Input(batch_shape=(None,), name=node_name_mapping['optional'], dtype=tf.string)
     out = Add(name=node_name_mapping['out'])([x, y])
-    model = Model(inputs=[x, y, optional], outputs=[out])
+    model = Model(inputs=[x, y], outputs=[out])
     return model
 
 
@@ -40,7 +39,7 @@ class TestKerasPackaging(unittest.TestCase):
             neuropod_path = os.path.join(test_dir, "test_neuropod")
 
             if alias_names:
-                node_name_mapping = {'x': 'x_', 'y': 'y_', 'optional': 'optional_', 'out': 'out_'}
+                node_name_mapping = {'x': 'x_', 'y': 'y_', 'out': 'out_'}
             else:
                 node_name_mapping = None
 

--- a/source/neuropods/python/tests/test_tensorflow_packaging.py
+++ b/source/neuropods/python/tests/test_tensorflow_packaging.py
@@ -61,7 +61,9 @@ class TestTensorflowPackaging(unittest.TestCase):
                 node_name_mapping={
                     "x": "some_namespace/in_x:0",
                     "y": "some_namespace/in_y:0",
-                    "out": "some_namespace/out:0",
+
+                    # The `:0` is optional
+                    "out": "some_namespace/out",
                 },
                 # Get the input/output spec along with test data
                 **get_addition_model_spec(do_fail=do_fail)

--- a/source/neuropods/python/tests/utils.py
+++ b/source/neuropods/python/tests/utils.py
@@ -18,7 +18,6 @@ def get_addition_model_spec(do_fail=False):
         input_spec=[
             {"name": "x", "dtype": "float32", "shape": ("batch_size",)},
             {"name": "y", "dtype": "float32", "shape": ("batch_size",)},
-            {"name": "optional", "dtype": "string", "shape": ("batch_size",)},
         ],
         output_spec=[
             {"name": "out", "dtype": "float32", "shape": ("batch_size",)},


### PR DESCRIPTION
This PR does the following:
- Makes `:0` optional at the end of node names in `node_name_mapping`
- Ensures that every item in the `input_spec` and `output_spec` has a corresponding item in `node_name_mapping`