### PR TITLE
Reformat python code with black and test with flake8

### DIFF
--- a/source/neuropods/python/backends/neuropod_executor.py
+++ b/source/neuropods/python/backends/neuropod_executor.py
@@ -10,19 +10,22 @@ import numpy as np
 from neuropods.backends import config_utils
 from neuropods.utils.dtype_utils import get_dtype
 
+
 def validate_tensors_against_specs(tensors, tensor_specs):
     # All instances of a symbol in a specification must
     # resolve to the same value at runtime. See below for more detail
     symbol_actual_map = {}
 
-    spec_tensor_names = {str(t['name']) for t in tensor_specs}
+    spec_tensor_names = {str(t["name"]) for t in tensor_specs}
     input_tensor_names = set(tensors.keys())
 
     unknown_tensor_names = input_tensor_names - spec_tensor_names
     if unknown_tensor_names:
         raise ValueError(
-            'Tensor name(s) \'{}\' are not found in the input spec'.format(
-                ', '.join(unknown_tensor_names)))
+            "Tensor name(s) '{}' are not found in the input spec".format(
+                ", ".join(unknown_tensor_names)
+            )
+        )
 
     # Iterate through all the tensor specs and validate
     # the matching tensor
@@ -42,14 +45,17 @@ def validate_tensors_against_specs(tensors, tensor_specs):
         if tensor.dtype.type != dtype.type:
             raise ValueError(
                 "Tensor '{}' is expected to be of type {}, but was of type {}".format(
-                    name, dtype, tensor.dtype))
+                    name, dtype, tensor.dtype
+                )
+            )
 
         # Validate the number of dimensions
         if len(tensor.shape) != len(shape):
             raise ValueError(
                 "Tensor '{}' is expected to have {} dimensions, but had {}".format(
-                    name, len(shape), len(
-                        tensor.shape)))
+                    name, len(shape), len(tensor.shape)
+                )
+            )
 
         # Validate the shape
         for i, (dim, expected) in enumerate(zip(tensor.shape, shape)):
@@ -61,7 +67,9 @@ def validate_tensors_against_specs(tensors, tensor_specs):
                 if dim != expected:
                     raise ValueError(
                         "Dim {} of tensor '{}' is expected to be of size {}, but was of size {}".format(
-                            i, name, expected, dim))
+                            i, name, expected, dim
+                        )
+                    )
             elif isinstance(expected, six.string_types):
                 # `expected` is a symbol
                 # Every instance of `expected` should have the same value
@@ -74,20 +82,20 @@ def validate_tensors_against_specs(tensors, tensor_specs):
                     # Make sure this usage matches the previous value
                     if dim != actual_value:
                         raise ValueError(
-                            ("All dims with expected value '{}' should be the same size. "
-                             "Dim {} of tensor '{}' was expected to be of size {}, but was of size {}").format(
-                                expected,
-                                i,
-                                name,
-                                actual_value,
-                                dim))
+                            (
+                                "All dims with expected value '{}' should be the same size. "
+                                "Dim {} of tensor '{}' was expected to be of size {}, but was of size {}"
+                            ).format(expected, i, name, actual_value, dim)
+                        )
                 else:
                     # This is the first time we're seeing this symbol
                     # Add it to the map so we can check future occurrences of this symbol
                     symbol_actual_map[expected] = dim
 
             else:
-                raise ValueError("Invalid value of item in expected shape: {}".format(expected))
+                raise ValueError(
+                    "Invalid value of item in expected shape: {}".format(expected)
+                )
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -101,7 +109,10 @@ class NeuropodExecutor(object):
         self.neuropod_config = config_utils.read_neuropod_config(neuropod_path)
 
         # Generate the tensor to device mapping
-        self.input_device_mapping = {tensor["name"] : self.neuropod_config["input_tensor_device"][tensor["name"]] for tensor in self.inputs}
+        self.input_device_mapping = {
+            tensor["name"]: self.neuropod_config["input_tensor_device"][tensor["name"]]
+            for tensor in self.inputs
+        }
 
     @property
     def inputs(self):

--- a/source/neuropods/python/backends/python/executor.py
+++ b/source/neuropods/python/backends/python/executor.py
@@ -22,7 +22,7 @@ open(os.path.join(SYMLINKS_DIR, "__init__.py"), "a").close()
 # Add it to our path if necessary
 sys.path.insert(0, SYMLINKS_DIR)
 
-# Make sure we clean up this directory at exit
+
 def cleanup_symlink():
     # Remove the symlinks (and __init__.py)
     for f in os.listdir(SYMLINKS_DIR):
@@ -31,7 +31,10 @@ def cleanup_symlink():
     # Delete the directory
     os.rmdir(SYMLINKS_DIR)
 
+
+# Make sure we clean up this directory at exit
 atexit.register(cleanup_symlink)
+
 
 class PythonNeuropodExecutor(NeuropodExecutor):
     """
@@ -74,9 +77,13 @@ class PythonNeuropodExecutor(NeuropodExecutor):
                     op_name = os.path.splitext(item)[0]
                     try:
                         importlib.import_module(op_name)
-                        raise ValueError(("Package `{}` is importable before loading the neuropod! "
-                                          "This means that a custom op in your neuropod package clashes with something already "
-                                          "accessible by python. Please check your PYTHONPATH and try again").format(op_name))
+                        raise ValueError(
+                            (
+                                "Package `{}` is importable before loading the neuropod! "
+                                "This means that a custom op in your neuropod package clashes with something already "
+                                "accessible by python. Please check your PYTHONPATH and try again"
+                            ).format(op_name)
+                        )
                     except ImportError:
                         pass
 
@@ -95,7 +102,9 @@ class PythonNeuropodExecutor(NeuropodExecutor):
             # See https://docs.python.org/3/library/importlib.html#importlib.import_module
             importlib.invalidate_caches()
 
-        entrypoint_package = importlib.import_module("{}.{}".format(rand_id, entrypoint_package_path))
+        entrypoint_package = importlib.import_module(
+            "{}.{}".format(rand_id, entrypoint_package_path)
+        )
 
         # Get the entrypoint function and run it with the data path
         self.model = entrypoint_package.__dict__[entrypoint_fn_name](data_path)
@@ -120,7 +129,8 @@ class PythonNeuropodExecutor(NeuropodExecutor):
             if not isinstance(value, np.ndarray):
                 raise RuntimeError(
                     "All outputs must be numpy arrays! Output `{}` was of type `{}`".format(
-                        key,
-                        type(value)))
+                        key, type(value)
+                    )
+                )
 
         return out

--- a/source/neuropods/python/backends/python/packager.py
+++ b/source/neuropods/python/backends/python/packager.py
@@ -11,12 +11,8 @@ from neuropods.utils.packaging_utils import packager
 
 @packager(platform="python")
 def create_python_neuropod(
-        neuropod_path,
-        data_paths,
-        code_path_spec,
-        entrypoint_package,
-        entrypoint,
-        **kwargs):
+    neuropod_path, data_paths, code_path_spec, entrypoint_package, entrypoint, **kwargs
+):
     """
     Packages arbitrary python code as a neuropod package.
 
