### PR TITLE
Add local lint and autofix scripts

### DIFF
--- a/tools/autofix.sh
+++ b/tools/autofix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# This script attempts to autofix lint errors
+
+pushd source
+
+# Reformat with clang-format
+find . -name "*.hh" -o -name "*.cc" | xargs -L1 clang-format -style=file -i
+
+pushd python
+
+# Run black
+black -t py27 -t py35 -t py36 neuropods
+
+# Run autopep8 to fix errors for flake8
+autopep8 -r --in-place neuropods
+
+popd
+popd

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# This script runs local lint tools
+# Does not run more heavyweight tools like infer or clang-tidy
+
+# Get run-clang-format if necessary
+if [ ! -f "/tmp/run-clang-format.py" ]; then
+    wget https://raw.githubusercontent.com/Sarcasm/run-clang-format/de6e8ca07d171a7f378d379ff252a00f2905e81d/run-clang-format.py -O /tmp/run-clang-format.py
+fi
+
+pushd source
+
+# Run clang-format
+python /tmp/run-clang-format.py -r .
+
+pushd python
+
+# Run black in check mode
+black --check -t py27 -t py35 -t py36 --diff neuropods
+
+# Run flake8
+flake8 neuropods
+
+popd
+popd


### PR DESCRIPTION
These scripts assume the user has `black`, `clang-format`, `flake8`, and `autopep8` installed locally.