### PR TITLE
Don't load the same custom op multiple times

### DIFF
--- a/source/neuropods/python/tests/custom_ops/tensorflow/test_tensorflow_custom_ops.py
+++ b/source/neuropods/python/tests/custom_ops/tensorflow/test_tensorflow_custom_ops.py
@@ -3,6 +3,7 @@
 #
 
 import os
+import shutil
 import subprocess
 import sys
 import tensorflow as tf
@@ -60,6 +61,10 @@ class TestTensorflowCustomOps(unittest.TestCase):
         )
         cls.custom_op_path = os.path.join(current_dir, "addition_op.so")
 
+        # For testing loading of a custom op multiple times
+        cls.second_custom_op = os.path.join(current_dir, "addition_op_copy.so")
+        shutil.copyfile(cls.custom_op_path, cls.second_custom_op)
+
     def package_simple_addition_model(self, do_fail=False):
         with TemporaryDirectory() as test_dir:
             neuropod_path = os.path.join(test_dir, "test_neuropod")
@@ -76,7 +81,7 @@ class TestTensorflowCustomOps(unittest.TestCase):
                     "y": "some_namespace/in_y:0",
                     "out": "some_namespace/out:0",
                 },
-                custom_ops=[self.custom_op_path],
+                custom_ops=[self.custom_op_path, self.second_custom_op],
                 # Get the input/output spec along with test data
                 **get_addition_model_spec(do_fail=do_fail)
             )

--- a/source/neuropods/python/tests/custom_ops/torchscript/test_torchscript_custom_ops.py
+++ b/source/neuropods/python/tests/custom_ops/torchscript/test_torchscript_custom_ops.py
@@ -4,6 +4,7 @@
 
 import glob
 import os
+import shutil
 import subprocess
 import sys
 import torch
@@ -34,6 +35,10 @@ class TestTorchScriptCustomOps(unittest.TestCase):
             os.path.join(current_dir, "build", "lib*", "addition_op.so")
         )[0]
 
+        # For testing loading of a custom op multiple times
+        cls.second_custom_op = os.path.join(current_dir, "addition_op_copy.so")
+        shutil.copyfile(cls.custom_op_path, cls.second_custom_op)
+
         # Load the op
         torch.ops.load_library(cls.custom_op_path)
 
@@ -49,7 +54,7 @@ class TestTorchScriptCustomOps(unittest.TestCase):
                     neuropod_path=neuropod_path,
                     model_name="addition_model",
                     module=model(),
-                    custom_ops=[self.custom_op_path],
+                    custom_ops=[self.custom_op_path, self.second_custom_op],
                     # Get the input/output spec along with test data
                     **get_addition_model_spec(do_fail=do_fail)
                 )

--- a/source/neuropods/python/utils/hash_utils.py
+++ b/source/neuropods/python/utils/hash_utils.py
@@ -1,0 +1,13 @@
+import hashlib
+
+# From https://stackoverflow.com/a/44873382
+
+
+def sha256sum(filename):
+    h = hashlib.sha256()
+    b = bytearray(128 * 1024)
+    mv = memoryview(b)
+    with open(filename, "rb", buffering=0) as f:
+        for n in iter(lambda: f.readinto(mv), 0):
+            h.update(mv[:n])
+    return h.hexdigest()


### PR DESCRIPTION
If multiple models that contain the same custom op are loaded into the same process, the op will be registered multiple times and cause the underlying framework to throw an error.

To avoid this, we compute the sha256 of every custom op we load and do not load the op if we've previously loaded it.

This is not ideal, but it is a generic solution that does not require using out of process execution for every model.