@@ -82,20 +78,27 @@ def create_python_neuropod(
 
     # Copy the data to be packaged
     for data_path_spec in data_paths:
-        shutil.copyfile(data_path_spec["path"], os.path.join(neuropod_data_path, data_path_spec["packaged_name"]))
+        shutil.copyfile(
+            data_path_spec["path"],
+            os.path.join(neuropod_data_path, data_path_spec["packaged_name"]),
+        )
 
     # Copy the specified source code while preserving package paths
     for copy_spec in code_path_spec:
         python_root = copy_spec["python_root"]
 
-        if os.path.realpath(neuropod_path).startswith(os.path.realpath(python_root) + os.sep):
-            raise ValueError("`neuropod_path` cannot be a subdirectory of `python_root`")
+        if os.path.realpath(neuropod_path).startswith(
+            os.path.realpath(python_root) + os.sep
+        ):
+            raise ValueError(
+                "`neuropod_path` cannot be a subdirectory of `python_root`"
+            )
 
         for dir_to_package in copy_spec["dirs_to_package"]:
             shutil.copytree(
                 os.path.join(python_root, dir_to_package),
                 os.path.join(neuropod_code_path, dir_to_package),
-                ignore=shutil.ignore_patterns('*.pyc'),
+                ignore=shutil.ignore_patterns("*.pyc"),
             )
 
     # Add __init__.py files as needed
@@ -108,7 +111,7 @@ def create_python_neuropod(
     # We also need to save the entrypoint package name so we know what to load at runtime
     # This is python specific config so it's not saved in the overall neuropod config
     with open(os.path.join(neuropod_path, "0", "config.json"), "w") as config_file:
-        json.dump({
-            "entrypoint_package": entrypoint_package,
-            "entrypoint": entrypoint
-        }, config_file)
+        json.dump(
+            {"entrypoint_package": entrypoint_package, "entrypoint": entrypoint},
+            config_file,
+        )

--- a/source/neuropods/python/backends/tensorflow/executor.py
+++ b/source/neuropods/python/backends/tensorflow/executor.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 from neuropods.backends.neuropod_executor import NeuropodExecutor
 from neuropods.utils.dtype_utils import get_dtype
 
+
 class TensorflowNeuropodExecutor(NeuropodExecutor):
     """
     Executes a Tensorflow neuropod
@@ -30,7 +31,9 @@ class TensorflowNeuropodExecutor(NeuropodExecutor):
                 tf.load_op_library(str(os.path.join(neuropod_path, "0", "ops", op)))
 
         # Load the model
-        with tf.gfile.GFile(os.path.join(neuropod_path, "0", "data", "model.pb"), "rb") as f:
+        with tf.gfile.GFile(
+            os.path.join(neuropod_path, "0", "data", "model.pb"), "rb"
+        ) as f:
             graph_def = tf.GraphDef()
             graph_def.ParseFromString(f.read())
 
@@ -52,7 +55,9 @@ class TensorflowNeuropodExecutor(NeuropodExecutor):
         self.graph = tf.Graph()
         with self.graph.as_default():
             tf.import_graph_def(graph_def, name="")
-            init_ops = [self.graph.get_operation_by_name(op_name) for op_name in init_op_names]
+            init_ops = [
+                self.graph.get_operation_by_name(op_name) for op_name in init_op_names
+            ]
 
         # Create a session
         self.sess = tf.Session(graph=self.graph)
@@ -110,8 +115,12 @@ class TensorflowNeuropodExecutor(NeuropodExecutor):
         for spec in self.neuropod_config["output_spec"]:
             name = spec["name"]
             dtype = get_dtype(spec["dtype"])
-            if dtype.type == np.str_ and outputs[name].dtype == 'object' and type(outputs[name].item(0)) == six.binary_type:
+            if (
+                dtype.type == np.str_
+                and outputs[name].dtype == "object"
+                and type(outputs[name].item(0)) == six.binary_type
+            ):
                 # If the tensor is supposed to be of type string, is of type object, and contains strings
-                outputs[name] = outputs[name].astype('str')
+                outputs[name] = outputs[name].astype("str")
 
         return outputs

--- a/source/neuropods/python/backends/tensorflow/packager.py
+++ b/source/neuropods/python/backends/tensorflow/packager.py
@@ -12,14 +12,15 @@ from neuropods.utils.packaging_utils import packager
 
 @packager(platform="tensorflow")
 def create_tensorflow_neuropod(
-        neuropod_path,
-        input_spec,
-        output_spec,
-        node_name_mapping,
-        frozen_graph_path=None,
-        graph_def=None,
-        init_op_names=[],
-        **kwargs):
+    neuropod_path,
+    input_spec,
+    output_spec,
+    node_name_mapping,
+    frozen_graph_path=None,
+    graph_def=None,
+    init_op_names=[],
+    **kwargs
+):
     """
     Packages a TensorFlow model as a neuropod package.
 
@@ -51,8 +52,12 @@ def create_tensorflow_neuropod(
     {common_doc_post}
     """
     # Make sure the inputs are valid
-    if (frozen_graph_path is not None and graph_def is not None) or (frozen_graph_path is None and graph_def is None):
-        raise ValueError("Exactly one of 'frozen_graph_path' and 'graph_def' must be provided.")
+    if (frozen_graph_path is not None and graph_def is not None) or (
+        frozen_graph_path is None and graph_def is None
+    ):
+        raise ValueError(
+            "Exactly one of 'frozen_graph_path' and 'graph_def' must be provided."
+        )
 
     # Create a folder to store the model
     neuropod_data_path = os.path.join(neuropod_path, "0", "data")
@@ -75,12 +80,21 @@ def create_tensorflow_neuropod(
     missing_keys = expected_keys - actual_keys
 
     if len(missing_keys) > 0:
-        raise ValueError("Expected an item in `node_name_mapping` for every tensor in input_spec and output_spec. Missing: `{}`".format(missing_keys))
+        raise ValueError(
+            "Expected an item in `node_name_mapping` for every tensor in input_spec and output_spec. Missing: `{}`".format(
+                missing_keys
+            )
+        )
 
     # We also need to save the node name mapping so we know how to run the model
     # This is tensorflow specific config so it's not saved in the overall neuropod config
     with open(os.path.join(neuropod_path, "0", "config.json"), "w") as config_file:
-        json.dump({
-            "node_name_mapping": node_name_mapping,
-            "init_op_names": init_op_names if isinstance(init_op_names, list) else [init_op_names],
-        }, config_file)
+        json.dump(
+            {
+                "node_name_mapping": node_name_mapping,
+                "init_op_names": init_op_names
+                if isinstance(init_op_names, list)
+                else [init_op_names],
+            },
+            config_file,
+        )

--- a/source/neuropods/python/backends/torchscript/executor.py
+++ b/source/neuropods/python/backends/torchscript/executor.py
@@ -9,8 +9,11 @@ import torch
 
 from neuropods.backends.neuropod_executor import NeuropodExecutor
 
-SINGLE_OUTPUT_ERROR_MSG = "Please either return a dictionary from your model or provide an `output_spec` " \
-                          "of size 1"
+SINGLE_OUTPUT_ERROR_MSG = (
+    "Please either return a dictionary from your model or provide an `output_spec` "
+    "of size 1"
+)
+
 
 class TorchScriptNeuropodExecutor(NeuropodExecutor):
     """
@@ -36,7 +39,10 @@ class TorchScriptNeuropodExecutor(NeuropodExecutor):
                 torch.ops.load_library(os.path.join(neuropod_path, "0", "ops", op))
 
         # Load the model onto the appropriate device (ideally a GPU if we have one available)
-        self.model = torch.jit.load(os.path.join(neuropod_path, "0", "data", "model.pt"), map_location=self._get_torch_device("GPU"))
+        self.model = torch.jit.load(
+            os.path.join(neuropod_path, "0", "data", "model.pt"),
+            map_location=self._get_torch_device("GPU"),
+        )
         self.model_expects_dictionary = False
 
         # Check the expected input format of the model
@@ -119,7 +125,9 @@ class TorchScriptNeuropodExecutor(NeuropodExecutor):
                 raise RuntimeError("Output spec missing." + SINGLE_OUTPUT_ERROR_MSG)
 
             if len(output_spec) != 1:
-                raise RuntimeError("Output spec has has more than one entry." + SINGLE_OUTPUT_ERROR_MSG)
+                raise RuntimeError(
+                    "Output spec has has more than one entry." + SINGLE_OUTPUT_ERROR_MSG
+                )
 
             name = output_spec[0]["name"]
             dtype = output_spec[0]["dtype"]
@@ -130,12 +138,15 @@ class TorchScriptNeuropodExecutor(NeuropodExecutor):
     def _insert_value_to_output(self, neuropod_out, key, value, dtype=None):
         if isinstance(value, torch.Tensor):
             neuropod_out[key] = value.cpu().numpy()
-        elif isinstance(value, list) and (dtype == "string" or  isinstance(value[0], string_types)):
+        elif isinstance(value, list) and (
+            dtype == "string" or isinstance(value[0], string_types)
+        ):
             neuropod_out[key] = np.array(value, dtype=np.str_)
         else:
             raise RuntimeError(
                 "All outputs must be torch tensors or list of strings! Output `{}` was of type `{}`".format(
-                    key,
-                    type(value)))
+                    key, type(value)
+                )
+            )
 
         return neuropod_out

--- a/source/neuropods/python/backends/torchscript/packager.py
+++ b/source/neuropods/python/backends/torchscript/packager.py
@@ -7,6 +7,7 @@ import torch
 
 from neuropods.utils.packaging_utils import packager
 
+
 @packager(platform="torchscript")
 def create_torchscript_neuropod(neuropod_path, module, **kwargs):
     """

--- a/source/neuropods/python/loader.py
+++ b/source/neuropods/python/loader.py
@@ -5,6 +5,7 @@
 from neuropods.backends import config_utils
 from neuropods.utils import zip_loader
 
+
 def load_neuropod(neuropod_path, **kwargs):
     """
     Load a neuropod package. Returns a NeuropodExecutor
@@ -24,48 +25,71 @@ def load_neuropod(neuropod_path, **kwargs):
 
     if platform == "python":
         from neuropods.backends.python.executor import PythonNeuropodExecutor
+
         return PythonNeuropodExecutor(neuropod_path, **kwargs)
     elif platform == "torchscript":
         from neuropods.backends.torchscript.executor import TorchScriptNeuropodExecutor
+
         return TorchScriptNeuropodExecutor(neuropod_path, **kwargs)
     elif platform == "tensorflow":
         from neuropods.backends.tensorflow.executor import TensorflowNeuropodExecutor
+
         return TensorflowNeuropodExecutor(neuropod_path, **kwargs)
     else:
-        raise ValueError("Invalid platform found in neuropod config: {}".format(platform))
+        raise ValueError(
+            "Invalid platform found in neuropod config: {}".format(platform)
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
     from six.moves import cPickle as pickle
 
-    parser = argparse.ArgumentParser(description='Load a model and run inference with provided sample data.')
-    parser.add_argument('--neuropod-path', help='The path to a neuropod to load', required=True)
-    parser.add_argument('--input-pkl-path', help='The path to sample input data for the model', required=True)
-    parser.add_argument('--args-pkl-path', help='The path to kwargs for `load_neuropod`.', default={})
-    parser.add_argument('--output-pkl-path', help='Where to write the output of the model', default=None)
-    parser.add_argument('--use-native', help=('Use the native bindings to run the model. This option can currently '
-                                              'only be used when running from the `source/python` directory within '
-                                              'the Neuropods source tree.'), default=False, action='store_true')
+    parser = argparse.ArgumentParser(
+        description="Load a model and run inference with provided sample data."
+    )
+    parser.add_argument(
+        "--neuropod-path", help="The path to a neuropod to load", required=True
+    )
+    parser.add_argument(
+        "--input-pkl-path",
+        help="The path to sample input data for the model",
+        required=True,
+    )
+    parser.add_argument(
+        "--args-pkl-path", help="The path to kwargs for `load_neuropod`.", default={}
+    )
+    parser.add_argument(
+        "--output-pkl-path", help="Where to write the output of the model", default=None
+    )
+    parser.add_argument(
+        "--use-native",
+        help=(
+            "Use the native bindings to run the model. This option can currently "
+            "only be used when running from the `source/python` directory within "
+            "the Neuropods source tree."
+        ),
+        default=False,
+        action="store_true",
+    )
     args = parser.parse_args()
 
     def run_model(model):
         # Load the input data
-        with open(args.input_pkl_path, 'rb') as pkl:
+        with open(args.input_pkl_path, "rb") as pkl:
             input_data = pickle.load(pkl)
 
         out = model.infer(input_data)
 
         # Save the output data to the requested path
         if args.output_pkl_path is not None:
-            with open(args.output_pkl_path, 'wb') as pkl:
+            with open(args.output_pkl_path, "wb") as pkl:
                 pickle.dump(out, pkl)
 
-    with open(args.args_pkl_path, 'rb') as pkl:
+    with open(args.args_pkl_path, "rb") as pkl:
         load_neuropod_kwargs = pickle.load(pkl)
 
     if args.use_native:
-        import os
         from neuropods_native import Neuropod as NeuropodNative
 
         model = NeuropodNative(args.neuropod_path, **load_neuropod_kwargs)

--- a/source/neuropods/python/packagers.py
+++ b/source/neuropods/python/packagers.py
@@ -3,6 +3,7 @@
 #
 import sys
 
+
 class PackagerLoader(object):
     """
     Create aliases for packagers so they can be used as
@@ -16,16 +17,29 @@ class PackagerLoader(object):
     In order to make sure we don't load all the backends unnecessarily, we need to lazy-load
     them when the packaging function is called
     """
+
     # This is checked by the import system
     # See https://docs.python.org/3/reference/import.html#__path__
     __path__ = []
 
     def __getattr__(self, packaging_function):
-        packager_name = packaging_function.replace("create_", "").replace("_neuropod", "")
+        packager_name = packaging_function.replace("create_", "").replace(
+            "_neuropod", ""
+        )
         packager_module = "neuropods.backends." + packager_name + ".packager"
 
-        if packager_name not in ["keras", "python", "pytorch", "tensorflow", "torchscript"]:
-            raise RuntimeError("Tried to get an invalid attribute on neuropods.packagers ({})".format(packaging_function))
+        if packager_name not in [
+            "keras",
+            "python",
+            "pytorch",
+            "tensorflow",
+            "torchscript",
+        ]:
+            raise RuntimeError(
+                "Tried to get an invalid attribute on neuropods.packagers ({})".format(
+                    packaging_function
+                )
+            )
 
         module = __import__(packager_module, fromlist=[packaging_function])
 

--- a/source/neuropods/python/tests/custom_ops/pytorch/addition_op_1/setup.py
+++ b/source/neuropods/python/tests/custom_ops/pytorch/addition_op_1/setup.py
@@ -4,11 +4,7 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension
 # See https://pytorch.org/tutorials/advanced/cpp_extension.html#building-with-setuptools
 # and https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html#building-with-setuptools
 setup(
-    name='addition_op',
-    ext_modules=[
-        CppExtension('addition_op', ['addition_op.cc']),
-    ],
-    cmdclass={
-        'build_ext': BuildExtension.with_options(no_python_abi_suffix=True)
-    }
+    name="addition_op",
+    ext_modules=[CppExtension("addition_op", ["addition_op.cc"]),],
+    cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
 )

--- a/source/neuropods/python/tests/custom_ops/pytorch/addition_op_2/setup.py
+++ b/source/neuropods/python/tests/custom_ops/pytorch/addition_op_2/setup.py
@@ -4,11 +4,7 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension
 # See https://pytorch.org/tutorials/advanced/cpp_extension.html#building-with-setuptools
 # and https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html#building-with-setuptools
 setup(
-    name='addition_op',
-    ext_modules=[
-        CppExtension('addition_op', ['addition_op.cc']),
-    ],
-    cmdclass={
-        'build_ext': BuildExtension.with_options(no_python_abi_suffix=True)
-    }
+    name="addition_op",
+    ext_modules=[CppExtension("addition_op", ["addition_op.cc"]),],
+    cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
 )

--- a/source/neuropods/python/tests/custom_ops/torchscript/setup.py
+++ b/source/neuropods/python/tests/custom_ops/torchscript/setup.py
@@ -4,11 +4,7 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension
 # See https://pytorch.org/tutorials/advanced/cpp_extension.html#building-with-setuptools
 # and https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html#building-with-setuptools
 setup(
-    name='addition_op',
-    ext_modules=[
-        CppExtension('addition_op', ['addition_op.cc']),
-    ],
-    cmdclass={
-        'build_ext': BuildExtension.with_options(no_python_abi_suffix=True)
-    }
+    name="addition_op",
+    ext_modules=[CppExtension("addition_op", ["addition_op.cc"]),],
+    cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
 )

--- a/source/neuropods/python/tests/custom_ops/torchscript/test_torchscript_custom_ops.py
+++ b/source/neuropods/python/tests/custom_ops/torchscript/test_torchscript_custom_ops.py
@@ -3,7 +3,6 @@
 #
 
 import glob
-import numpy as np
 import os
 import subprocess
 import sys
@@ -14,15 +13,16 @@ from testpath.tempdir import TemporaryDirectory
 from neuropods.packagers import create_torchscript_neuropod
 from neuropods.tests.utils import get_addition_model_spec, check_addition_model
 
+
 class CustomOpModel(torch.jit.ScriptModule):
     """
     A simple addition model that uses a custom op
     """
+
     @torch.jit.script_method
     def forward(self, x, y):
-        return {
-            "out": torch.ops.neuropod_test_ops.add(x, y)
-        }
+        return {"out": torch.ops.neuropod_test_ops.add(x, y)}
+
 
 class TestTorchScriptCustomOps(unittest.TestCase):
     @classmethod
@@ -30,7 +30,9 @@ class TestTorchScriptCustomOps(unittest.TestCase):
         # Build the custom op
         current_dir = os.path.dirname(os.path.abspath(__file__))
         subprocess.check_call([sys.executable, "setup.py", "build"], cwd=current_dir)
-        cls.custom_op_path = glob.glob(os.path.join(current_dir, "build", "lib*", "addition_op.so"))[0]
+        cls.custom_op_path = glob.glob(
+            os.path.join(current_dir, "build", "lib*", "addition_op.so")
+        )[0]
 
         # Load the op
         torch.ops.load_library(cls.custom_op_path)
@@ -66,5 +68,5 @@ class TestTorchScriptCustomOps(unittest.TestCase):
             self.package_simple_addition_model(do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/gpu_test_basic_environment_support.py
+++ b/source/neuropods/python/tests/gpu_test_basic_environment_support.py
@@ -4,18 +4,24 @@
 
 import unittest
 
-# Tests that the environment running the tests has GPUs available
-# and that various frameworks used in the tests support using the
-# GPUs
+
 class TestGPUEnvSupport(unittest.TestCase):
+    """
+    Tests that the environment running the tests has GPUs available
+    and that various frameworks used in the tests support using the
+    GPUs
+    """
+
     def test_torch_gpu(self):
         import torch
+
         self.assertTrue(torch.cuda.is_available())
 
     def test_tf_gpu(self):
         import tensorflow as tf
+
         self.assertTrue(tf.test.is_built_with_cuda() and tf.test.is_gpu_available())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/gpu_test_torchscript_devices.py
+++ b/source/neuropods/python/tests/gpu_test_torchscript_devices.py
@@ -7,14 +7,18 @@ import os
 import torch
 import unittest
 from testpath.tempdir import TemporaryDirectory
+from torch import Tensor
+from typing import Dict
 
 from neuropods.packagers import create_torchscript_neuropod
 from neuropods.utils.eval_utils import load_and_test_neuropod
+
 
 class DevicesModel(torch.jit.ScriptModule):
     """
     This model returns which device its inputs are on (0 for cpu and 1 for gpu)
     """
+
     @torch.jit.script_method
     def get_device(self, item):
         if item.device == torch.device("cpu"):
@@ -41,6 +45,7 @@ class DevicesModel(torch.jit.ScriptModule):
             "x": self.get_device(data["x"]),
             "y": self.get_device(data["y"]),
         }
+
 
 class TestTorchScriptDevices(unittest.TestCase):
     def package_devices_model(self):
@@ -85,7 +90,7 @@ class TestTorchScriptDevices(unittest.TestCase):
                     "x": np.array([0], dtype=np.int64),
                     "y": np.array([0], dtype=np.int64),
                 },
-                neuropod_load_args={"visible_gpu": None}
+                neuropod_load_args={"visible_gpu": None},
             )
 
     def test_device_model(self):
