### PR TITLE
Reformat C++ code with clang-format

### DIFF
--- a/source/neuropods/backends/neuropod_backend.cc
+++ b/source/neuropods/backends/neuropod_backend.cc
@@ -3,13 +3,13 @@
 //
 
 #include "neuropods/backends/neuropod_backend.hh"
-#include "neuropods/internal/neuropod_loader.hh"
 
+#include "neuropods/internal/neuropod_loader.hh"
 
 namespace neuropods
 {
 
-NeuropodBackend::NeuropodBackend() = default;
+NeuropodBackend::NeuropodBackend()  = default;
 NeuropodBackend::~NeuropodBackend() = default;
 
 NeuropodBackend::NeuropodBackend(const std::string &neuropod_path)
@@ -17,7 +17,8 @@ NeuropodBackend::NeuropodBackend(const std::string &neuropod_path)
     loader_ = get_loader(neuropod_path);
 }
 
-std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs)
+std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap &        inputs,
+                                                         const std::vector<std::string> &requested_outputs)
 {
     // We're not doing any filtering
     if (requested_outputs.size() == 0)
@@ -27,7 +28,7 @@ std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap 
 
     // Run inference and get all the outputs
     auto data = infer(inputs);
-    auto out = stdx::make_unique<NeuropodValueMap>();
+    auto out  = stdx::make_unique<NeuropodValueMap>();
 
     // Filter to the requested outputs
     for (const auto &tensor_name : requested_outputs)

--- a/source/neuropods/backends/neuropod_backend.hh
+++ b/source/neuropods/backends/neuropod_backend.hh
@@ -41,7 +41,8 @@ public:
     // Run inference and get a subset of the outputs
     // The default implementation runs inference, gets all the outputs, and then filters the outputs
     // Backends can override this to more efficiently generate only the requested outputs
-    virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs);
+    virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
+                                                    const std::vector<std::string> &requested_outputs);
 
 protected:
     // Used to load files in a Neuropod

--- a/source/neuropods/backends/python_bridge/python_bridge.cc
+++ b/source/neuropods/backends/python_bridge/python_bridge.cc
@@ -45,19 +45,19 @@ std::unique_ptr<py::gil_scoped_release> maybe_initialize()
         return nullptr;
     }
 
