### PR TITLE
[OPE] Pass requested outputs to the worker process

### DIFF
--- a/source/neuropod/multiprocess/control_messages.cc
+++ b/source/neuropod/multiprocess/control_messages.cc
@@ -20,6 +20,7 @@ std::ostream &operator<<(std::ostream &out, const MessageType value)
         GENERATE_CASE(LOAD_NEUROPOD);
         GENERATE_CASE(ADD_INPUT);
         GENERATE_CASE(INFER);
+        GENERATE_CASE(REQUEST_OUTPUT);
         GENERATE_CASE(RETURN_OUTPUT);
         GENERATE_CASE(END_OUTPUT);
         GENERATE_CASE(INFER_COMPLETE);

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -19,8 +19,13 @@ enum MessageType
     LOAD_NEUROPOD,
 
     // Sent by the main process when passing tensors to the worker process
-    // Valid next messages: ADD_INPUT, INFER
+    // Valid next messages: ADD_INPUT, REQUEST_OUTPUT, INFER
     ADD_INPUT,
+
+    // Sent by the main process to the worker process to request a subset
+    // of the outputs
+    // Valid next messages: REQUEST_OUTPUT, INFER
+    REQUEST_OUTPUT,
 
     // Sent by the main process once all inputs have been added and we're ready
     // to run inference
@@ -81,7 +86,7 @@ struct __attribute__((__packed__)) control_message
     // Only used if the message type is ADD_INPUT or RETURN_OUTPUT
     char tensor_id[MAX_NUM_TENSORS_PER_MESSAGE][24];
 
-    // Only used if the message type is ADD_INPUT or RETURN_OUTPUT
+    // Only used if the message type is ADD_INPUT, REQUEST_OUTPUT, or RETURN_OUTPUT
     char tensor_name[MAX_NUM_TENSORS_PER_MESSAGE][256];
 
     // Linux defines the max path length as 4096 (including a NULL char)

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -60,6 +60,10 @@ public:
     // Note: this is threadsafe
     void send_message(MessageType type);
 
+    // Utility to send a vector of tensor names to a message queue
+    // Note: this is threadsafe
+    void send_message(MessageType type, const std::vector<std::string> &data);
+
     // Utility to send a NeuropodValueMap to a message queue
     // Note: this is threadsafe
     void send_message(MessageType type, const NeuropodValueMap &data);

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -129,8 +129,11 @@ public:
         }
     }
 
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs) { return infer(inputs, {}); }
+
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs)
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
+                                            const std::vector<std::string> &requested_outputs)
     {
         if (free_memory_every_cycle_)
         {
@@ -140,6 +143,10 @@ public:
 
         // Add inputs
         control_channel_.send_message(ADD_INPUT, inputs);
+
+        // Request outputs
+        // TODO(vip): Don't send this message if requested_outputs is empty
+        control_channel_.send_message(REQUEST_OUTPUT, requested_outputs);
 
         // Run inference
         control_channel_.send_message(INFER);


### PR DESCRIPTION
Previously, if the user requested a specific set of outputs, the worker process would generate all the outputs defined by the spec and the main process would filter to the ones that the user requested.

This PR passes requested tensors to the worker process.