### PR TITLE
Remove apply_visitor from NeuropodTensor

### DIFF
--- a/source/neuropods/BUILD
+++ b/source/neuropods/BUILD
@@ -35,6 +35,7 @@ cc_binary(
         ":neuropods_hdrs",
         "//neuropods/internal:backend_registration_impl",
         "//neuropods/internal:neuropod_loader_impl",
+        "//neuropods/internal:neuropod_tensor_raw_data_access_impl",
         "//neuropods/internal:tensor_serialization_impl",
         "//neuropods/multiprocess:multiprocess_impl",
         "//neuropods/serialization:serialization_impl",

--- a/source/neuropods/bindings/BUILD
+++ b/source/neuropods/bindings/BUILD
@@ -29,6 +29,7 @@ cc_library(
     ],
     deps = [
         "//neuropods/internal:neuropod_tensor",
+        "//neuropods/internal:neuropod_tensor_raw_data_access",
         "//neuropods:neuropods_hdrs",
         "@pybind11_repo//:pybind11",
     ],

--- a/source/neuropods/internal/BUILD
+++ b/source/neuropods/internal/BUILD
@@ -76,6 +76,7 @@ cc_library(
         "//neuropods:__subpackages__",
     ],
     deps = [
+        ":neuropod_tensor_raw_data_access",
         "@boost_repo//:boost",
         "//neuropods/backends:neuropod_backend",
         "//neuropods/serialization:serialization_hdrs",
@@ -161,6 +162,30 @@ cc_library(
         "//neuropods:__subpackages__",
     ],
     linkopts = ["-lz"],
+)
+
+cc_library(
+    name = "neuropod_tensor_raw_data_access",
+    hdrs = [
+        "neuropod_tensor_raw_data_access.hh",
+    ],
+    visibility = [
+        "//neuropods:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "neuropod_tensor_raw_data_access_impl",
+    srcs = [
+        "neuropod_tensor_raw_data_access.cc",
+    ],
+    deps = [
+        ":neuropod_tensor",
+        ":neuropod_tensor_raw_data_access",
+    ],
+    visibility = [
+        "//neuropods:__subpackages__",
+    ],
 )
 
 # Package all the header files

--- a/source/neuropods/internal/neuropod_tensor_raw_data_access.cc
+++ b/source/neuropods/internal/neuropod_tensor_raw_data_access.cc
@@ -1,0 +1,27 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#include "neuropods/internal/neuropod_tensor_raw_data_access.hh"
+
+#include "neuropods/internal/neuropod_tensor.hh"
+
+namespace neuropods
+{
+
+void * NeuropodTensorRawDataAccess::get_untyped_data_ptr(NeuropodTensor &tensor)
+{
+    return tensor.get_untyped_data_ptr();
+}
+
+const void * NeuropodTensorRawDataAccess::get_untyped_data_ptr(const NeuropodTensor &tensor)
+{
+    return tensor.get_untyped_data_ptr();
+}
+
+size_t NeuropodTensorRawDataAccess::get_bytes_per_element(const NeuropodTensor &tensor)
+{
+    return tensor.get_bytes_per_element();
+}
+
+} // namespace neuropods

--- a/source/neuropods/internal/neuropod_tensor_raw_data_access.hh
+++ b/source/neuropods/internal/neuropod_tensor_raw_data_access.hh
@@ -1,0 +1,27 @@
+//
+// Uber, Inc. (c) 2019
+//
+
+#pragma once
+
+#include <cstdlib>
+
+namespace neuropods
+{
+
+class NeuropodTensor;
+
+// This struct is used internally within the library to access raw untyped data
+// from a NeuropodTensor
+//
+// This should NOT be used externally
+struct NeuropodTensorRawDataAccess
+{
+    static void * get_untyped_data_ptr(NeuropodTensor &tensor);
+
+    static const void * get_untyped_data_ptr(const NeuropodTensor &tensor);
+
+    static size_t get_bytes_per_element(const NeuropodTensor &tensor);
+};
+
+} // namespace neuropods

--- a/source/neuropods/internal/neuropod_tensor_serialization.cc
+++ b/source/neuropods/internal/neuropod_tensor_serialization.cc
@@ -4,6 +4,7 @@
 
 #include "neuropods/backends/tensor_allocator.hh"
 #include "neuropods/internal/neuropod_tensor.hh"
+#include "neuropods/internal/neuropod_tensor_raw_data_access.hh"
 #include "neuropods/serialization/serialization.hh"
 
 #include <boost/serialization/array.hpp>
@@ -15,45 +16,24 @@ namespace neuropods
 namespace
 {
 
-struct serialize_visitor : public NeuropodTensorVisitor<void>
-{
-    template <typename T, class Archive>
-    void operator()(const TypedNeuropodTensor<T> *tensor, Archive &ar) const
-    {
-        ar &boost::serialization::make_array(tensor->get_raw_data_ptr(), tensor->get_num_elements());
-    }
-
-    template <class Archive>
-    void operator()(const TypedNeuropodTensor<std::string> *tensor, Archive &ar) const
-    {
-        const auto data = tensor->get_data_as_vector();
-        ar &       data;
-    }
-};
-
-struct deserialize_visitor : public NeuropodTensorVisitor<void>
-{
-    template <typename T, class Archive>
-    void operator()(TypedNeuropodTensor<T> *tensor, Archive &ar) const
-    {
-        ar &boost::serialization::make_array(tensor->get_raw_data_ptr(), tensor->get_num_elements());
-    }
-
-    template <class Archive>
-    void operator()(TypedNeuropodTensor<std::string> *tensor, Archive &ar) const
-    {
-        std::vector<std::string> data;
-        ar &                     data;
-        tensor->set(data);
-    }
-};
-
 void serialize_tensor(const NeuropodTensor &tensor, boost::archive::binary_oarchive &ar)
 {
     int tensor_type = static_cast<int>(tensor.get_tensor_type());
     ar << tensor_type;
     ar << tensor.get_dims();
-    tensor.apply_visitor(serialize_visitor{}, ar);
+
+    if (tensor.get_tensor_type() == STRING_TENSOR)
+    {
+        const auto data = tensor.as_typed_tensor<std::string>()->get_data_as_vector();
+        ar << data;
+    }
+    else
+    {
+        ar << boost::serialization::make_array(
+            static_cast<const uint8_t *>(NeuropodTensorRawDataAccess::get_untyped_data_ptr(tensor)),
+            tensor.get_num_elements() * NeuropodTensorRawDataAccess::get_bytes_per_element(tensor)
+        );
+    }
 }
 
 std::shared_ptr<NeuropodTensor> deserialize_tensor(boost::archive::binary_iarchive &ar,
@@ -65,7 +45,20 @@ std::shared_ptr<NeuropodTensor> deserialize_tensor(boost::archive::binary_iarchi
     ar >> dims;
 
     auto out = allocator.allocate_tensor(dims, static_cast<TensorType>(type));
-    out->apply_visitor(deserialize_visitor{}, ar);
+    if (out->get_tensor_type() == STRING_TENSOR)
+    {
+        std::vector<std::string> data;
+        ar >> data;
+        out->as_typed_tensor<std::string>()->set(data);
+    }
+    else
+    {
+        ar >> boost::serialization::make_array(
+            static_cast<uint8_t *>(NeuropodTensorRawDataAccess::get_untyped_data_ptr(*out)),
+            out->get_num_elements() * NeuropodTensorRawDataAccess::get_bytes_per_element(*out)
+        );
+    }
+
     return out;
 }
 

--- a/source/neuropods/multiprocess/BUILD
+++ b/source/neuropods/multiprocess/BUILD
@@ -72,6 +72,7 @@ cc_library(
     deps = [
         ":ipc_control_channel",
         "//neuropods:neuropods_hdrs",
+        "//neuropods/internal:neuropod_tensor_raw_data_access",
     ],
 )
 


### PR DESCRIPTION
The main use case for `apply_visitor` was copying, wrapping, or serializing data from a `NeuropodTensor` without having to manually downcast to a `TypedNeuropodTensor` of every type.

The introduction of `get_untyped_data_ptr()` lets us do this in a cleaner way