### PR TITLE
[OPE] Fix race condition in heartbeat thread

### DIFF
--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -25,11 +25,10 @@ namespace
 class HeartbeatController
 {
 private:
-    std::atomic_bool send_heartbeat_;
-    std::thread      heartbeat_thread_;
-
+    std::atomic_bool        send_heartbeat_;
     std::condition_variable cv_;
     std::mutex              mutex_;
+    std::thread             heartbeat_thread_;
 
 public:
     HeartbeatController(IPCControlChannel &control_channel, size_t interval_ms)
@@ -51,7 +50,11 @@ public:
     ~HeartbeatController()
     {
         // Join the heartbeat thread
-        send_heartbeat_ = false;
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            send_heartbeat_ = false;
+        }
+
         cv_.notify_all();
         heartbeat_thread_.join();
     }


### PR DESCRIPTION
This PR fixes two issues with the heartbeat thread. The first one is that it was possible for the `heartbeat_thread_` to launch before `mutex_` was created.

This would cause `mutex lock failed: Invalid argument` errors every once in a while.

This issue was fixed by changing the declaration order to put the `std::thread` last.

The second issue is that it was possible for the shutdown notification to be missed by the worker thread because we didn't lock the mutex before setting `send_heartbeat_` to false.