### PR TITLE
[TF] Fix performance regression

### DIFF
--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -28,11 +28,18 @@ class TensorflowNeuropodBackend : public NeuropodBackendWithDefaultAllocator<Ten
 private:
     std::unique_ptr<tensorflow::Session> session_;
 
+    // Cached access to callable handles
+    std::unordered_map<std::string, int64_t> callable_handle_cache_;
+
     // Map from a neuropod node name to the appropriate node in the TF graph
     std::unordered_map<std::string, std::string> node_name_mapping_;
 
     // The outputs of the model. This is from the neuropod model config
     std::vector<std::string> output_names_;
+
+    // Get a callable given feeds and fetches
+    // This will try to use a cached one if possible
+    int64_t get_callable(const std::vector<std::string> &tensor_feeds, const std::vector<std::string> &tensor_fetches);
 
 public:
     explicit TensorflowNeuropodBackend(const std::string &           neuropod_path,


### PR DESCRIPTION
In #239 we switched from using `session_->Run` to `session_->RunCallable`.

As part of this, we also used `MakeCallable` and `ReleaseCallable` in every inference call. Other TF functions including `Run` do caching internally for repeated calls with the same inputs (see [here](https://github.com/tensorflow/tensorflow/blob/r1.2/tensorflow/core/common_runtime/direct_session.cc#L980)), but `MakeCallable` does not.

It finds a subgraph and does optimization passes internally for every call.

To fix this, we cache handles returned by `MakeCallable` and release them in the destructor of `TensorflowNeuropodBackend`

## Context

This issue was found when I was rebasing #212. I noticed that the baselines on master were roughly 10x slower than the baselines in that PR. After some profiling, I found the problem and created this PR to fix it.

This exposes a general problem of not gating on benchmarks in CI. When we have done this in the past, CI variance caused many false positives, but it may be a good idea to have very generous thresholds to catch large regressions like this.

I'll create an issue about this with more details.