### PR TITLE
Remove slow data access methods from NeuropodTensor

### DIFF
--- a/source/neuropods/internal/neuropod_tensor.hh
+++ b/source/neuropods/internal/neuropod_tensor.hh
@@ -175,7 +175,7 @@ public:
         {
             NEUROPOD_ERROR("Tensor is expected to have shape of {1} to be casted to a scalar.");
         }
-        return (*this->template as_typed_tensor<T>())[0];
+        return this->template as_typed_tensor<T>()->template accessor<1>()[0];
     }
 
     template <typename T>
@@ -188,7 +188,7 @@ public:
         {
             NEUROPOD_ERROR("Tensor is expected to have shape of {1} to be casted to a scalar.");
         }
-        return (*this->template as_typed_tensor<T>())[0];
+        return this->template as_typed_tensor<T>()->template accessor<1>()[0];
     }
 
     template <typename Visitor, typename... Params>
@@ -291,17 +291,6 @@ public:
         this->assure_rank(N);
         return TensorAccessor<const T, N>(get_raw_data_ptr(), get_strides().data());
     }
-
-    const T &operator[](uint32_t r) const { return (*this)(r); }
-    T &      operator[](uint32_t r) { return (*this)(r); }
-
-    const T &operator()(uint32_t r) const { return accessor<1>()[r]; }
-
-    T &operator()(uint32_t r) { return accessor<1>()[r]; }
-
-    const T &operator()(uint32_t r, uint32_t c) const { return accessor<2>()[r][c]; }
-
-    T &operator()(uint32_t r, uint32_t c) { return accessor<2>()[r][c]; }
 
     const T *begin() const
     {

--- a/source/neuropods/tests/test_conversions_eigen.cc
+++ b/source/neuropods/tests/test_conversions_eigen.cc
@@ -20,9 +20,10 @@ public:
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
         const_tensor = tensor;
 
+        auto accessor = tensor->accessor<1>();
         for (size_t i = 0; i < ROWS; ++i)
         {
-            (*tensor)[i]       = i;
+            accessor[i]        = i;
             expected_vector[i] = i;
         }
     }
@@ -48,12 +49,13 @@ public:
         tensor       = untyped_tensor->as_typed_tensor<int32_t>();
         const_tensor = tensor;
 
+        auto accessor = tensor->accessor<2>();
         int i = 0;
         for (size_t row = 0; row < untyped_tensor->get_dims()[0]; ++row)
         {
             for (size_t col = 0; col < untyped_tensor->get_dims()[1]; ++col)
             {
-                (*tensor)(row, col)       = i;
+                accessor[row][col]        = i;
                 expected_matrix(row, col) = i;
                 ++i;
             }
@@ -83,7 +85,7 @@ TEST_F(int32_tensor_fixture, typed_vector_as_eigen)
     EXPECT_EQ(actual, expected_vector);
     // Make sure we are using the same underlying buffer and the neuropod tensor data is editable
     actual(0) = 42;
-    EXPECT_EQ((*tensor)[0], 42);
+    EXPECT_EQ(tensor->accessor<1>()[0], 42);
 }
 
 TEST_F(int32_tensor_fixture, untyped_vector_as_eigen_type_mismatch)
@@ -101,7 +103,7 @@ TEST_F(int32_tensor_fixture, const_typed_vector_as_eigen)
 {
     const auto actual = neuropods::as_eigen(*const_tensor);
     EXPECT_EQ(actual, expected_vector);
-    (*tensor)[0] = 42;
+    tensor->accessor<1>()[0] = 42;
     EXPECT_EQ(actual(0), 42);
 }
 

--- a/source/neuropods/tests/test_internal_neuropod_tensor.cc
+++ b/source/neuropods/tests/test_internal_neuropod_tensor.cc
@@ -22,9 +22,10 @@ public:
         tensor       = untyped_tensor->as_typed_tensor<uint8_t>();
         const_tensor = tensor;
 
+        auto accessor = tensor->accessor<1>();
         for (size_t i = 0; i < EXPECTED_SIZE; ++i)
         {
-            (*tensor)[i] = i;
+            accessor[i] = i;
         }
     }
 
@@ -75,10 +76,11 @@ TEST(test_stream_operator, typed_tensor)
     auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({3}, neuropods::UINT8_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<uint8_t>();
+    auto accessor = typed_tensor.accessor<1>();
 
-    typed_tensor[0] = 10;
-    typed_tensor[1] = 11;
-    typed_tensor[2] = 12;
+    accessor[0] = 10;
+    accessor[1] = 11;
+    accessor[2] = 12;
 
     ss << typed_tensor;
     EXPECT_THAT(ss.str(), HasSubstr("NeuropodTensor"));
@@ -93,10 +95,11 @@ TEST(test_stream_operator, typed_float_tensor)
     auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<float>();
+    auto accessor = typed_tensor.accessor<1>();
 
     for (int i = 0; i < TENSOR_SIZE; ++i)
     {
-        typed_tensor[i] = i + 0.5;
+        accessor[i] = i + 0.5;
     }
 
     ss << typed_tensor;


### PR DESCRIPTION
Remove slow data access methods from NeuropodTensor to prevent accidental usage.

Users should call `accessor()` directly