@@ -94,5 +99,5 @@ class TestTorchScriptDevices(unittest.TestCase):
         self.package_devices_model()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_config_utils.py
+++ b/source/neuropods/python/tests/test_config_utils.py
@@ -4,7 +4,10 @@
 
 import unittest
 
-from neuropods.backends.config_utils import canonicalize_tensor_spec, validate_neuropod_config
+from neuropods.backends.config_utils import (
+    canonicalize_tensor_spec,
+    validate_neuropod_config,
+)
 
 
 def get_valid_config():
@@ -17,9 +20,7 @@ def get_valid_config():
         "output_spec": [
             {"name": "y", "dtype": "float32", "shape": (None, 2, "some_symbol")},
         ],
-        "input_tensor_device": {
-            "x": "GPU"
-        }
+        "input_tensor_device": {"x": "GPU"},
     }
 
 
@@ -111,5 +112,5 @@ class TestSpecValidation(unittest.TestCase):
             validate_neuropod_config(config)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_eval_utils.py
+++ b/source/neuropods/python/tests/test_eval_utils.py
@@ -11,8 +11,8 @@ class TestEvalUtil(unittest.TestCase):
             neuropod_path = os.path.join(test_dir, "test_neuropod")
             os.mkdir(neuropod_path)
 
-            test_input = { "x": 3, "y": 4 }
-            test_expected_output = { "out": 7 }
+            test_input = {"x": 3, "y": 4}
+            test_expected_output = {"out": 7}
 
             save_test_data(neuropod_path, test_input, test_expected_output)
             test_data = load_test_data(neuropod_path)

