### PR TITLE
Pin to a specific version of the docker-compose Buildkite plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.12.0-torch-1.1.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -22,7 +22,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.13.1-torch-1.2.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -34,7 +34,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7
           config: docker-compose.test.yml
           env:
@@ -46,7 +46,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.15.0-torch-1.3.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -58,7 +58,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.12.0-torch-1.1.0-py3
           config: docker-compose.test.yml
           env:
@@ -70,7 +70,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.13.1-torch-1.2.0-py3
           config: docker-compose.test.yml
           env:
@@ -82,7 +82,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3
           config: docker-compose.test.yml
           env:
@@ -94,7 +94,7 @@ steps:
       queue: private-default
     command: build/test.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-cpu-variant-tf-1.15.0-torch-1.3.0-py3
           config: docker-compose.test.yml
           env:
@@ -106,7 +106,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.12.0-torch-1.1.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -118,7 +118,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.13.1-torch-1.2.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -130,7 +130,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7
           config: docker-compose.test.yml
           env:
@@ -142,7 +142,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.15.0-torch-1.3.0-py2.7
           config: docker-compose.test.yml
           env:
@@ -154,7 +154,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.12.0-torch-1.1.0-py3
           config: docker-compose.test.yml
           env:
@@ -166,7 +166,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.13.1-torch-1.2.0-py3
           config: docker-compose.test.yml
           env:
@@ -178,7 +178,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3
           config: docker-compose.test.yml
           env:
@@ -190,7 +190,7 @@ steps:
       queue: private-gpu
     command: build/test_gpu.sh
     plugins:
-      - docker-compose:
+      - docker-compose#v3.1.0:
           run: test-gpu-variant-tf-1.15.0-torch-1.3.0-py3
           config: docker-compose.test.yml
           env:

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -133,7 +133,7 @@ for platform, py_version, framework_version in itertools.product(PLATFORMS, PY_V
         "      queue: private-{}\n".format("gpu" if is_gpu else "default"),
         "    command: build/{}.sh\n".format("test_gpu" if is_gpu else "test"),
         "    plugins:\n",
-        "      - docker-compose:\n",
+        "      - docker-compose#v3.1.0:\n",
         "          run: {}\n".format(variant_name),
         "          config: docker-compose.test.yml\n",
         "          env:\n",


### PR DESCRIPTION
Last night, a breaking change [landed](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/pull/210) in the `docker-compose` buildkite plugin repo. Since we didn't pin to a specific version of the plugin, this broke our CI pipelines

See also: https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/issues/241