### PR TITLE
Mark get_tensor_type_from_cpp as inline

### DIFF
--- a/source/neuropods/internal/neuropod_tensor.hh
+++ b/source/neuropods/internal/neuropod_tensor.hh
@@ -26,13 +26,13 @@ namespace
 
 // Utility to get a neuropod tensor type from a c++ type
 template <typename T>
-TensorType get_tensor_type_from_cpp() = delete;
+inline TensorType get_tensor_type_from_cpp() = delete;
 
-#define GET_TENSOR_TYPE_FN(CPP_TYPE, NEUROPOD_TYPE)                 \
-    template <>                                                     \
-    [[gnu::unused]] TensorType get_tensor_type_from_cpp<CPP_TYPE>() \
-    {                                                               \
-        return NEUROPOD_TYPE;                                       \
+#define GET_TENSOR_TYPE_FN(CPP_TYPE, NEUROPOD_TYPE)        \
+    template <>                                            \
+    inline TensorType get_tensor_type_from_cpp<CPP_TYPE>() \
+    {                                                      \
+        return NEUROPOD_TYPE;                              \
     }
 
 FOR_EACH_TYPE_MAPPING_INCLUDING_STRING(GET_TENSOR_TYPE_FN)


### PR DESCRIPTION
Previously, `get_tensor_type_from_cpp` was marked as `[[gnu::unused]]` even though it can be used. This can cause a build warning in user code.

Since we're not building with C++17, we don't have `[[maybe_unused]]` available so we mark this (tiny) function as inline instead.