--- a/source/neuropods/python/tests/test_keras_packaging.py
+++ b/source/neuropods/python/tests/test_keras_packaging.py
@@ -2,33 +2,36 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
 import tensorflow as tf
+import unittest
 from tensorflow.keras.layers import Input, Add
 from tensorflow.keras.models import Model
-import unittest
 from testpath.tempdir import TemporaryDirectory
 
-from neuropods.backends.keras.packager import create_keras_neuropod, \
-    infer_keras_input_spec, infer_keras_output_spec
-from neuropods.loader import load_neuropod
+from neuropods.backends.keras.packager import (
+    create_keras_neuropod,
+    infer_keras_input_spec,
+    infer_keras_output_spec,
+)
 from neuropods.tests.utils import get_addition_model_spec, check_addition_model
+
 
 def create_keras_addition_model(node_name_mapping=None):
     """
     A simple addition model
     """
     if node_name_mapping is None:
+
         class id_dict(dict):
             def __missing__(self, key):
                 return key
 
         node_name_mapping = id_dict()
 
-    x = Input(batch_shape=(None,), name=node_name_mapping['x'])
-    y = Input(batch_shape=(None,), name=node_name_mapping['y'])
-    out = Add(name=node_name_mapping['out'])([x, y])
+    x = Input(batch_shape=(None,), name=node_name_mapping["x"])
+    y = Input(batch_shape=(None,), name=node_name_mapping["y"])
+    out = Add(name=node_name_mapping["out"])([x, y])
     model = Model(inputs=[x, y], outputs=[out])
     return model
 
@@ -39,7 +42,7 @@ class TestKerasPackaging(unittest.TestCase):
             neuropod_path = os.path.join(test_dir, "test_neuropod")
 
             if alias_names:
-                node_name_mapping = {'x': 'x_', 'y': 'y_', 'out': 'out_'}
+                node_name_mapping = {"x": "x_", "y": "y_", "out": "out_"}
             else:
                 node_name_mapping = None
 
@@ -77,13 +80,13 @@ class TestKerasPackaging(unittest.TestCase):
     def test_input_spec_inference(self):
         # Test whether addition model's input spec is inferred correctly
         inferred_spec = infer_keras_input_spec(create_keras_addition_model())
-        self.assertEquals(get_addition_model_spec()['input_spec'], inferred_spec)
+        self.assertEquals(get_addition_model_spec()["input_spec"], inferred_spec)
 
     def test_output_spec_inference(self):
         # Test whether addition model's output spec is inferred correctly
         inferred_spec = infer_keras_output_spec(create_keras_addition_model())
-        self.assertEquals(get_addition_model_spec()['output_spec'], inferred_spec)
+        self.assertEquals(get_addition_model_spec()["output_spec"], inferred_spec)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_python_isolation.py
+++ b/source/neuropods/python/tests/test_python_isolation.py
@@ -4,14 +4,11 @@
 
 import numpy as np
 import os
-import shutil
 import unittest
-from tempfile import mkdtemp
 from testpath.tempdir import TemporaryDirectory
 
 from neuropods.loader import load_neuropod
 from neuropods.packagers import create_python_neuropod
