### PR TITLE
Convert DeviceType enum to a namespace + constants

### DIFF
--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -213,7 +213,7 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &             torch
 
 TorchNeuropodBackend::~TorchNeuropodBackend() = default;
 
-torch::Device TorchNeuropodBackend::get_torch_device(neuropod::DeviceType target_device)
+torch::Device TorchNeuropodBackend::get_torch_device(NeuropodDeviceType target_device)
 {
     if (options_.visible_device == Device::CPU || !torch::cuda::is_available())
     {

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -33,11 +33,11 @@ private:
     RuntimeOptions options_;
 
     // The device mapping for the input tensors
-    std::unordered_map<std::string, DeviceType> input_device_mapping_;
+    std::unordered_map<std::string, NeuropodDeviceType> input_device_mapping_;
 
     // Get a torch device given a target neuropod device
     // (this also depends on the visible device in the options above)
-    torch::Device get_torch_device(neuropod::DeviceType target_device);
+    torch::Device get_torch_device(NeuropodDeviceType target_device);
 
 public:
     TorchNeuropodBackend(const std::string &           neuropod_path,

--- a/source/neuropod/internal/config_utils.cc
+++ b/source/neuropod/internal/config_utils.cc
@@ -193,7 +193,7 @@ std::unique_ptr<ModelConfig> load_model_config(std::istream &input_stream)
     }
 
     // Load the device mapping if any
-    std::unordered_map<std::string, DeviceType> input_tensor_device;
+    std::unordered_map<std::string, NeuropodDeviceType> input_tensor_device;
     if (obj.isMember("input_tensor_device"))
     {
         const Json::Value &device_mapping = obj["input_tensor_device"];

--- a/source/neuropod/internal/config_utils.hh
+++ b/source/neuropod/internal/config_utils.hh
@@ -16,11 +16,12 @@ namespace neuropod
 {
 
 // Device types that are supported in the Neuropod configuration
-enum DeviceType
+typedef int NeuropodDeviceType;
+namespace DeviceType
 {
-    CPU,
-    GPU
-};
+constexpr int CPU = 0;
+constexpr int GPU = 1;
+}; // namespace DeviceType
 
 // A struct that stores a specification for a tensor
 struct TensorSpec
@@ -45,7 +46,7 @@ struct ModelConfig
     const std::vector<std::string> custom_ops;
 
     // A map from an input tensor name to a device type
-    const std::unordered_map<std::string, DeviceType> input_tensor_device;
+    const std::unordered_map<std::string, NeuropodDeviceType> input_tensor_device;
 };
 
 std::unique_ptr<ModelConfig> load_model_config(const std::string &neuropod_path);


### PR DESCRIPTION
This PR converts the `DeviceType` enum to a namespace + constants for `CPU` and `GPU`.

Previously it was very easy to accidentally make mistakes when checking devices. For example:

```
RuntimeOptions opts;
if (opts.visible_device == CPU)
{
...
}
```
would actually be comparing `visible_device` with `DeviceType::CPU`. This is comparing a `neuropod::NeuropodDevice` (which is an alias for `int`) with a `neuropod::DeviceType` (which is an enum).

With our current set of build flags, the compiler doesn't complain about this comparison. This leads to some issues that are tricky to track down.

This PR makes such comparisons less error prone by converting `DeviceType` to a namespace. This means that it is no longer valid to just reference `CPU` - it must either explicitly be `DeviceType::CPU` or `Device::CPU`

Build flags will also be updated in a future PR to expose more warnings at compile time.