### PR TITLE
Fix Travis CI builds

### DIFF
--- a/build/ci/travis_build.sh
+++ b/build/ci/travis_build.sh
@@ -7,6 +7,19 @@ NEUROPODS_PYTHON_BINARY="${NEUROPODS_PYTHON_BINARY:-python}"
 # Install system dependencies
 ./build/install_system_deps.sh
 
+# Mac and Travis CI specific deps
+if [[ $(uname -s) == 'Darwin' ]]; then
+    # Install python 3.6 (Newest version of py3 that supports TF 1.12.0)
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    brew unlink python
+    wget https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg &> /dev/null
+    sudo installer -pkg python-3.6.8-macosx10.9.pkg -target /
+
+    # Install libomp 5
+    brew unlink libomp
+    brew install https://homebrew.bintray.com/bottles/libomp-5.0.1.high_sierra.bottle.tar.gz
+fi
+
 # Do everything in a virtualenv
 sudo ${NEUROPODS_PYTHON_BINARY} -m pip install virtualenv
 ${NEUROPODS_PYTHON_BINARY} -m virtualenv /tmp/neuropod_venv


### PR DESCRIPTION
Two changes happened over the last few weeks that break the macOS Travis CI build:
- The default Python 3 version on Homebrew is now Python 3.7. There is no prebuilt TensorFlow 1.12.0 wheel for Python 3.7 so installation fails
- `brew install libomp` no longer installs libomp 5 (which is needed by PyTorch)

To fix this, we explicitly install Python 3.6 and libomp 5 in the Travis build script