-from neuropods.tests.utils import get_addition_model_spec, check_addition_model
 
 DUMMY_MODEL_SOURCE = """
 import numpy as np
@@ -42,12 +39,12 @@ class TestPythonIsolation(unittest.TestCase):
             neuropod_path=neuropod_path,
             model_name="dummy_model",
             data_paths=[],
-            code_path_spec=[{
-                "python_root": model_code_dir,
-                "dirs_to_package": [
-                    ""  # Package everything in the python_root
-                ],
-            }],
+            code_path_spec=[
+                {
+                    "python_root": model_code_dir,
+                    "dirs_to_package": [""],  # Package everything in the python_root
+                }
+            ],
             entrypoint_package="dummy_model",
             entrypoint="get_model",
             input_spec=[{"name": "x", "dtype": "float32", "shape": (1,)}],
@@ -72,5 +69,5 @@ class TestPythonIsolation(unittest.TestCase):
                         self.assertEqual(n2.infer(input_data)["out"][0], 2.0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_pytorch_packaging.py
+++ b/source/neuropods/python/tests/test_pytorch_packaging.py
@@ -2,11 +2,8 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
-import shutil
 import unittest
-from tempfile import mkdtemp
 from testpath.tempdir import TemporaryDirectory
 
 from neuropods.packagers import create_pytorch_neuropod
@@ -44,12 +41,14 @@ class TestPytorchPackaging(unittest.TestCase):
                 neuropod_path=neuropod_path,
                 model_name="addition_model",
                 data_paths=[],
-                code_path_spec=[{
-                    "python_root": model_code_dir,
-                    "dirs_to_package": [
-                        ""  # Package everything in the python_root
-                    ],
-                }],
+                code_path_spec=[
+                    {
+                        "python_root": model_code_dir,
+                        "dirs_to_package": [
+                            ""  # Package everything in the python_root
+                        ],
+                    }
+                ],
                 entrypoint_package="addition_model",
                 entrypoint="get_model",
                 # Get the input/output spec along with test data
@@ -70,5 +69,5 @@ class TestPytorchPackaging(unittest.TestCase):
             self.package_simple_addition_model(do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_pytorch_strings.py
+++ b/source/neuropods/python/tests/test_pytorch_strings.py
@@ -2,7 +2,6 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
 import unittest
 from testpath.tempdir import TemporaryDirectory
@@ -41,12 +40,12 @@ def package_strings_model(out_dir, do_fail=False):
         neuropod_path=neuropod_path,
         model_name="strings_model",
         data_paths=[],
-        code_path_spec=[{
-            "python_root": model_code_dir,
-            "dirs_to_package": [
-                ""  # Package everything in the python_root
-            ],
-        }],
+        code_path_spec=[
+            {
+                "python_root": model_code_dir,
+                "dirs_to_package": [""],  # Package everything in the python_root
+            }
+        ],
         entrypoint_package="strings_model",
         entrypoint="get_model",
         # Get the input/output spec along with test data
@@ -71,5 +70,5 @@ class TestPytorchPackaging(unittest.TestCase):
                 package_strings_model(test_dir, do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_randomify.py
+++ b/source/neuropods/python/tests/test_randomify.py
@@ -10,21 +10,19 @@ from tempfile import mkdtemp
 from neuropods.loader import load_neuropod
 from neuropods.utils.randomify import randomify_neuropod
 
-input_spec = \
-    [
-        {'name': 'in_string_vector', 'dtype': 'string', 'shape': ('N',)},
-        {'name': 'in_int_matrix', 'dtype': 'int32', 'shape': ('N', 'M')},
-        {'name': 'in_float32_matrix', 'dtype': 'float32', 'shape': ('N', None)},
-        {'name': 'in_float64_scalar', 'dtype': 'float64', 'shape': ()},
-    ]
+input_spec = [
+    {"name": "in_string_vector", "dtype": "string", "shape": ("N",)},
+    {"name": "in_int_matrix", "dtype": "int32", "shape": ("N", "M")},
+    {"name": "in_float32_matrix", "dtype": "float32", "shape": ("N", None)},
+    {"name": "in_float64_scalar", "dtype": "float64", "shape": ()},
+]
 
-output_spec = \
-    [
-        {'name': 'out_string_vector', 'dtype': 'string', 'shape': ('N',)},
-        {'name': 'out_int_matrix', 'dtype': 'int32', 'shape': ('N', 'M')},
-        {'name': 'out_float_matrix', 'dtype': 'int32', 'shape': ('N', None)},
-        {'name': 'out_float_scalar', 'dtype': 'float32', 'shape': ()},
-    ]
+output_spec = [
+    {"name": "out_string_vector", "dtype": "string", "shape": ("N",)},
+    {"name": "out_int_matrix", "dtype": "int32", "shape": ("N", "M")},
+    {"name": "out_float_matrix", "dtype": "int32", "shape": ("N", None)},
+    {"name": "out_float_scalar", "dtype": "float32", "shape": ()},
+]
 
 
 class TestSpecValidation(unittest.TestCase):
@@ -32,7 +30,7 @@ class TestSpecValidation(unittest.TestCase):
     def setUpClass(cls):
         cls.tmpdir = mkdtemp()
 
-        neuropod_path = os.path.join(cls.tmpdir, 'test_stub_neuropod')
+        neuropod_path = os.path.join(cls.tmpdir, "test_stub_neuropod")
         randomify_neuropod(neuropod_path, input_spec, output_spec)
         neuropod = load_neuropod(neuropod_path)
         cls.neuropod = neuropod
@@ -43,25 +41,35 @@ class TestSpecValidation(unittest.TestCase):
 
     def test_no_inputs(self):
         result = TestSpecValidation.neuropod.infer({})
-        self.assertGreater(result['out_string_vector'].shape[0], 0)
-        self.assertEqual(result['out_string_vector'].shape[0], result['out_int_matrix'].shape[0])
-        self.assertGreater(result['out_float_matrix'].shape[0], 0)
-        self.assertTrue(np.isscalar(result['out_float_scalar']))
+        self.assertGreater(result["out_string_vector"].shape[0], 0)
+        self.assertEqual(
+            result["out_string_vector"].shape[0], result["out_int_matrix"].shape[0]
+        )
+        self.assertGreater(result["out_float_matrix"].shape[0], 0)
+        self.assertTrue(np.isscalar(result["out_float_scalar"]))
 
     def test_some_inputs(self):
         result = TestSpecValidation.neuropod.infer(
-            {'in_float32_matrix': np.asarray([[1.1, 2.2], [0, 1], [2, 3]], dtype=np.float32)})
-        self.assertGreater(result['out_string_vector'].shape[0], 0)
+            {
+                "in_float32_matrix": np.asarray(
+                    [[1.1, 2.2], [0, 1], [2, 3]], dtype=np.float32
+                )
+            }
+        )
+        self.assertGreater(result["out_string_vector"].shape[0], 0)
 
     def test_invalid_input_name(self):
         with self.assertRaises(ValueError):
             TestSpecValidation.neuropod.infer(
-                {'bogus': np.asarray([[1.1, 2.2], [0, 1], [2, 3]], dtype=np.float32)})
+                {"bogus": np.asarray([[1.1, 2.2], [0, 1], [2, 3]], dtype=np.float32)}
+            )
 
     def test_invalid_shape(self):
         with self.assertRaises(ValueError):
-            TestSpecValidation.neuropod.infer({'in_float32_matrix': np.asarray([3], dtype=np.float32)})
+            TestSpecValidation.neuropod.infer(
+                {"in_float32_matrix": np.asarray([3], dtype=np.float32)}
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_serialization.py
+++ b/source/neuropods/python/tests/test_serialization.py
@@ -7,14 +7,26 @@ import neuropods_native
 import six
 import unittest
 
+
 class TestSerialization(unittest.TestCase):
     def test_different_types_and_shapes(self):
         """
         Exhaustive noop serialization-->deserialization test over all supported datatypes and several distrinct
         shapes
         """
-        _TESTED_DTYPES = [np.float32, np.float64, np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64,
-                          np.uint64, np.string_]
+        _TESTED_DTYPES = [
+            np.float32,
+            np.float64,
+            np.int8,
+            np.uint8,
+            np.int16,
+            np.uint16,
+            np.int32,
+            np.uint32,
+            np.int64,
+            np.uint64,
+            np.string_,
+        ]
         _TESTED_SHAPES = [(1,), (3,), (2, 3), (2, 3, 4)]
 
         # Used for testing NeuropodValueMap serialization
@@ -58,8 +70,8 @@ class TestSerialization(unittest.TestCase):
 
     def test_invalid_stream_deserialization(self):
         with self.assertRaises(RuntimeError if six.PY2 else TypeError):
-            neuropods_native.deserialize('bogus')
+            neuropods_native.deserialize("bogus")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_tensor_validation.py
+++ b/source/neuropods/python/tests/test_tensor_validation.py
@@ -23,7 +23,9 @@ class TestSpecValidation(unittest.TestCase):
         # Shouldn't raise a ValueError
         validate_tensors_against_specs(test_input, TEST_SPEC)
 
-    @unittest.skip("We temporary made all tensors optional, until a proper mechanism is implemented")
+    @unittest.skip(
+        "We temporary made all tensors optional, until a proper mechanism is implemented"
+    )
     def test_missing_tensor(self):
         test_input = {
             "x": np.array([[1, 2], [3, 4]], dtype=np.float32),
@@ -33,7 +35,9 @@ class TestSpecValidation(unittest.TestCase):
             # Missing a tensor
             validate_tensors_against_specs(test_input, TEST_SPEC)
 
-    @unittest.skip("We temporary made all tensors optional, until a proper mechanism is implemented")
+    @unittest.skip(
+        "We temporary made all tensors optional, until a proper mechanism is implemented"
+    )
     def test_missing_tensors(self):
         test_input = {}
 
@@ -54,7 +58,7 @@ class TestSpecValidation(unittest.TestCase):
     def test_incorrect_dtype(self):
         test_input = {
             "x": np.array([[1, 2], [3, 4]], dtype=np.int32),
-            "y": np.array([[1, 2], [3, 4]], dtype=np.int32)
+            "y": np.array([[1, 2], [3, 4]], dtype=np.int32),
         }
 
         with self.assertRaises(ValueError):
@@ -113,7 +117,7 @@ class TestSpecValidation(unittest.TestCase):
     def test_invalid_shape_entry(self):
         test_input = {
             "x": np.array([[1, 2], [3, 4]], dtype=np.float32),
-            "y": np.array([[1, 2], [3, 4]], dtype=np.float32)
+            "y": np.array([[1, 2], [3, 4]], dtype=np.float32),
         }
 
         SPEC = [
@@ -138,5 +142,5 @@ class TestSpecValidation(unittest.TestCase):
         validate_tensors_against_specs(test_input, SPEC)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_tensorflow_packaging.py
+++ b/source/neuropods/python/tests/test_tensorflow_packaging.py
@@ -12,6 +12,7 @@ from neuropods.packagers import create_tensorflow_neuropod
 from neuropods.loader import load_neuropod
 from neuropods.tests.utils import get_addition_model_spec, check_addition_model
 
+
 def create_tf_addition_model():
     """
     A simple addition model
