### PR TITLE
Add lint + static analyzers to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,30 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
+            - GH_UPLOAD_TOKEN
+
+  - label: ":docker: Lint"
+    agents:
+      queue: private-default
+    command: build/ci/buildkite_lint.sh
+    plugins:
+      - docker-compose#v3.1.0:
+          run: test-cpu-variant-tf-1.12.0-torch-1.1.0-py2.7
+          config: docker-compose.test.yml
+          env:
+            - BUILDKITE
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_COMMIT
+            - BUILDKITE_JOB_ID
+            - BUILDKITE_PROJECT_SLUG
+            - BUILDKITE_PULL_REQUEST
+            - BUILDKITE_TAG
+            - CI
+            - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.13.1-torch-1.2.0-py2.7)"
@@ -47,6 +71,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7)"
@@ -69,6 +94,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.15.0-torch-1.3.0-py2.7)"
@@ -91,6 +117,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.12.0-torch-1.1.0-py3)"
@@ -113,6 +140,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.13.1-torch-1.2.0-py3)"
@@ -135,6 +163,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3)"
@@ -157,6 +186,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: CPU Tests (test-cpu-variant-tf-1.15.0-torch-1.3.0-py3)"
@@ -179,6 +209,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.12.0-torch-1.1.0-py2.7)"
@@ -201,6 +232,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.13.1-torch-1.2.0-py2.7)"
@@ -223,6 +255,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py2.7)"
@@ -245,6 +278,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.15.0-torch-1.3.0-py2.7)"
@@ -267,6 +301,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.12.0-torch-1.1.0-py3)"
@@ -289,6 +324,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.13.1-torch-1.2.0-py3)"
@@ -311,6 +347,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.14.0-torch-1.3.0.dev20190820-py3)"
@@ -333,6 +370,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1.15.0-torch-1.3.0-py3)"
@@ -355,6 +393,7 @@ steps:
             - BUILDKITE_TAG
             - CI
             - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
 
 

--- a/build/ci/buildkite_lint.sh
+++ b/build/ci/buildkite_lint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install lint deps
+./build/ci/install_lint_deps.sh
+
+# Run lint
+./build/ci/lint.sh

--- a/build/ci/install_lint_deps.sh
+++ b/build/ci/install_lint_deps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# We need a newer version of libstdc++ for infer to run
+# We also need python3.6 for black to run
+apt-get install -y --no-install-recommends software-properties-common
+add-apt-repository -y ppa:ubuntu-toolchain-r/test
+add-apt-repository -y ppa:jonathonf/python-3.6
+apt-get update
+apt-get install -y --no-install-recommends libstdc++6 python3.6 tzdata jq
+
+# Install bazel-compdb
+INSTALL_DIR="/usr/local/bin"
+VERSION="0.4.2"
+(
+  cd "${INSTALL_DIR}" \
+  && curl -L "https://github.com/grailbio/bazel-compilation-database/archive/${VERSION}.tar.gz" | tar -xz \
+  && ln -f -s "${INSTALL_DIR}/bazel-compilation-database-${VERSION}/generate.sh" bazel-compdb
+)
+
+# Install infer
+VERSION=0.17.0; \
+curl -sSL "https://github.com/facebook/infer/releases/download/v$VERSION/infer-linux64-v$VERSION.tar.xz" \
+| sudo tar -C /opt -xJ && \
+ln -s "/opt/infer-linux64-v$VERSION/bin/infer" /usr/local/bin/infer
+
+# Get run-clang-format
+wget https://raw.githubusercontent.com/Sarcasm/run-clang-format/de6e8ca07d171a7f378d379ff252a00f2905e81d/run-clang-format.py
+
+# Install pip, black, and flake8
+wget https://bootstrap.pypa.io/get-pip.py
+python3.6 get-pip.py
+python3.6 -m pip install black flake8

--- a/build/ci/lint.sh
+++ b/build/ci/lint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+pushd source
+
+# Generate compile commands
+bazel-compdb
+
+# Filter compile commands
+jq '[.[] | select(.file | (contains(".so") or contains("external/") or contains(".hh")) | not)]' compile_commands.json > compile_commands.json2
+mv compile_commands.json2 compile_commands.json
+
+# Run infer
+python ../build/ci/set_status.py --context "lint/infer" --description "Infer Static Analysis" \
+    infer --fail-on-issue --compilation-database compile_commands.json
+
+# Run clang-tidy
+# ./bazel-source/external/llvm_toolchain/share/clang/run-clang-tidy.py -clang-tidy-binary ./bazel-source/external/llvm_toolchain/bin/clang-tidy
+
+# Run clang-format
+python ../build/ci/set_status.py --context "lint/clang-format" --description "Clang Format Checks" \
+    python ../run-clang-format.py --clang-format-executable bazel-source/external/llvm_toolchain/bin/clang-format -r .
+
+pushd python
+
+# Run black
+python ../../build/ci/set_status.py --context "lint/black" --description "Black Python Formatting Checks" \
+    black --check -t py27 -t py35 -t py36 --diff neuropods
+
+# Run flake8
+python ../../build/ci/set_status.py --context "lint/flake8" --description "flake8 Python Style Checks" \
+    flake8 neuropods
+
+popd
+popd

