### PR TITLE
Remove unused test utilities

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -198,7 +198,6 @@ create_pytorch_neuropod(
     output_spec=addition_problem_definition.OUTPUT_SPEC,
     test_input_data=addition_problem_definition.TEST_INPUT_DATA,
     test_expected_out=addition_problem_definition.TEST_EXPECTED_OUT,
-    test_deps=['torch', 'numpy'],
 )
 ```
 

--- a/source/neuropods/python/backends/python/packager.py
+++ b/source/neuropods/python/backends/python/packager.py
@@ -16,7 +16,6 @@ def create_python_neuropod(
         code_path_spec,
         entrypoint_package,
         entrypoint,
-        skip_virtualenv=False,
         **kwargs):
     """
     Packages arbitrary python code as a neuropod package.

--- a/source/neuropods/python/tests/custom_ops/pytorch/test_pytorch_custom_ops.py
+++ b/source/neuropods/python/tests/custom_ops/pytorch/test_pytorch_custom_ops.py
@@ -70,12 +70,7 @@ class TestPytorchPackaging(unittest.TestCase):
             }],
             entrypoint_package="addition_model",
             entrypoint="get_model",
-            test_deps=['torch', 'numpy'],
             custom_ops=[custom_op_path],
-            # This runs the test in the current process instead of in a new virtualenv
-            # We are using this to ensure the test will work even if the CI environment
-            # is restrictive
-            skip_virtualenv=True,
             # Get the input/output spec along with test data
             **get_addition_model_spec(do_fail=do_fail)
         )

--- a/source/neuropods/python/tests/test_python_isolation.py
+++ b/source/neuropods/python/tests/test_python_isolation.py
@@ -50,11 +50,6 @@ class TestPythonIsolation(unittest.TestCase):
             }],
             entrypoint_package="dummy_model",
             entrypoint="get_model",
-            test_deps=['numpy'],
-            # This runs the test in the current process instead of in a new virtualenv
-            # We are using this to ensure the test will work even if the CI environment
-            # is restrictive
-            skip_virtualenv=True,
             input_spec=[{"name": "x", "dtype": "float32", "shape": (1,)}],
             output_spec=[{"name": "out", "dtype": "float32", "shape": (1,)}],
             test_input_data={"x": np.array([0.0], dtype=np.float32)},

--- a/source/neuropods/python/tests/test_pytorch_packaging.py
+++ b/source/neuropods/python/tests/test_pytorch_packaging.py
@@ -52,11 +52,6 @@ class TestPytorchPackaging(unittest.TestCase):
                 }],
                 entrypoint_package="addition_model",
                 entrypoint="get_model",
-                test_deps=['torch', 'numpy'],
-                # This runs the test in the current process instead of in a new virtualenv
-                # We are using this to ensure the test will work even if the CI environment
-                # is restrictive
-                skip_virtualenv=True,
                 # Get the input/output spec along with test data
                 **get_addition_model_spec(do_fail=do_fail)
             )

--- a/source/neuropods/python/tests/test_pytorch_strings.py
+++ b/source/neuropods/python/tests/test_pytorch_strings.py
@@ -49,11 +49,6 @@ def package_strings_model(out_dir, do_fail=False):
         }],
         entrypoint_package="strings_model",
         entrypoint="get_model",
-        test_deps=['torch', 'numpy'],
-        # This runs the test in the current process instead of in a new virtualenv
-        # We are using this to ensure the test will work even if the CI environment
-        # is restrictive
-        skip_virtualenv=True,
         # Get the input/output spec along with test data
         **get_string_concat_model_spec(do_fail=do_fail)
     )

--- a/source/neuropods/python/utils/env_utils.py
+++ b/source/neuropods/python/utils/env_utils.py
@@ -2,9 +2,6 @@
 # Uber, Inc. (c) 2018
 #
 
-"""
-Utilities for dealing with virtualenvs and pip
-"""
 from six.moves import cPickle as pickle
 import os
 import shutil
@@ -16,44 +13,6 @@ from testpath.tempdir import TemporaryDirectory
 
 import neuropods
 
-
-def create_virtualenv(venv_path, packages_to_install=[], verbose=False):
-    with open(os.devnull, 'w') as FNULL:
-        stdout = None if verbose else FNULL
-
-        # Create the virtualenv
-        retcode = subprocess.call(['/usr/bin/env', 'virtualenv', venv_path], env={}, stdout=stdout)
-        if retcode != 0:
-            raise ValueError("Error creating virtual environment for testing! Please make sure `virtualenv` is installed")
-
-        # Install the specified pip packages
-        for package in ['pip', 'six'] + packages_to_install:
-            subprocess.check_call([os.path.join(venv_path, 'bin', 'pip'), 'install', '-U', package], env={}, stdout=stdout)
-
-        # Copy the neuropods library into the virtualenv
-        # This dir is added to the pythonpath in `eval_in_virtualenv`
-        shutil.copytree(neuropods.__path__[0], os.path.join(venv_path, "neuropod_test_libs", "neuropods"))
-
-
-def eval_in_virtualenv(neuropod_path, input_data, venv_path, **kwargs):
-    """
-    Loads and runs a neuropod model in a separate process with specified input data.
-    It also does this in a virtualenv in order to make sure that the model was
-    packaged correctly and does not have any unspecified dependencies.
-
-    Raises a CalledProcessError if there was an error evaluating the neuropod
-
-    :param  neuropod_path   The path to the neuropod to load
-    :param  input_data      A pickleable dict containing sample input to the model
-    :param  venv_path       The path to a virtualenv to run the model in
-    """
-    return eval_in_new_process(
-        neuropod_path,
-        input_data,
-        os.path.join(venv_path, 'bin', 'python'),
-        env={"PYTHONPATH": os.path.join(venv_path, "neuropod_test_libs")},
-        **kwargs
-    )
 
 def eval_in_new_process(neuropod_path, input_data, binary_path=sys.executable, extra_args=[], neuropod_load_args={}, **kwargs):
     """
@@ -87,7 +46,3 @@ def eval_in_new_process(neuropod_path, input_data, binary_path=sys.executable, e
 
         with open(output_filepath, 'rb') as output_pkl:
             return pickle.load(output_pkl)
-
-
-if __name__ == '__main__':
-    create_virtualenv("/tmp/neuropod_test_venv", packages_to_install=['torch', 'torchvision'])


### PR DESCRIPTION
This PR removes code for creating and testing in a new virtualenv at packaging time. This was initially used to provide a little isolation when packaging pytorch models, but no longer adds significant value.

The defaults were false (and it wasn't publicly documented) so it should be safe to remove.