-    #ifndef __APPLE__
-    // This binary is already linked against `libpython`; the dlopen just
-    // promotes it to RTLD_GLOBAL.
-    #define STR_HELPER(x) #x
-    #define STR(x) STR_HELPER(x)
-    #define PYTHON_LIB_NAME "libpython" STR(PYTHON_VERSION) ".so"
+#ifndef __APPLE__
+// This binary is already linked against `libpython`; the dlopen just
+// promotes it to RTLD_GLOBAL.
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+#define PYTHON_LIB_NAME "libpython" STR(PYTHON_VERSION) ".so"
     void *libpython = dlopen(PYTHON_LIB_NAME, RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
 
     if (libpython == nullptr)
     {
         NEUROPOD_ERROR("Failed to promote libpython to RTLD_GLOBAL. Error from dlopen: " << dlerror());
     }
-    #endif
+#endif
 
     // If we have a virtualenv, use it
     if (auto venv_path = std::getenv("VIRTUAL_ENV"))

--- a/source/neuropods/backends/tensor_allocator.hh
+++ b/source/neuropods/backends/tensor_allocator.hh
@@ -89,12 +89,12 @@ public:
         // Note: This is intended to be used in tests and therefore is not optimized for performance
 
         // Compute the size and allocate a tensor
-        int64_t size = std::ceil((end - start) / static_cast<double>(step));
-        auto tensor = allocate_tensor<T>({size});
+        int64_t size   = std::ceil((end - start) / static_cast<double>(step));
+        auto    tensor = allocate_tensor<T>({size});
 
         // Fill the tensor
-        auto data_ptr    = tensor->get_raw_data_ptr();
-        const auto numel = tensor->get_num_elements();
+        auto       data_ptr = tensor->get_raw_data_ptr();
+        const auto numel    = tensor->get_num_elements();
         for (int i = 0, val = 0; i < numel; i++, val += step)
         {
             data_ptr[i] = start + val;
@@ -119,8 +119,8 @@ public:
         // Note: This is intended to be used in tests and therefore is not optimized for performance
 
         auto smallest_dim = std::min(M, N);
-        auto tensor = zeros<T>({M, N});
-        auto accessor = tensor->template accessor<2>();
+        auto tensor       = zeros<T>({M, N});
+        auto accessor     = tensor->template accessor<2>();
 
         for (int i = 0; i < smallest_dim; i++)
         {
@@ -141,13 +141,13 @@ public:
         auto tensor = allocate_tensor<T>(input_dims);
 
         // Setup random number generation
-        std::random_device rd;
-        std::mt19937 gen(rd());
+        std::random_device          rd;
+        std::mt19937                gen(rd());
         std::normal_distribution<T> d(mean, stddev);
 
         // Fill the tensor with random numbers
-        auto data_ptr    = tensor->get_raw_data_ptr();
-        const auto numel = tensor->get_num_elements();
+        auto       data_ptr = tensor->get_raw_data_ptr();
+        const auto numel    = tensor->get_num_elements();
         for (int i = 0; i < numel; i++)
         {
             data_ptr[i] = d(gen);

--- a/source/neuropods/backends/tensorflow/tf_backend.cc
+++ b/source/neuropods/backends/tensorflow/tf_backend.cc
@@ -8,11 +8,12 @@
 
 #include <json/json.h>
 
-#include <dlfcn.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+
+#include <dlfcn.h>
 
 namespace neuropods
 {
@@ -102,7 +103,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &        
 {
 #ifndef __APPLE__
     // We need to do this so the custom ops can see the symbols from TF
-    void * libtensorflow = dlopen("libtensorflow_framework.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
+    void *libtensorflow = dlopen("libtensorflow_framework.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
     if (libtensorflow == nullptr)
     {
         NEUROPOD_ERROR("Failed to promote libtensorflow to RTLD_GLOBAL. Error from dlopen: " << dlerror());
@@ -126,7 +127,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &        
 
     // Setup the nodename mapping and get the init ops (if any)
     std::vector<std::string> init_ops;
-    auto config_stream = loader_->get_istream_for_file("0/config.json");
+    auto                     config_stream = loader_->get_istream_for_file("0/config.json");
     setup_node_mapping_and_init_ops(*config_stream, node_name_mapping_, init_ops);
 
     // Get a list of the output nodes
@@ -234,7 +235,8 @@ std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer(const Neuropo
 }
 
 // Run inference with a set of requested outputs
-std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs)
+std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer(const NeuropodValueMap &        inputs,
+                                                                   const std::vector<std::string> &requested_outputs)
 {
     // Get the set of outputs we want to compute
     const auto &output_names = requested_outputs.size() > 0 ? requested_outputs : output_names_;

--- a/source/neuropods/backends/tensorflow/tf_backend.hh
+++ b/source/neuropods/backends/tensorflow/tf_backend.hh
@@ -57,7 +57,8 @@ public:
     std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
 
     // Run inference with a set of requested outputs
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
+                                            const std::vector<std::string> &requested_outputs);
 };
 
 } // namespace neuropods

--- a/source/neuropods/backends/torchscript/torch_backend.cc
+++ b/source/neuropods/backends/torchscript/torch_backend.cc
@@ -175,7 +175,7 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &           neuropo
 
     if (!model_)
     {
-      NEUROPOD_ERROR("Failed to load TorchScript graph for neuropod" << neuropod_path.c_str());
+        NEUROPOD_ERROR("Failed to load TorchScript graph for neuropod" << neuropod_path.c_str());
     }
 
     for (const auto &tensor_spec : model_config->outputs)

--- a/source/neuropods/bindings/neuropods_native.cc
+++ b/source/neuropods/bindings/neuropods_native.cc
@@ -103,12 +103,10 @@ std::unique_ptr<Neuropod> make_neuropod(py::kwargs kwargs, Params &&... params)
 PYBIND11_MODULE(neuropods_native, m)
 {
     py::class_<Neuropod>(m, "Neuropod")
-        .def(py::init([](const std::string &path, py::kwargs kwargs) {
-            return make_neuropod(kwargs, path);
-        }))
-        .def(py::init([](const std::string &path, const std::unordered_map<std::string, std::string> &default_backend_overrides, py::kwargs kwargs) {
-            return make_neuropod(kwargs, path, default_backend_overrides);
-        }))
+        .def(py::init([](const std::string &path, py::kwargs kwargs) { return make_neuropod(kwargs, path); }))
+        .def(py::init([](const std::string &                                 path,
+                         const std::unordered_map<std::string, std::string> &default_backend_overrides,
+                         py::kwargs kwargs) { return make_neuropod(kwargs, path, default_backend_overrides); }))
         .def(py::init([](const std::string &path, const std::string &backend_name, py::kwargs kwargs) {
             return make_neuropod(kwargs, path, backend_name);
         }))
@@ -119,10 +117,12 @@ PYBIND11_MODULE(neuropods_native, m)
           &deserialize_tensor_binding,
           "Deserialize a string of bytes to a NeuropodTensor (and return it as a numpy array)");
 
-    m.def("serialize", &serialize_valuemap_binding, "Convert a dict of numpy arrays to a NeuropodValueMap and serialize it");
+    m.def("serialize",
+          &serialize_valuemap_binding,
+          "Convert a dict of numpy arrays to a NeuropodValueMap and serialize it");
     m.def("deserialize_dict",
-        &deserialize_valuemap_binding,
-        "Deserialize a string of bytes to a NeuropodValueMap (and return it as a dict of numpy arrays)");
+          &deserialize_valuemap_binding,
+          "Deserialize a string of bytes to a NeuropodValueMap (and return it as a dict of numpy arrays)");
 }
 
 } // namespace neuropods

--- a/source/neuropods/bindings/python_bindings.cc
+++ b/source/neuropods/bindings/python_bindings.cc
@@ -39,15 +39,12 @@ TensorType get_array_type(py::array &array)
 #undef IS_INSTANCE_CHECK
 }
 
-
 pybind11::dtype get_py_type(const NeuropodTensor &tensor)
 {
 #define GET_TYPE(CPP_TYPE, NEUROPOD_TYPE)       \
-    case NEUROPOD_TYPE:                         \
-    {                                           \
+    case NEUROPOD_TYPE: {                       \
         return pybind11::dtype::of<CPP_TYPE>(); \
     }
-
 
     const auto &tensor_type = tensor.get_tensor_type();
     switch (tensor_type)
@@ -101,7 +98,7 @@ std::shared_ptr<NeuropodTensor> tensor_from_numpy(NeuropodTensorAllocator &alloc
     // Capture the array in our deleter so it doesn't get deallocated
     // until we're done
     auto to_delete = std::make_shared<py::array>(array);
-    auto deleter = [to_delete](void *unused) mutable {
+    auto deleter   = [to_delete](void *unused) mutable {
         py::gil_scoped_acquire gil;
         to_delete.reset();
     };

--- a/source/neuropods/internal/logging.hh
+++ b/source/neuropods/internal/logging.hh
@@ -7,5 +7,5 @@
 // Don't disable any logging at compile time
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 
-#include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"
+#include "spdlog/spdlog.h"

--- a/source/neuropods/internal/neuropod_loader.cc
+++ b/source/neuropods/internal/neuropod_loader.cc
@@ -3,16 +3,18 @@
 //
 
 #include "neuropods/internal/neuropod_loader.hh"
-#include "neuropods/internal/memory_utils.hh"
+
 #include "neuropods/internal/error_utils.hh"
+#include "neuropods/internal/memory_utils.hh"
 
 #include <ghc/filesystem.hpp>
+
+#include <fstream>
+#include <iterator>
+#include <sstream>
+
 #include <picosha2.h>
 #include <unzipper.h>
-
-#include <iterator>
-#include <fstream>
-#include <sstream>
 
 namespace neuropods
 {
@@ -29,10 +31,7 @@ private:
     std::string neuropod_path_;
 
 public:
-    LocalLoader(const std::string &neuropod_path)
-        : neuropod_path_(neuropod_path)
-    {
-    }
+    LocalLoader(const std::string &neuropod_path) : neuropod_path_(neuropod_path) {}
 
     ~LocalLoader() = default;
 
@@ -54,10 +53,7 @@ public:
         return fs::absolute(neuropod_path_) / path;
     }
 
-    std::string ensure_local()
-    {
-        return neuropod_path_;
-    }
+    std::string ensure_local() { return neuropod_path_; }
 };
 
 // Loads a neuropod from a zipfile
@@ -73,10 +69,7 @@ private:
     std::string tempdir_;
 
 public:
-    ZipLoader(const std::string neuropod_path)
-        : unzipper_(neuropod_path), did_unzip_(false)
-    {
-    }
+    ZipLoader(const std::string neuropod_path) : unzipper_(neuropod_path), did_unzip_(false) {}
 
     ~ZipLoader()
     {
@@ -131,7 +124,7 @@ public:
 
         // Update metadata to make sure we cleanup
         did_unzip_ = true;
-        tempdir_ = tempdir;
+        tempdir_   = tempdir;
 
         return tempdir;
     }
@@ -144,9 +137,10 @@ NeuropodLoader::~NeuropodLoader() = default;
 // Get the SHA256 of a file
 std::string NeuropodLoader::get_hash_for_file(const std::string &path)
 {
-    auto stream = get_istream_for_file(path);
+    auto                       stream = get_istream_for_file(path);
     std::vector<unsigned char> hash(picosha2::k_digest_size);
-    picosha2::hash256(std::istreambuf_iterator<char>(*stream), std::istreambuf_iterator<char>(), hash.begin(), hash.end());
+    picosha2::hash256(
+        std::istreambuf_iterator<char>(*stream), std::istreambuf_iterator<char>(), hash.begin(), hash.end());
 
     return picosha2::bytes_to_hex_string(hash.begin(), hash.end());
 }

--- a/source/neuropods/internal/neuropod_loader.hh
+++ b/source/neuropods/internal/neuropod_loader.hh
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <string>
 #include <iostream>
 #include <memory>
+#include <string>
 
 namespace neuropods
 {

--- a/source/neuropods/internal/neuropod_tensor.cc
+++ b/source/neuropods/internal/neuropod_tensor.cc
@@ -56,10 +56,8 @@ bool NeuropodValue::operator==(const NeuropodValue &other) const
 {
     if (!is_tensor_ || !other.is_tensor_)
     {
-        NEUROPOD_ERROR(
-            "The equality operator is currently only defined for tensor types. "
-            "Tried to compare a value that is not a tensor."
-        );
+        NEUROPOD_ERROR("The equality operator is currently only defined for tensor types. "
+                       "Tried to compare a value that is not a tensor.");
     }
 
     return (*as_tensor()) == (*other.as_tensor());
@@ -86,14 +84,15 @@ bool NeuropodTensor::operator==(const NeuropodTensor &other) const
     if (get_tensor_type() == STRING_TENSOR)
     {
         // TODO(vip): optimize
-        return as_typed_tensor<std::string>()->get_data_as_vector() == other.as_typed_tensor<std::string>()->get_data_as_vector();
+        return as_typed_tensor<std::string>()->get_data_as_vector() ==
+               other.as_typed_tensor<std::string>()->get_data_as_vector();
     }
 
     // Compare the contents of the tensor
     const auto num_bytes = get_num_elements() * get_bytes_per_element();
 
-    const void * first  = get_untyped_data_ptr();
-    const void * second = other.get_untyped_data_ptr();
+    const void *first  = get_untyped_data_ptr();
+    const void *second = other.get_untyped_data_ptr();
 
     // Optimization for comparing tensors pointing to the same memory
     if (first == second)

--- a/source/neuropods/internal/neuropod_tensor.hh
+++ b/source/neuropods/internal/neuropod_tensor.hh
@@ -60,7 +60,7 @@ namespace internal
 // A struct used internally to work with NeuropodTensors
 struct NeuropodTensorRawDataAccess;
 
-}
+} // namespace internal
 
 // Base value type for Neuropod
 class NeuropodValue
@@ -257,7 +257,7 @@ public:
 
     virtual ~TypedNeuropodTensor() {}
 
-    T *get_raw_data_ptr() { return static_cast<T *>(get_untyped_data_ptr()); }
+    T *      get_raw_data_ptr() { return static_cast<T *>(get_untyped_data_ptr()); }
     const T *get_raw_data_ptr() const { return static_cast<const T *>(get_untyped_data_ptr()); }
 
     template <size_t N>
@@ -378,6 +378,7 @@ public:
         out << ']';
         return out;
     }
+
 protected:
     size_t get_bytes_per_element() const { return sizeof(T); }
 };
@@ -402,10 +403,7 @@ public:
 
 protected:
     // We can't get a raw pointer from a string tensor
-    void *get_untyped_data_ptr()
-    {
-        NEUROPOD_ERROR("`get_untyped_data_ptr` is not supported for string tensors");
-    };
+    void *get_untyped_data_ptr() { NEUROPOD_ERROR("`get_untyped_data_ptr` is not supported for string tensors"); };
 
     const void *get_untyped_data_ptr() const
     {
@@ -420,8 +418,7 @@ protected:
 
 // Utility to make a tensor of a specific type
 #define MAKE_TENSOR(CPP_TYPE, NEUROPOD_TYPE)                                              \
-    case NEUROPOD_TYPE:                                                                   \
-    {                                                                                     \
+    case NEUROPOD_TYPE: {                                                                 \
         return stdx::make_unique<TensorClass<CPP_TYPE>>(std::forward<Params>(params)...); \
     }
 

--- a/source/neuropods/internal/neuropod_tensor_raw_data_access.cc
+++ b/source/neuropods/internal/neuropod_tensor_raw_data_access.cc
@@ -12,12 +12,12 @@ namespace neuropods
 namespace internal
 {
 
-void * NeuropodTensorRawDataAccess::get_untyped_data_ptr(NeuropodTensor &tensor)
+void *NeuropodTensorRawDataAccess::get_untyped_data_ptr(NeuropodTensor &tensor)
 {
     return tensor.get_untyped_data_ptr();
 }
 
-const void * NeuropodTensorRawDataAccess::get_untyped_data_ptr(const NeuropodTensor &tensor)
+const void *NeuropodTensorRawDataAccess::get_untyped_data_ptr(const NeuropodTensor &tensor)
 {
     return tensor.get_untyped_data_ptr();
 }

--- a/source/neuropods/internal/neuropod_tensor_raw_data_access.hh
+++ b/source/neuropods/internal/neuropod_tensor_raw_data_access.hh
@@ -20,9 +20,9 @@ namespace internal
 // This should NOT be used externally
 struct NeuropodTensorRawDataAccess
 {
-    static void * get_untyped_data_ptr(NeuropodTensor &tensor);
+    static void *get_untyped_data_ptr(NeuropodTensor &tensor);
 
-    static const void * get_untyped_data_ptr(const NeuropodTensor &tensor);
+    static const void *get_untyped_data_ptr(const NeuropodTensor &tensor);
 
     static size_t get_bytes_per_element(const NeuropodTensor &tensor);
 };

--- a/source/neuropods/internal/neuropod_tensor_serialization.cc
+++ b/source/neuropods/internal/neuropod_tensor_serialization.cc
@@ -31,8 +31,7 @@ void serialize_tensor(const NeuropodTensor &tensor, boost::archive::binary_oarch
     {
         ar << boost::serialization::make_array(
             static_cast<const uint8_t *>(internal::NeuropodTensorRawDataAccess::get_untyped_data_ptr(tensor)),
-            tensor.get_num_elements() * internal::NeuropodTensorRawDataAccess::get_bytes_per_element(tensor)
-        );
+            tensor.get_num_elements() * internal::NeuropodTensorRawDataAccess::get_bytes_per_element(tensor));
     }
 }
 
@@ -54,9 +53,8 @@ std::shared_ptr<NeuropodTensor> deserialize_tensor(boost::archive::binary_iarchi
     else
     {
         ar >> boost::serialization::make_array(
-            static_cast<uint8_t *>(internal::NeuropodTensorRawDataAccess::get_untyped_data_ptr(*out)),
-            out->get_num_elements() * internal::NeuropodTensorRawDataAccess::get_bytes_per_element(*out)
-        );
+                  static_cast<uint8_t *>(internal::NeuropodTensorRawDataAccess::get_untyped_data_ptr(*out)),
+                  out->get_num_elements() * internal::NeuropodTensorRawDataAccess::get_bytes_per_element(*out));
     }
 
     return out;

--- a/source/neuropods/multiprocess/control_messages.cc
+++ b/source/neuropods/multiprocess/control_messages.cc
@@ -8,11 +8,14 @@ namespace neuropods
 {
 
 // Used to print out the enum names rather than just a number
-std::ostream& operator<<(std::ostream& out, const MessageType value)
+std::ostream &operator<<(std::ostream &out, const MessageType value)
 {
-    const char* s = 0;
-#define GENERATE_CASE(item) case(item): s = #item; break;
-    switch(value)
+    const char *s = 0;
+#define GENERATE_CASE(item) \
+    case (item):            \
+        s = #item;          \
+        break;
+    switch (value)
     {
         GENERATE_CASE(LOAD_NEUROPOD);
         GENERATE_CASE(ADD_INPUT);

--- a/source/neuropods/multiprocess/control_messages.hh
+++ b/source/neuropods/multiprocess/control_messages.hh
@@ -53,7 +53,7 @@ enum MessageType
 };
 
 // Used to print out the enum names rather than just a number
-std::ostream& operator<<(std::ostream& out, const MessageType value);
+std::ostream &operator<<(std::ostream &out, const MessageType value);
 
 // We can batch multiple tensors into a single message in order to minimize
 // communication overhead. This is the maximum number of tensors we can include

--- a/source/neuropods/multiprocess/multiprocess.cc
+++ b/source/neuropods/multiprocess/multiprocess.cc
@@ -33,11 +33,8 @@ namespace
 pid_t start_worker_process(const std::string &control_queue_name)
 {
     pid_t child_pid;
-    char * argv[] = {
-        const_cast<char*>("neuropod_multiprocess_worker"),
-        const_cast<char *>(control_queue_name.c_str()),
-        NULL
-    };
+    char *argv[] = {
+        const_cast<char *>("neuropod_multiprocess_worker"), const_cast<char *>(control_queue_name.c_str()), NULL};
 
     // Spawn a process
     const auto status = posix_spawnp(&child_pid, "neuropod_multiprocess_worker", NULL, NULL, argv, environ);

--- a/source/neuropods/multiprocess/tensor_utils.hh
+++ b/source/neuropods/multiprocess/tensor_utils.hh
@@ -2,8 +2,8 @@
 // Uber, Inc. (c) 2019
 //
 
-#include "neuropods/neuropods.hh"
 #include "neuropods/internal/neuropod_tensor_raw_data_access.hh"
+#include "neuropods/neuropods.hh"
 
 #include <iostream>
 #include <string>
@@ -24,7 +24,7 @@ std::shared_ptr<NeuropodTensor> wrap_existing_tensor(Neuropod &neuropod, std::sh
     //
     // In this case, we're capturing `tensor` in the deleter below. This ensures that the tensor
     // doesn't get deallocated until we're done with the new tensor.
-    const auto  deleter = [tensor](void *unused) {};
+    const auto  deleter     = [tensor](void *unused) {};
     const auto &tensor_type = tensor->get_tensor_type();
     if (tensor_type == STRING_TENSOR)
     {
@@ -55,7 +55,7 @@ std::shared_ptr<NeuropodTensor> wrap_existing_tensor(std::shared_ptr<NeuropodTen
     //
     // In this case, we're capturing `tensor` in the deleter below. This ensures that the tensor
     // doesn't get deallocated until we're done with the new tensor.
-    const auto  deleter = [tensor](void *unused) {};
+    const auto  deleter     = [tensor](void *unused) {};
     const auto &tensor_type = tensor->get_tensor_type();
     if (tensor_type == STRING_TENSOR)
     {

--- a/source/neuropods/neuropods.cc
+++ b/source/neuropods/neuropods.cc
@@ -42,7 +42,8 @@ Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBac
 
 Neuropod::~Neuropod() = default;
 
-std::unique_ptr<NeuropodValueMap> Neuropod::infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs)
+std::unique_ptr<NeuropodValueMap> Neuropod::infer(const NeuropodValueMap &        inputs,
+                                                  const std::vector<std::string> &requested_outputs)
 {
     // TODO(vip): make sure that names in `inputs` are not repeated
     // Run inference

--- a/source/neuropods/neuropods.hh
+++ b/source/neuropods/neuropods.hh
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "neuropods/version.hh"
 #include "neuropods/backends/neuropod_backend.hh"
 #include "neuropods/internal/config_utils.hh"
+#include "neuropods/version.hh"
 
 #include <memory>
 #include <string>
@@ -90,7 +90,8 @@ public:
     ~Neuropod();
 
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs = {});
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
+                                            const std::vector<std::string> &requested_outputs = {});
 
     // Get the inputs and outputs of the loaded Neuropod
     const std::vector<TensorSpec> &get_inputs() const;

--- a/source/neuropods/serialization/serialization.cc
+++ b/source/neuropods/serialization/serialization.cc
@@ -57,7 +57,7 @@ void serialize(boost::archive::binary_oarchive &out, const NeuropodValue &item)
     it->second(item, out);
 }
 
-template<>
+template <>
 std::shared_ptr<NeuropodValue> deserialize(boost::archive::binary_iarchive &ar, NeuropodTensorAllocator &allocator)
 {
     init_registrar_if_needed();
@@ -87,11 +87,11 @@ void serialize(boost::archive::binary_oarchive &out, const NeuropodValueMap &ite
     }
 }
 
-template<>
+template <>
 NeuropodValueMap deserialize(boost::archive::binary_iarchive &ar, NeuropodTensorAllocator &allocator)
 {
     NeuropodValueMap out;
-    int num_items;
+    int              num_items;
     ar >> num_items;
 
     for (int i = 0; i < num_items; i++)

--- a/source/neuropods/serialization/serialization.hh
+++ b/source/neuropods/serialization/serialization.hh
@@ -11,8 +11,8 @@
 
 #include <functional>
 #include <memory>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 namespace neuropods
 {
@@ -52,21 +52,21 @@ bool register_serializable(std::function<void(const T &, boost::archive::binary_
     return true;
 }
 
-template<typename ReturnType>
+template <typename ReturnType>
 ReturnType deserialize(boost::archive::binary_iarchive &ar, NeuropodTensorAllocator &allocator);
 
 // Serialize a NeuropodValue
 void serialize(boost::archive::binary_oarchive &out, const NeuropodValue &item);
 
 // Deserialize from an archive
-template<>
+template <>
 std::shared_ptr<NeuropodValue> deserialize(boost::archive::binary_iarchive &ar, NeuropodTensorAllocator &allocator);
 
 // Serialize a NeuropodValueMap
 void serialize(boost::archive::binary_oarchive &out, const NeuropodValueMap &item);
 
 // Deserialize a NeuropodValueMap from an archive
-template<>
+template <>
 NeuropodValueMap deserialize(boost::archive::binary_iarchive &ar, NeuropodTensorAllocator &allocator);
 
 } // namespace detail

--- a/source/neuropods/tests/benchmark_accessor.cc
+++ b/source/neuropods/tests/benchmark_accessor.cc
@@ -11,7 +11,7 @@ static void benchmark_raw(benchmark::State &state)
     neuropods::TestNeuropodBackend backend;
 
     auto allocator = backend.get_tensor_allocator();
-    auto tensor = allocator->allocate_tensor<float>({3, 5});
+    auto tensor    = allocator->allocate_tensor<float>({3, 5});
 
     auto data_ptr = tensor->get_raw_data_ptr();
 
@@ -34,7 +34,7 @@ static void benchmark_accessor(benchmark::State &state)
     neuropods::TestNeuropodBackend backend;
 
     auto allocator = backend.get_tensor_allocator();
-    auto tensor = allocator->allocate_tensor<float>({3, 5});
+    auto tensor    = allocator->allocate_tensor<float>({3, 5});
 
     auto accessor = tensor->accessor<2>();
 

--- a/source/neuropods/tests/benchmark_multiprocess.cc
+++ b/source/neuropods/tests/benchmark_multiprocess.cc
@@ -25,7 +25,6 @@ struct load_out_of_process
     }
 };
 
-
 } // namespace
 
 template <typename Loader>
@@ -54,7 +53,6 @@ void benchmark_object_detection(benchmark::State &state)
 
 BENCHMARK_TEMPLATE(benchmark_object_detection, load_in_process);
 BENCHMARK_TEMPLATE(benchmark_object_detection, load_out_of_process);
-
 
 template <typename Loader>
 void benchmark_small_inputs(benchmark::State &state)

--- a/source/neuropods/tests/test_backend_registration.cc
+++ b/source/neuropods/tests/test_backend_registration.cc
@@ -3,7 +3,6 @@
 //
 
 #include "gtest/gtest.h"
-
 #include "neuropods/internal/backend_registration.hh"
 
 namespace neuropods

--- a/source/neuropods/tests/test_conversions_eigen.cc
+++ b/source/neuropods/tests/test_conversions_eigen.cc
@@ -50,7 +50,7 @@ public:
         const_tensor = tensor;
 
         auto accessor = tensor->accessor<2>();
-        int i = 0;
+        int  i        = 0;
         for (size_t row = 0; row < untyped_tensor->get_dims()[0]; ++row)
         {
             for (size_t col = 0; col < untyped_tensor->get_dims()[1]; ++col)

--- a/source/neuropods/tests/test_factories.cc
+++ b/source/neuropods/tests/test_factories.cc
@@ -42,8 +42,8 @@ TEST(test_factories, test_factories)
     const std::vector<int64_t> dims      = {3, 4, 5};
 
     auto zeros = allocator->zeros<uint16_t>(dims);
-    auto ones = allocator->ones<int32_t>(dims);
-    auto full = allocator->full<double>(dims, 1.23);
+    auto ones  = allocator->ones<int32_t>(dims);
+    auto full  = allocator->full<double>(dims, 1.23);
     auto randn = allocator->randn<float>(dims);
 
     EXPECT_TRUE(is_full<uint16_t>(*zeros, 0, num_items));
@@ -68,17 +68,21 @@ TEST(test_factories, test_factories)
     EXPECT_TRUE(matches_expected(*range3, {0, 2, 4, 6, 8}));
 
     auto eye1 = allocator->eye<float>(4, 4);
+    // clang-format off
     EXPECT_TRUE(matches_expected(*eye1, {
         1, 0, 0, 0,
         0, 1, 0, 0,
         0, 0, 1, 0,
         0, 0, 0, 1
     }));
+    // clang-format on
 
     auto eye2 = allocator->eye<float>(3, 7);
+    // clang-format off
     EXPECT_TRUE(matches_expected(*eye2, {
         1, 0, 0, 0, 0, 0, 0,
         0, 1, 0, 0, 0, 0, 0,
         0, 0, 1, 0, 0, 0, 0
     }));
+    // clang-format on
 }

--- a/source/neuropods/tests/test_internal_neuropod_tensor.cc
+++ b/source/neuropods/tests/test_internal_neuropod_tensor.cc
@@ -76,7 +76,7 @@ TEST(test_stream_operator, typed_tensor)
     auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({3}, neuropods::UINT8_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<uint8_t>();
-    auto accessor = typed_tensor.accessor<1>();
+    auto  accessor     = typed_tensor.accessor<1>();
 
     accessor[0] = 10;
     accessor[1] = 11;
@@ -95,7 +95,7 @@ TEST(test_stream_operator, typed_float_tensor)
     auto untyped_tensor = test_backend.get_tensor_allocator()->allocate_tensor({TENSOR_SIZE}, neuropods::FLOAT_TENSOR);
 
     auto &typed_tensor = *untyped_tensor->as_typed_tensor<float>();
-    auto accessor = typed_tensor.accessor<1>();
+    auto  accessor     = typed_tensor.accessor<1>();
 
     for (int i = 0; i < TENSOR_SIZE; ++i)
     {

--- a/source/neuropods/tests/test_loader.cc
+++ b/source/neuropods/tests/test_loader.cc
@@ -3,11 +3,11 @@
 //
 
 #include "gtest/gtest.h"
-
 #include "neuropods/internal/neuropod_loader.hh"
 
 TEST(test_loader, test_sha)
 {
     auto loader = neuropods::get_loader("neuropods/tests/test_data/pytorch_addition_model/");
-    EXPECT_EQ(loader->get_hash_for_file("0/data/random_content"), "9ac0d09c343ccce2f317fc395d6253f6e3531cc863acbda09e90c7ecdafa5b10");
+    EXPECT_EQ(loader->get_hash_for_file("0/data/random_content"),
+              "9ac0d09c343ccce2f317fc395d6253f6e3531cc863acbda09e90c7ecdafa5b10");
 }

--- a/source/neuropods/tests/test_serialization.cc
+++ b/source/neuropods/tests/test_serialization.cc
@@ -101,20 +101,23 @@ TEST(test_allocate_tensor, neuropod_value_map)
 
     auto allocator = backend.get_tensor_allocator();
 
-    const std::shared_ptr<neuropods::NeuropodValue> float_tensor_1D = allocator->allocate_tensor({3}, neuropods::FLOAT_TENSOR);
+    const std::shared_ptr<neuropods::NeuropodValue> float_tensor_1D =
+        allocator->allocate_tensor({3}, neuropods::FLOAT_TENSOR);
     float_tensor_1D->as_typed_tensor<float>()->copy_from({0.0, 0.1, 0.2});
 
-    const std::shared_ptr<neuropods::NeuropodValue> string_tensor_2D = allocator->allocate_tensor({2, 2}, neuropods::STRING_TENSOR);
+    const std::shared_ptr<neuropods::NeuropodValue> string_tensor_2D =
+        allocator->allocate_tensor({2, 2}, neuropods::STRING_TENSOR);
     string_tensor_2D->as_typed_tensor<std::string>()->set({"A", "B", "C", "D"});
 
-    const std::shared_ptr<neuropods::NeuropodValue> int_tensor_2D = allocator->allocate_tensor({2, 3}, neuropods::INT32_TENSOR);
+    const std::shared_ptr<neuropods::NeuropodValue> int_tensor_2D =
+        allocator->allocate_tensor({2, 3}, neuropods::INT32_TENSOR);
     int_tensor_2D->as_typed_tensor<int32_t>()->copy_from({0, 1, 2, 3, 4, 5});
 
     // Create a map
     neuropods::NeuropodValueMap data;
-    data["int"] = int_tensor_2D;
+    data["int"]    = int_tensor_2D;
     data["string"] = string_tensor_2D;
-    data["float"] = float_tensor_1D;
+    data["float"]  = float_tensor_1D;
 
     // Serialize the map
     std::stringstream ss;

--- a/source/neuropods/tests/test_shm_tensor.cc
+++ b/source/neuropods/tests/test_shm_tensor.cc
@@ -54,7 +54,7 @@ TEST(test_shm_tensor, simple)
         uint8_t expected_data[num_items];
         std::fill_n(expected_data, num_items, i);
 
-        auto          actual_data              = tensor->as_typed_tensor<uint8_t>()->get_raw_data_ptr();
+        auto actual_data = tensor->as_typed_tensor<uint8_t>()->get_raw_data_ptr();
         EXPECT_EQ(memcmp(actual_data, expected_data, num_items * sizeof(uint8_t)), 0);
     }
 }

--- a/source/neuropods/tests/test_test_backend.cc
+++ b/source/neuropods/tests/test_test_backend.cc
@@ -3,16 +3,16 @@
 //
 
 #include "gtest/gtest.h"
-
-#include "neuropods/neuropods.hh"
 #include "neuropods/backends/test_backend/test_neuropod_backend.hh"
 #include "neuropods/internal/memory_utils.hh"
+#include "neuropods/neuropods.hh"
 
 TEST(test_test_backend, init)
 {
     // Make sure we can load a neuropod with garbage data and run inference without crashing
-    auto config = neuropods::stdx::make_unique<neuropods::ModelConfig>(neuropods::ModelConfig{"name", "platform", {}, {}, {}, {}});
+    auto config = neuropods::stdx::make_unique<neuropods::ModelConfig>(
+        neuropods::ModelConfig{"name", "platform", {}, {}, {}, {}});
     neuropods::TestNeuropodBackend backend("somepath", config, {});
-    neuropods::NeuropodValueMap inputs;
+    neuropods::NeuropodValueMap    inputs;
     backend.infer(inputs);
 }


### PR DESCRIPTION
This PR reformats the C++ code in preparation for #229 

The changes here are entirely an automatic reformat using
```
find -name *.hh -o -name *.cc | xargs -L1 clang-format -style=file -i
```

so it should be safe to land once builds pass.