@@ -22,8 +23,8 @@ def create_tf_addition_model():
             x = tf.placeholder(tf.float32, name="in_x")
             y = tf.placeholder(tf.float32, name="in_y")
 
-            # UATG(flake8/F841) Assigned to a variable for clarity
-            out = tf.add(x, y, name="out")
+            # Assigned to a variable for clarity
+            out = tf.add(x, y, name="out")  # noqa: F841
 
     return g.as_graph_def()
 
@@ -35,7 +36,12 @@ def create_tf_accumulator_model():
     g = tf.Graph()
     with g.as_default():
         with tf.name_scope("some_namespace"):
-            acc = tf.get_variable('accumulator', initializer=tf.zeros_initializer(), shape=(), dtype=tf.float32)
+            acc = tf.get_variable(
+                "accumulator",
+                initializer=tf.zeros_initializer(),
+                shape=(),
+                dtype=tf.float32,
+            )
             x = tf.placeholder(tf.float32, name="in_x")
 
             assign_op = tf.assign_add(acc, x)
@@ -61,7 +67,6 @@ class TestTensorflowPackaging(unittest.TestCase):
                 node_name_mapping={
                     "x": "some_namespace/in_x:0",
                     "y": "some_namespace/in_y:0",
-
                     # The `:0` is optional
                     "out": "some_namespace/out",
                 },
@@ -87,19 +92,11 @@ class TestTensorflowPackaging(unittest.TestCase):
                 "x": "some_namespace/in_x:0",
                 "out": "some_namespace/out:0",
             },
-            input_spec=[
-                {"name": "x", "dtype": "float32", "shape": ()},
-            ],
-            output_spec=[
-                {"name": "out", "dtype": "float32", "shape": ()},
-            ],
+            input_spec=[{"name": "x", "dtype": "float32", "shape": ()},],
+            output_spec=[{"name": "out", "dtype": "float32", "shape": ()},],
             init_op_names=[init_op_name] if init_op_name_as_list else init_op_name,
-            test_input_data={
-                "x": np.float32(5.0),
-            },
-            test_expected_out={
-                "out": np.float32(5.0),
-            },
+            test_input_data={"x": np.float32(5.0),},
+            test_expected_out={"out": np.float32(5.0),},
         )
 
     def test_simple_addition_model(self):
@@ -124,9 +121,13 @@ class TestTensorflowPackaging(unittest.TestCase):
                 neuropod_path = os.path.join(test_dir, "test_neuropod")
                 self.package_accumulator_model(neuropod_path, init_op_name_as_list)
                 neuropod_path = load_neuropod(neuropod_path)
