### PR TITLE
[TF] Fix regression caused by incorrect caching of callables

### DIFF
--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -7,6 +7,7 @@
 #include "neuropod/backends/neuropod_backend.hh"
 #include "neuropod/backends/tensorflow/tf_tensor.hh"
 
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,8 +15,9 @@
 namespace tensorflow
 {
 
-// Forward declare tensorflow::Session
+// Forward declare tensorflow::Session and tensorflow::Tensor
 class Session;
+class Tensor;
 
 } // namespace tensorflow
 
@@ -39,7 +41,8 @@ private:
 
     // Get a callable given feeds and fetches
     // This will try to use a cached one if possible
-    int64_t get_callable(const std::vector<std::string> &tensor_feeds, const std::vector<std::string> &tensor_fetches);
+    int64_t get_callable(const std::map<std::string, tensorflow::Tensor> &tensor_feeds,
+                         const std::map<std::string, std::string> &       tensor_fetches);
 
 public:
     explicit TensorflowNeuropodBackend(const std::string &           neuropod_path,


### PR DESCRIPTION
Fixes #252

When running a TF subgraph, we use callables. These let you run parts of the graph given inputs and a set of outputs.

Previously, it was possible for us to get a TF callable from our cache that had the same inputs and outputs as our current requested callable, but with a different order. Our caching code handled this, but the rest of the inference code didn't.

If the cache returned a callable that had the inputs in a different order than our request, it was possible for the input tensors to be passed in an incorrect order when calling `RunCallable`. A similar issue was theoretically possible with the outputs. This PR resolves both issues.

I'll follow up with another PR that streamlines the code a bit more.

### Test plan:
Before this PR, I was able to reproduce the issue using the test provided in #252
After applying the PR, the issue is resolved.

(The test from #252 is not included in this PR and will be landed separately)