### PR TITLE
[OPE] Add device support and python bindings

### DIFF
--- a/source/neuropod/bindings/BUILD
+++ b/source/neuropod/bindings/BUILD
@@ -10,6 +10,7 @@ cc_binary(
     ],
     deps = [
         ":bindings",
+        "//neuropod/multiprocess:multiprocess_hdrs",
         "//neuropod/serialization:serialization_hdrs",
         "//neuropod/backends/test_backend:test_backend_hdrs",
     ],

--- a/source/neuropod/multiprocess/multiprocess.hh
+++ b/source/neuropod/multiprocess/multiprocess.hh
@@ -17,8 +17,9 @@ namespace neuropod
 //
 // This function starts a new worker process and loads a neuropod in it.
 // The below function loads a neuropod in an existing worker process.
-std::unique_ptr<Neuropod> load_neuropod_in_new_process(const std::string &neuropod_path,
-                                                       bool               free_memory_every_cycle = true);
+std::unique_ptr<Neuropod> load_neuropod_in_new_process(const std::string &   neuropod_path,
+                                                       const RuntimeOptions &options                 = {},
+                                                       bool                  free_memory_every_cycle = true);
 
 // Run the neuropod in an existing worker
 // (using shared memory to communicate between the processes)

--- a/source/neuropod/python/utils/eval_utils.py
+++ b/source/neuropod/python/utils/eval_utils.py
@@ -53,7 +53,7 @@ def print_output_summary(out):
 
 
 def load_and_test_native(
-    neuropod_path, test_input_data, test_expected_out=None, **kwargs
+    neuropod_path, test_input_data, test_expected_out=None, neuropod_load_args={}
 ):
     """
     Loads a neuropod using the python bindings and runs inference.
@@ -65,9 +65,11 @@ def load_and_test_native(
     # Converts unicode to ascii for Python 3
     test_input_data = maybe_convert_bindings_types(test_input_data)
 
-    out = eval_in_new_process(
-        neuropod_path, test_input_data, extra_args=["--use-native"], **kwargs
-    )
+    from neuropod_native import load_neuropod_in_new_process
+
+    # Load the model using native out-of-process execution
+    model = load_neuropod_in_new_process(neuropod_path, **neuropod_load_args)
+    out = model.infer(test_input_data)
 
     # Check the output
     if test_expected_out is not None:


### PR DESCRIPTION
This PR adds the ability to set a device when using out-of-process execution. It does this by setting `CUDA_VISIBLE_DEVICES` when launching the worker process.

We also add python bindings for OPE and use them in the tests. This means that the device selection tests run against OPE and ensure that it is correctly setting devices.