-                np.testing.assert_equal(neuropod_path.infer({"x": np.float32(2.0)}), {"out": 2.0})
-                np.testing.assert_equal(neuropod_path.infer({"x": np.float32(4.0)}), {"out": 6.0})
+                np.testing.assert_equal(
+                    neuropod_path.infer({"x": np.float32(2.0)}), {"out": 2.0}
+                )
+                np.testing.assert_equal(
+                    neuropod_path.infer({"x": np.float32(4.0)}), {"out": 6.0}
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_tensorflow_strings.py
+++ b/source/neuropods/python/tests/test_tensorflow_strings.py
@@ -2,7 +2,6 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
 import tensorflow as tf
 import unittest
@@ -10,6 +9,7 @@ from testpath.tempdir import TemporaryDirectory
 
 from neuropods.packagers import create_tensorflow_neuropod
 from neuropods.tests.utils import get_string_concat_model_spec, check_strings_model
+
 
 def create_tf_strings_model():
     """
@@ -21,8 +21,8 @@ def create_tf_strings_model():
             x = tf.placeholder(tf.string, name="in_x")
             y = tf.placeholder(tf.string, name="in_y")
 
-            # UATG(flake8/F841) Assigned to a variable for clarity
-            out = tf.string_join([x, y], separator=" ", name="out")
+            # Assigned to a variable for clarity
+            out = tf.string_join([x, y], separator=" ", name="out")  # noqa: F841
 
     return g.as_graph_def()
 
@@ -62,5 +62,5 @@ class TestTensorflowStrings(unittest.TestCase):
             self.package_strings_model(do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_torchscript_packaging.py
+++ b/source/neuropods/python/tests/test_torchscript_packaging.py
@@ -2,24 +2,26 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
 import torch
 import unittest
 from testpath.tempdir import TemporaryDirectory
+from torch import Tensor
+from typing import Dict
 
 from neuropods.packagers import create_torchscript_neuropod
 from neuropods.tests.utils import get_addition_model_spec, check_addition_model
+
 
 class AdditionModel(torch.jit.ScriptModule):
     """
     A simple addition model
     """
+
     @torch.jit.script_method
     def forward(self, x, y):
-        return {
-            "out": x + y
-        }
+        return {"out": x + y}
+
 
 class AdditionModelDictInput(torch.jit.ScriptModule):
     """
@@ -27,20 +29,22 @@ class AdditionModelDictInput(torch.jit.ScriptModule):
     If there are a large number of inputs, it may be more convenient to take the
     input as a dict rather than as individual parameters.
     """
+
     @torch.jit.script_method
     def forward(self, data):
         # type: (Dict[str, Tensor])
-        return {
-            "out": data["x"] + data["y"]
-        }
+        return {"out": data["x"] + data["y"]}
+
 
 class AdditionModelTensorOutput(torch.jit.ScriptModule):
     """
     A simple addition model
     """
+
     @torch.jit.script_method
     def forward(self, x, y):
         return x + y
+
 
 class TestTorchScriptPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False):
@@ -73,5 +77,5 @@ class TestTorchScriptPackaging(unittest.TestCase):
             self.package_simple_addition_model(do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/test_torchscript_strings.py
+++ b/source/neuropods/python/tests/test_torchscript_strings.py
@@ -2,19 +2,21 @@
 # Uber, Inc. (c) 2018
 #
 
-import numpy as np
 import os
 import torch
 import unittest
 from testpath.tempdir import TemporaryDirectory
+from typing import Dict, List
 
 from neuropods.packagers import create_torchscript_neuropod
 from neuropods.tests.utils import get_string_concat_model_spec, check_strings_model
+
 
 class StringsModel(torch.jit.ScriptModule):
     """
     A model that concatenates two input strings
     """
+
     @torch.jit.script_method
     def forward(self, x, y):
         # type: (List[str], List[str])
@@ -26,9 +28,8 @@ class StringsModel(torch.jit.ScriptModule):
             s = y[i]
             out.append(f + " " + s)
 
-        return {
-            "out": out[1:]
-        }
+        return {"out": out[1:]}
+
 
 class StringsModelDictInput(torch.jit.ScriptModule):
     """
@@ -36,6 +37,7 @@ class StringsModelDictInput(torch.jit.ScriptModule):
     If there are a large number of inputs, it may be more convenient to take the
     input as a dict rather than as individual parameters.
     """
+
     @torch.jit.script_method
     def forward(self, data):
         # type: (Dict[str, List[str]])
@@ -50,14 +52,14 @@ class StringsModelDictInput(torch.jit.ScriptModule):
             s = y[i]
             out.append(f + " " + s)
 
-        return {
-            "out": out[1:]
-        }
+        return {"out": out[1:]}
+
 
 class StringsModelListOutput(torch.jit.ScriptModule):
     """
     A model that concatenates two input strings
     """
+
     @torch.jit.script_method
     def forward(self, x, y):
         # type: (List[str], List[str])
@@ -106,5 +108,5 @@ class TestTorchScriptStrings(unittest.TestCase):
                     package_strings_model(test_dir, model=model, do_fail=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/source/neuropods/python/tests/utils.py
+++ b/source/neuropods/python/tests/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from neuropods.loader import load_neuropod
 
+
 def get_addition_model_spec(do_fail=False):
     """
     Returns the input/output spec for an addition model along with test data.
@@ -19,9 +20,7 @@ def get_addition_model_spec(do_fail=False):
             {"name": "x", "dtype": "float32", "shape": ("batch_size",)},
             {"name": "y", "dtype": "float32", "shape": ("batch_size",)},
         ],
-        output_spec=[
-            {"name": "out", "dtype": "float32", "shape": ("batch_size",)},
-        ],
+        output_spec=[{"name": "out", "dtype": "float32", "shape": ("batch_size",)},],
         test_input_data={
             "x": np.arange(5, dtype=np.float32),
             "y": np.arange(5, dtype=np.float32),
@@ -30,6 +29,7 @@ def get_addition_model_spec(do_fail=False):
             "out": np.zeros(5) if do_fail else np.arange(5) + np.arange(5)
         },
     )
+
 
 def get_string_concat_model_spec(do_fail=False):
     """
@@ -48,17 +48,14 @@ def get_string_concat_model_spec(do_fail=False):
             {"name": "x", "dtype": "string", "shape": ("batch_size",)},
             {"name": "y", "dtype": "string", "shape": ("batch_size",)},
         ],
-        output_spec=[
-            {"name": "out", "dtype": "string", "shape": ("batch_size",)},
-        ],
+        output_spec=[{"name": "out", "dtype": "string", "shape": ("batch_size",)},],
         test_input_data={
             "x": np.array(["apple", "banana", "carrot"]),
             "y": np.array(["sauce", "pudding", "cake"]),
         },
-        test_expected_out={
-            "out": expected_out,
-        },
+        test_expected_out={"out": expected_out,},
     )
+
 
 def check_addition_model(neuropod_path):
     """
@@ -72,6 +69,7 @@ def check_addition_model(neuropod_path):
         check_specs_match(neuropod.inputs, target["input_spec"])
         check_specs_match(neuropod.outputs, target["output_spec"])
 
+
 def check_strings_model(neuropod_path):
     """
     Validate that the inputs and outputs of the loaded neuropod match
@@ -83,6 +81,7 @@ def check_strings_model(neuropod_path):
         # Validate that the specs match
         check_specs_match(neuropod.inputs, target["input_spec"])
         check_specs_match(neuropod.outputs, target["output_spec"])
+
 
 def check_specs_match(specs, targets):
     """

--- a/source/neuropods/python/utils/dtype_utils.py
+++ b/source/neuropods/python/utils/dtype_utils.py
@@ -1,12 +1,16 @@
 import six
 import numpy as np
 
-# Get numpy dtypes from strings in a python 2 and 3 compatible way
+
 def get_dtype(arg):
+    """
+    Get numpy dtypes from strings in a python 2 and 3 compatible way
+    """
     if arg == "string":
         arg = "str"
 
     return np.dtype(arg)
+
 
 def get_dtype_name(arg):
     name = get_dtype(arg).name
@@ -15,8 +19,7 @@ def get_dtype_name(arg):
 
     return name
 
-# Python 3 represents strings as unicode. The native code doesn't suppport unicode
-# arrays
+
 def maybe_convert_bindings_types(items):
     if six.PY3:
         # Python 3 uses unicode for strings. We need to convert before passing to

--- a/source/neuropods/python/utils/env_utils.py
+++ b/source/neuropods/python/utils/env_utils.py
@@ -3,18 +3,21 @@
 #
 
 from six.moves import cPickle as pickle
-import os
-import shutil
 import subprocess
 import sys
 
 from tempfile import mkstemp
 from testpath.tempdir import TemporaryDirectory
 
-import neuropods
 
-
-def eval_in_new_process(neuropod_path, input_data, binary_path=sys.executable, extra_args=[], neuropod_load_args={}, **kwargs):
+def eval_in_new_process(
+    neuropod_path,
+    input_data,
+    binary_path=sys.executable,
+    extra_args=[],
+    neuropod_load_args={},
+    **kwargs
+):
     """
     Loads and runs a neuropod model in a separate process with specified input data.
 
@@ -28,21 +31,32 @@ def eval_in_new_process(neuropod_path, input_data, binary_path=sys.executable, e
     """
     with TemporaryDirectory() as tmpdir:
         _, input_filepath = mkstemp(dir=tmpdir)
-        with open(input_filepath, 'wb') as input_pkl:
+        with open(input_filepath, "wb") as input_pkl:
             pickle.dump(input_data, input_pkl, protocol=-1)
 
         _, args_filepath = mkstemp(dir=tmpdir)
-        with open(args_filepath, 'wb') as args_pkl:
+        with open(args_filepath, "wb") as args_pkl:
             pickle.dump(neuropod_load_args, args_pkl, protocol=-1)
 
         _, output_filepath = mkstemp(dir=tmpdir)
 
-        subprocess.check_call([binary_path, '-m', 'neuropods.loader',
-                               '--neuropod-path', neuropod_path,
-                               '--input-pkl-path', input_filepath,
-                               '--output-pkl-path', output_filepath,
-                               '--args-pkl-path', args_filepath,
-                               ] + extra_args, **kwargs)
+        subprocess.check_call(
+            [
+                binary_path,
+                "-m",
+                "neuropods.loader",
+                "--neuropod-path",
+                neuropod_path,
+                "--input-pkl-path",
+                input_filepath,
+                "--output-pkl-path",
+                output_filepath,
+                "--args-pkl-path",
+                args_filepath,
+            ]
+            + extra_args,
+            **kwargs
+        )
 
-        with open(output_filepath, 'rb') as output_pkl:
+        with open(output_filepath, "rb") as output_pkl:
             return pickle.load(output_pkl)

--- a/source/neuropods/python/utils/eval_utils.py
+++ b/source/neuropods/python/utils/eval_utils.py
@@ -4,17 +4,14 @@
 
 import logging
 import os
