### PR TITLE
Asynchronously cleanup control channels for out-of-process execution

### DIFF
--- a/build/allowed_deps.txt
+++ b/build/allowed_deps.txt
@@ -12,4 +12,5 @@
  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libtbb.so.2]
  0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]

--- a/build/set_build_env.sh
+++ b/build/set_build_env.sh
@@ -5,6 +5,7 @@ set -e
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-bin/neuropod/backends/python_bridge/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-bin/neuropod/backends/torchscript/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-bin/neuropod/backends/tensorflow/
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/bazel-bin/neuropod/
 
 # The worker process for the multiprocess backend needs to be on the path
 export PATH=$PATH:`pwd`/bazel-bin/neuropod/multiprocess/

--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -138,3 +138,19 @@ http_archive(
     url = "https://github.com/gabime/spdlog/archive/v1.4.2.zip",
     strip_prefix = "spdlog-1.4.2",
 )
+
+http_archive(
+    name = "tbb_linux_repo",
+    build_file = "@//deps:BUILD.tbb",
+    sha256 = "3b23e3ed546c76dbd371295afc6811dd150fab7ee7a63b0a21c89ffb5a1dd452",
+    url = "https://github.com/intel/tbb/releases/download/v2020.0/tbb-2020.0-lin.tgz",
+    strip_prefix = "tbb",
+)
+
+http_archive(
+    name = "tbb_mac_repo",
+    build_file = "@//deps:BUILD.tbb",
+    sha256 = "7133827638806a5eaf977c08999e861a9a6ad44ebc595c8c0d83198a7652b664",
+    url = "https://github.com/intel/tbb/releases/download/v2020.0/tbb-2020.0-mac.tgz",
+    strip_prefix = "tbb",
+)

--- a/source/deps/BUILD.tbb
+++ b/source/deps/BUILD.tbb
@@ -1,0 +1,26 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "tbb",
+    srcs = glob([
+        "lib/intel64/gcc4.8/libtbb.so.2",
+        "lib/libtbb.dylib",
+    ]),
+    hdrs = glob(["include/**"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tbb_libs",
+    srcs = glob([
+        "lib/intel64/gcc4.8/libtbb.so.2",
+        "lib/libtbb.dylib",
+    ]),
+)

--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -3,6 +3,7 @@
 #
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("//bazel:copy_libs.bzl", "copy_libs")
 
 cc_library(
     name = "neuropod_hdrs",
@@ -39,7 +40,18 @@ cc_binary(
         "//neuropod/internal:tensor_serialization_impl",
         "//neuropod/multiprocess:multiprocess_impl",
         "//neuropod/serialization:serialization_impl",
-    ]
+    ],
+    data = [
+        ":copy_tbb"
+    ],
+)
+
+copy_libs(
+    name = "copy_tbb",
+    libs = select({
+        "@bazel_tools//src/conditions:darwin": "@tbb_mac_repo//:tbb_libs",
+        "//conditions:default": "@tbb_linux_repo//:tbb_libs",
+    }),
 )
 
 pkg_tar(
@@ -62,7 +74,10 @@ pkg_tar(
     package_dir = "lib/",
     srcs = [
         ":libneuropod.so",
-    ]
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": ["@tbb_mac_repo//:tbb_libs"],
+        "//conditions:default": ["@tbb_linux_repo//:tbb_libs"],
+    }),
 )
 
 pkg_tar(

--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -125,5 +125,8 @@ cc_library(
         "//neuropod/backends:neuropod_backend",
         "//neuropod/internal:deleter",
         "@boost_repo//:boost",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": ["@tbb_mac_repo//:tbb"],
+        "//conditions:default": ["@tbb_linux_repo//:tbb"],
+    }),
 )

--- a/source/neuropod/multiprocess/ipc_control_channel.cc
+++ b/source/neuropod/multiprocess/ipc_control_channel.cc
@@ -185,11 +185,21 @@ bool IPCControlChannel::recv_message(control_message &received, size_t timeout_m
     return successful_read;
 }
 
+std::string IPCControlChannel::get_control_queue_name()
+{
+    return control_queue_name_;
+}
+
 void IPCControlChannel::cleanup()
 {
+    IPCControlChannel::cleanup(control_queue_name_);
+}
+
+void IPCControlChannel::cleanup(const std::string &control_queue_name)
+{
     // Delete the control channels
-    ipc::message_queue::remove(("neuropod_" + control_queue_name_ + "_tw").c_str());
-    ipc::message_queue::remove(("neuropod_" + control_queue_name_ + "_fw").c_str());
+    ipc::message_queue::remove(("neuropod_" + control_queue_name + "_tw").c_str());
+    ipc::message_queue::remove(("neuropod_" + control_queue_name + "_fw").c_str());
 }
 
 } // namespace neuropod

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -72,6 +72,12 @@ public:
 
     // Cleanup the message queues
     void cleanup();
+
+    // Get the control queue name
+    std::string get_control_queue_name();
+
+    // Cleanup the message queues
+    static void cleanup(const std::string &control_queue_name);
 };
 
 } // namespace neuropod


### PR DESCRIPTION
This PR adds a dependency on TBB and uses a TBB `task_group` for asynchronous cleanup of control channels when destructing a `MultiprocessNeuropodBackend`. This lets us avoid blocking while we wait for worker processes to terminate.

This change saves us ~60 seconds when running Python tests with native bindings