--- a/build/ci/set_status.py
+++ b/build/ci/set_status.py
@@ -1,0 +1,54 @@
+#
+# Uber, Inc. (c) 2019
+#
+
+import argparse
+import os
+import subprocess
+import requests
+
+GH_STATUS_TOKEN = os.getenv("GH_STATUS_TOKEN")
+GIT_COMMIT = os.getenv("TRAVIS_COMMIT", os.getenv("BUILDKITE_COMMIT"))
+
+def set_status(sha, status):
+    # https://api.github.com/repos/uber/neuropods/statuses/{sha}
+    status_id = requests.post(
+        'https://api.github.com/repos/uber/neuropods/statuses/{}'.format(sha),
+        headers = {"Authorization": "token {}".format(GH_STATUS_TOKEN)},
+        json = status
+    ).json()["id"]
+    print("Status ID: {}".format(status_id))
+
+if __name__ == '__main__':
+    # Make sure we have the information we need to continue
+    if not GIT_COMMIT:
+        raise ValueError("Could not get current commit")
+
+    if not GH_STATUS_TOKEN:
+        raise ValueError("Could not get GH token")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--context', help='The context of the github status', required=True)
+    parser.add_argument('--description', help='The description of the github status', required=True)
+    parser.add_argument('command', help='The command to run')
+    parser.add_argument('args', help='The args to the command to run', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    # The status to send to github
+    status = {
+        "state": "success",
+        "description": args.description,
+        "context": args.context,
+    }
+
+    # Try running the command
+    command = [args.command] + args.args
+    try:
+        print("Running command:", command)
+        subprocess.check_call(command)
+    except subprocess.CalledProcessError as e:
+        # The check failed
+        status["state"] = "failure"
+
+    print("Setting GH commit ({}) status: {}".format(GIT_COMMIT, status))
+    set_status(GIT_COMMIT, status)

--- a/source/.inferconfig
+++ b/source/.inferconfig
@@ -1,0 +1,3 @@
+{
+  "report-blacklist-files-containing":["NEUROPODS_CI_SKIP_INFER"]
+}

--- a/source/neuropods/bindings/python_bindings.cc
+++ b/source/neuropods/bindings/python_bindings.cc
@@ -121,6 +121,13 @@ py::array tensor_to_numpy(std::shared_ptr<NeuropodTensor> value)
 {
     auto tensor = value->as_tensor();
 
+    // This isn't going to be null, but we do a null check to keep
+    // static analyzers happy
+    if (tensor == nullptr)
+    {
+        NEUROPOD_ERROR("Error converting value to tensor");
+    }
+
     if (tensor->get_tensor_type() == STRING_TENSOR)
     {
         // This makes a copy

--- a/source/neuropods/tests/benchmark_accessor.cc
+++ b/source/neuropods/tests/benchmark_accessor.cc
@@ -2,6 +2,9 @@
 // Uber, Inc. (c) 2019
 //
 
+// Don't run infer on this file
+// NEUROPODS_CI_SKIP_INFER
+
 #include "benchmark/benchmark.h"
 #include "neuropods/backends/test_backend/test_neuropod_backend.hh"
 #include "neuropods/neuropods.hh"

--- a/source/neuropods/tests/benchmark_multiprocess.cc
+++ b/source/neuropods/tests/benchmark_multiprocess.cc
@@ -2,6 +2,9 @@
 // Uber, Inc. (c) 2019
 //
 
+// Don't run infer on this file
+// NEUROPODS_CI_SKIP_INFER
+
 #include "benchmark/benchmark.h"
 #include "neuropods/multiprocess/multiprocess.hh"
 #include "neuropods/neuropods.hh"

--- a/source/neuropods/tests/benchmark_shm_allocator.cc
+++ b/source/neuropods/tests/benchmark_shm_allocator.cc
@@ -2,6 +2,9 @@
 // Uber, Inc. (c) 2019
 //
 
+// Don't run infer on this file
+// NEUROPODS_CI_SKIP_INFER
+
 #include "benchmark/benchmark.h"
 #include "neuropods/multiprocess/shm_allocator.hh"
 

--- a/source/neuropods/tests/test_input_output.cc
+++ b/source/neuropods/tests/test_input_output.cc
@@ -35,6 +35,13 @@ void check_tensor_eq_ptr(const std::shared_ptr<neuropods::NeuropodTensor> &tenso
     // Downcast to a TypedNeuropodTensor so we can get the data pointer
     const auto typed_tensor = tensor->as_typed_tensor<T>();
 
+    // This isn't going to be null, but we do a null check to keep
+    // static analyzers happy
+    if (typed_tensor == nullptr)
+    {
+        NEUROPOD_ERROR("Error converting to typed tensor");
+    }
+
     // Get a pointer to the internal data
     const auto tensor_data_ptr = typed_tensor->get_raw_data_ptr();
 


### PR DESCRIPTION
This PR creates a CI build that runs linters and static analyzers (for both Python and C++).

It currently runs [infer](https://fbinfer.com/), [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [black](https://github.com/psf/black), and [flake8](http://flake8.pycqa.org/). clang-tidy will be added soon.

The return value of each of these tools is used to create a [GitHub commit status](https://developer.github.com/v3/repos/statuses/) that we can require to pass before landing.