-import six
 import pickle
 
 import numpy as np
-from testpath.tempdir import TemporaryDirectory
 
-from neuropods.loader import load_neuropod
 from neuropods.utils.env_utils import eval_in_new_process
 from neuropods.utils.dtype_utils import maybe_convert_bindings_types
 
-RUN_NATIVE_TESTS   = os.getenv("NEUROPODS_RUN_NATIVE_TESTS") is not None
+RUN_NATIVE_TESTS = os.getenv("NEUROPODS_RUN_NATIVE_TESTS") is not None
 TEST_DATA_FILENAME = "test_data.pkl"
 
 logger = logging.getLogger(__name__)
@@ -30,11 +27,11 @@ def check_output_matches_expected(out, expected_out):
             success_condition = np.allclose(value, out[key])
 
         if not success_condition:
-            logger.info("Output for key '{}' does not match expected\nExpected:\n{}\nActual\n{}\n".format(
-                key,
-                value,
-                out[key],
-            ))
+            logger.info(
+                "Output for key '{}' does not match expected\nExpected:\n{}\nActual\n{}\n".format(
+                    key, value, out[key],
+                )
+            )
             raise ValueError("{} does not match expected value!".format(key))
 
 
@@ -42,12 +39,22 @@ def print_output_summary(out):
     logger.info("No expected test output specified; printing summary to stdout")
     for key, value in out.items():
         if isinstance(value, np.ndarray):
-            logger.info("\t{}: np.array with shape {} and dtype {}".format(key, value.shape, value.dtype))
+            logger.info(
+                "\t{}: np.array with shape {} and dtype {}".format(
+                    key, value.shape, value.dtype
+                )
+            )
         else:
-            raise ValueError("All outputs must be numpy arrays! Output `{}` was of type `{}`".format(key, type(value)))
+            raise ValueError(
+                "All outputs must be numpy arrays! Output `{}` was of type `{}`".format(
+                    key, type(value)
+                )
+            )
 
 
-def load_and_test_native(neuropod_path, test_input_data, test_expected_out=None, **kwargs):
+def load_and_test_native(
+    neuropod_path, test_input_data, test_expected_out=None, **kwargs
+):
     """
     Loads a neuropod using the python bindings and runs inference.
     If expected output is specified, the output of the model is checked against
@@ -58,15 +65,23 @@ def load_and_test_native(neuropod_path, test_input_data, test_expected_out=None,
     # Converts unicode to ascii for Python 3
     test_input_data = maybe_convert_bindings_types(test_input_data)
 
-    out = eval_in_new_process(neuropod_path, test_input_data, extra_args=["--use-native"], **kwargs)
+    out = eval_in_new_process(
+        neuropod_path, test_input_data, extra_args=["--use-native"], **kwargs
+    )
 
     # Check the output
     if test_expected_out is not None:
         # Throws a ValueError if the output doesn't match the expected value
         check_output_matches_expected(out, test_expected_out)
 
-def load_and_test_neuropod(neuropod_path, test_input_data, test_expected_out=None,
-                           neuropod_load_args={}, **kwargs):
+
+def load_and_test_neuropod(
+    neuropod_path,
+    test_input_data,
+    test_expected_out=None,
+    neuropod_load_args={},
+    **kwargs
+):
     """
     Loads a neuropod in a new process and verifies that inference runs.
     If expected output is specified, the output of the model is checked against
@@ -75,11 +90,18 @@ def load_and_test_neuropod(neuropod_path, test_input_data, test_expected_out=Non
     Raises a ValueError if the outputs don't match the expected values
     """
     if RUN_NATIVE_TESTS:
-        return load_and_test_native(neuropod_path, test_input_data, test_expected_out, neuropod_load_args=neuropod_load_args)
+        return load_and_test_native(
+            neuropod_path,
+            test_input_data,
+            test_expected_out,
+            neuropod_load_args=neuropod_load_args,
+        )
 
     # Run the evaluation in a new process. This is important to make sure
     # custom ops are being tested correctly
-    out = eval_in_new_process(neuropod_path, test_input_data, neuropod_load_args=neuropod_load_args)
+    out = eval_in_new_process(
+        neuropod_path, test_input_data, neuropod_load_args=neuropod_load_args
+    )
 
     # Check the output
     if test_expected_out is not None:
@@ -99,12 +121,10 @@ def save_test_data(neuropod_path, test_input_data, test_expected_out):
     :param test_expected_out: a dictionary of expected output feature values
     :return: None
     """
-    test_data = {
-        "test_input": test_input_data,
-        "test_output": test_expected_out
-    }
+    test_data = {"test_input": test_input_data, "test_output": test_expected_out}
     with open(os.path.join(neuropod_path, TEST_DATA_FILENAME), "wb") as test_data_file:
         pickle.dump(test_data, test_data_file)
+
 
 def load_test_data(neuropod_path):
     """
@@ -114,7 +134,9 @@ def load_test_data(neuropod_path):
     :return: dict or None
     """
     try:
-        with open(os.path.join(neuropod_path, TEST_DATA_FILENAME), "rb") as test_data_file:
+        with open(
+            os.path.join(neuropod_path, TEST_DATA_FILENAME), "rb"
+        ) as test_data_file:
             return pickle.load(test_data_file)
     except IOError as err:
         logger.warn("load_test_data IOError {}".format(err))

--- a/source/neuropods/python/utils/zip_loader.py
+++ b/source/neuropods/python/utils/zip_loader.py
@@ -11,11 +11,14 @@ import zipfile
 # Delete the created directories at process shutdown
 TO_CLEANUP = []
 
+
 def cleanup():
     for item in TO_CLEANUP:
         shutil.rmtree(item)
 
+
 atexit.register(cleanup)
+
 
 def extract_neuropod_if_necessary(path):
     if os.path.isdir(path):

--- a/source/neuropods/tests/test_data/pytorch_addition_model/0/code/addition_model.py
+++ b/source/neuropods/tests/test_data/pytorch_addition_model/0/code/addition_model.py
@@ -3,9 +3,7 @@ import torch.nn as nn
 
 class AdditionModel(nn.Module):
     def forward(self, x, y):
-        return {
-            "out": x + y
-        }
+        return {"out": x + y}
 
 
 def get_model(_):

--- a/source/neuropods/tests/test_data/pytorch_addition_model_gpu/0/code/addition_model.py
+++ b/source/neuropods/tests/test_data/pytorch_addition_model_gpu/0/code/addition_model.py
@@ -1,13 +1,12 @@
 import torch
 import torch.nn as nn
 
+
 class AdditionModel(nn.Module):
     def forward(self, x, y):
         x = torch.from_numpy(x).cuda(0)
         y = torch.from_numpy(y).cuda(0)
-        return {
-            "out": (x + y).cpu().numpy()
-        }
+        return {"out": (x + y).cpu().numpy()}
 
 
 def get_model(_):

--- a/source/neuropods/tests/test_data/pytorch_strings_model/0/code/strings_model.py
+++ b/source/neuropods/tests/test_data/pytorch_strings_model/0/code/strings_model.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -6,9 +5,7 @@ import torch.nn as nn
 
 class StringsModel(nn.Module):
     def forward(self, x, y):
-        return {
-            "out": np.array([f + " " + s for f, s in zip(x, y)])
-        }
+        return {"out": np.array([f + " " + s for f, s in zip(x, y)])}
 
 
 def get_model(_):

--- a/source/python/.flake8
+++ b/source/python/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore =
+    # https://github.com/psf/black#line-breaks--binary-operators
+    W503,
+    E231,
+    E501

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -1,11 +1,6 @@
 from setuptools import setup, find_packages
 
-REQUIRED_PACKAGES = [
-    "numpy<1.17.0",
-    "testpath",
-    "future",
-    "six"
-]
+REQUIRED_PACKAGES = ["numpy<1.17.0", "testpath", "typing", "future", "six"]
 
 setup(
     name="neuropods",


### PR DESCRIPTION
This PR reformats the python code in preparation for #229.

I tested locally to ensure that we pass `flake8` and `black` checks. Most of this PR was an automatic reformat using `black` (in addition to manual removal of some unused imports) so it should be safe to land once builds pass.