### PR TITLE
Optimize the shared memory allocator

### DIFF
--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -132,12 +132,6 @@ public:
     // Run inference
     std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs)
     {
-        if (free_memory_every_cycle_)
-        {
-            // Clean up any unused shm tensors that haven't been reused
-            shm_allocator.free_unused_shm_blocks();
-        }
-
         // Add inputs
         control_channel_.send_message(ADD_INPUT, inputs);
 
@@ -190,6 +184,12 @@ public:
         // Let the worker know it no longer needs to keep references to the output
         // tensors
         control_channel_.send_message(INFER_COMPLETE);
+
+        if (free_memory_every_cycle_)
+        {
+            // Clean up any unused shm tensors that haven't been reused
+            shm_allocator.free_unused_shm_blocks();
+        }
 
         return to_return;
     }

--- a/source/neuropod/multiprocess/shm_allocator.hh
+++ b/source/neuropod/multiprocess/shm_allocator.hh
@@ -24,18 +24,24 @@ namespace neuropod
 //
 // To free all the currently unused blocks, call `free_unused_shm_blocks`. This should
 // periodically be called to ensure that unused shared memory is freed.
+
+// The allocator also employs a similar approach for loading blocks:
+// If we've loaded a block before, we're likely to load it again.
+//
+// Internally, we maintain a pool of blocks of memory we've loaded in the past.
+// If we are requested to load a block again, we don't need to redo all the work to open
+// the shared memory objects.
+//
+// To free all the currently unused blocks, call `free_unused_shm_blocks`. This should
+// periodically be called to ensure that unused shared memory is freed.
+
 // Note: the three functions below are all threadsafe
 
 // The block ID is just 24 opaque bytes (from the perspective of users of this allocator)
 using SHMBlockID = std::array<char, 24>;
 
-class UnusedPool;
 class SHMAllocator
 {
-private:
-    // Keeps track of unused blocks of shared memory so we can reuse them
-    std::unique_ptr<UnusedPool> unused_pool_;
-
 public:
     SHMAllocator();
     ~SHMAllocator();


### PR DESCRIPTION
Previously, we implemented an optimization based on the idea that "If we allocate a block of size N, we're likely to do so again."

This PR optimizes the shared memory allocator with another simple idea:

_If we've loaded a specific block of shared memory before, we're likely to load it again._

Both of these optimizations are supported by a new `SHMCachePool` which lets us share a lot of logic between the two.

This PR removes **over 60%** of our out-of-process overhead for the small inputs benchmark with no significant difference on the object detection benchmark. See below for details.

## Benchmarks:

These benchmarks were run in Docker on a laptop (restarting Docker between runs).

### Baseline

```
Running ./neuropods/tests/benchmark_multiprocess
Run on (12 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x12)
  L1 Instruction 32K (x12)
  L2 Unified 256K (x12)
  L3 Unified 12288K (x12)
Load Average: 0.94, 0.31, 0.11
***WARNING*** Library was built as DEBUG. Timings may be affected.
2019-11-03 11:40:47.383362: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations
------------------------------------------------------------------------------------------
benchmark_object_detection<load_in_process>         799825 ns       613920 ns         1105
2019-11-03 11:40:48.510205: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:40:50.504515: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:40:52.512179: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:40:54.532002: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
benchmark_object_detection<load_out_of_process>    1049887 ns       593978 ns         1036
benchmark_small_inputs<load_in_process>             406124 ns       293716 ns         2411
2019-11-03 11:40:58.031370: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:41:00.058136: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:41:02.082820: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:41:04.104024: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
benchmark_small_inputs<load_out_of_process>        1743788 ns       573006 ns         1217
```

### With this PR

```
Running ./neuropods/tests/benchmark_multiprocess
Run on (12 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x12)
  L1 Instruction 32K (x12)
  L2 Unified 256K (x12)
  L3 Unified 12288K (x12)
Load Average: 1.09, 0.35, 0.12
***WARNING*** Library was built as DEBUG. Timings may be affected.
2019-11-03 11:35:27.652798: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations
------------------------------------------------------------------------------------------
benchmark_object_detection<load_in_process>         773664 ns       575084 ns         1044
2019-11-03 11:35:28.718129: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:30.717402: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:32.729567: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:34.753360: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
benchmark_object_detection<load_out_of_process>    1046758 ns       584814 ns         1028
benchmark_small_inputs<load_in_process>             385712 ns       270756 ns         2513
2019-11-03 11:35:38.251537: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:40.276164: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:42.297464: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:44.322453: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
2019-11-03 11:35:46.346724: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
benchmark_small_inputs<load_out_of_process>         912365 ns       304543 ns         2317
```
