### PR TITLE
Load model configuration in NeuropodBackend

### DIFF
--- a/source/neuropod/backends/BUILD
+++ b/source/neuropod/backends/BUILD
@@ -19,6 +19,7 @@ cc_library(
     deps = [
         "//neuropod/internal:backend_registration",
         "//neuropod/internal:deleter",
+        "//neuropod/internal:neuropod_config_utils",
         "//neuropod/internal:neuropod_tensor",
         "//neuropod/internal:neuropod_loader",
     ],

--- a/source/neuropod/backends/neuropod_backend.cc
+++ b/source/neuropod/backends/neuropod_backend.cc
@@ -4,6 +4,7 @@
 
 #include "neuropod/backends/neuropod_backend.hh"
 
+#include "neuropod/internal/config_utils.hh"
 #include "neuropod/internal/neuropod_loader.hh"
 
 namespace neuropod
@@ -12,9 +13,31 @@ namespace neuropod
 NeuropodBackend::NeuropodBackend()  = default;
 NeuropodBackend::~NeuropodBackend() = default;
 
-NeuropodBackend::NeuropodBackend(const std::string &neuropod_path)
+NeuropodBackend::NeuropodBackend(const std::string &neuropod_path) : model_config_(load_model_config(neuropod_path))
 {
     loader_ = get_loader(neuropod_path);
+}
+
+const std::vector<TensorSpec> &NeuropodBackend::get_inputs() const
+{
+    if (model_config_ == nullptr)
+    {
+        static const std::vector<TensorSpec> empty = {};
+        return empty;
+    }
+
+    return model_config_->inputs;
+}
+
+const std::vector<TensorSpec> &NeuropodBackend::get_outputs() const
+{
+    if (model_config_ == nullptr)
+    {
+        static const std::vector<TensorSpec> empty = {};
+        return empty;
+    }
+
+    return model_config_->outputs;
 }
 
 std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap &        inputs,

--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -44,9 +44,16 @@ public:
     virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
                                                     const std::vector<std::string> &requested_outputs);
 
+    // Get the inputs and outputs of this model
+    const std::vector<TensorSpec> &get_inputs() const;
+    const std::vector<TensorSpec> &get_outputs() const;
+
 protected:
     // Used to load files in a Neuropod
     std::unique_ptr<NeuropodLoader> loader_;
+
+    // The neuropod model config
+    std::unique_ptr<ModelConfig> model_config_;
 };
 
 template <template <class> class TensorImpl>

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -81,7 +81,6 @@ static auto gil_release = maybe_initialize();
 } // namespace
 
 PythonBridge::PythonBridge(const std::string &             neuropod_path,
-                           std::unique_ptr<ModelConfig> &  model_config,
                            const RuntimeOptions &          options,
                            const std::vector<std::string> &python_path_additions)
     : NeuropodBackendWithDefaultAllocator<TestNeuropodTensor>(neuropod_path)

--- a/source/neuropod/backends/python_bridge/python_bridge.hh
+++ b/source/neuropod/backends/python_bridge/python_bridge.hh
@@ -39,7 +39,6 @@ private:
 
 public:
     PythonBridge(const std::string &             neuropod_path,
-                 std::unique_ptr<ModelConfig> &  model_config,
                  const RuntimeOptions &          options,
                  const std::vector<std::string> &python_path_additions = get_default_python_path());
 

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -118,9 +118,7 @@ std::string get_handle_cache_key(const std::map<std::string, tensorflow::Tensor>
 
 } // namespace
 
-TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &           neuropod_path,
-                                                     std::unique_ptr<ModelConfig> &model_config,
-                                                     const RuntimeOptions &        options)
+TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
     : NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>(neuropod_path),
       session_(tensorflow::NewSession(get_tf_opts(options)))
 {
@@ -134,7 +132,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &        
 #endif
 
     // Load custom ops (if any)
-    for (const auto &item : model_config->custom_ops)
+    for (const auto &item : model_config_->custom_ops)
     {
         const auto path = "0/ops/" + item;
         const auto hash = loader_->get_hash_for_file(path);
@@ -185,7 +183,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &        
     setup_node_mapping_and_init_ops(*config_stream, node_name_mapping_, init_ops);
 
     // Get a list of the output nodes
-    for (const auto &output : model_config->outputs)
+    for (const auto &output : model_config_->outputs)
     {
         output_names_.emplace_back(output.name);
     }

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -45,9 +45,7 @@ private:
                          const std::map<std::string, std::string> &       tensor_fetches);
 
 public:
-    explicit TensorflowNeuropodBackend(const std::string &           neuropod_path,
-                                       std::unique_ptr<ModelConfig> &model_config,
-                                       const RuntimeOptions &        options);
+    TensorflowNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options);
 
     ~TensorflowNeuropodBackend();
 

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.cc
@@ -7,12 +7,8 @@
 namespace neuropod
 {
 
-TestNeuropodBackend::TestNeuropodBackend() {}
-TestNeuropodBackend::TestNeuropodBackend(const std::string &           neuropod_path,
-                                         std::unique_ptr<ModelConfig> &model_config,
-                                         const RuntimeOptions &        options)
-{
-}
+TestNeuropodBackend::TestNeuropodBackend() = default;
+TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options) {}
 TestNeuropodBackend::~TestNeuropodBackend() = default;
 
 // Run inference

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.hh
@@ -18,9 +18,7 @@ class TestNeuropodBackend : public NeuropodBackendWithDefaultAllocator<TestNeuro
 {
 public:
     TestNeuropodBackend();
-    TestNeuropodBackend(const std::string &           neuropod_path,
-                        std::unique_ptr<ModelConfig> &model_config,
-                        const RuntimeOptions &        options);
+    TestNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options);
     ~TestNeuropodBackend();
 
     // Run inference

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -155,12 +155,10 @@ std::mutex                      loaded_op_mutex;
 
 } // namespace
 
-TorchNeuropodBackend::TorchNeuropodBackend(const std::string &           neuropod_path,
-                                           std::unique_ptr<ModelConfig> &model_config,
-                                           const RuntimeOptions &        options)
+TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
     : NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>(neuropod_path),
       options_(options),
-      input_device_mapping_(model_config->input_tensor_device)
+      input_device_mapping_(model_config_->input_tensor_device)
 {
     // Get the model from the neuropod
     auto graph_stream = loader_->get_istream_for_file("0/data/model.pt");
@@ -168,7 +166,7 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &           neuropo
     // Custom ops
     // Make sure we don't load a custom op twice
     std::vector<std::string> custom_ops;
-    for (const auto &item : model_config->custom_ops)
+    for (const auto &item : model_config_->custom_ops)
     {
         const auto path = "0/ops/" + item;
         const auto hash = loader_->get_hash_for_file(path);
@@ -194,14 +192,14 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &           neuropo
         NEUROPOD_ERROR("Failed to load TorchScript graph for neuropod" << neuropod_path.c_str());
     }
 
-    for (const auto &tensor_spec : model_config->outputs)
+    for (const auto &tensor_spec : model_config_->outputs)
     {
         output_specs_.emplace_back(tensor_spec);
     }
 }
 
 TorchNeuropodBackend::TorchNeuropodBackend(const std::string &torchscript_model_path)
-    : TorchNeuropodBackend(torchscript_model_path, {})
+    : TorchNeuropodBackend(torchscript_model_path, std::vector<std::string>())
 {
 }
 

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -40,9 +40,7 @@ private:
     torch::Device get_torch_device(NeuropodDeviceType target_device);
 
 public:
-    TorchNeuropodBackend(const std::string &           neuropod_path,
-                         std::unique_ptr<ModelConfig> &model_config,
-                         const RuntimeOptions &        options);
+    TorchNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options);
 
     // Create a TorchNeuropodBackend using the path to a TorchScript model exported using `torch.jit.save`
     TorchNeuropodBackend(const std::string &torchscript_model_path);

--- a/source/neuropod/internal/backend_registration.hh
+++ b/source/neuropod/internal/backend_registration.hh
@@ -19,18 +19,15 @@ class NeuropodBackend;
 struct RuntimeOptions;
 
 // A function that takes in a path to a neuropod and returns a pointer to a NeuropodBackend
-typedef std::unique_ptr<NeuropodBackend> (*BackendFactoryFunction)(const std::string &           neuropod_path,
-                                                                   std::unique_ptr<ModelConfig> &config,
-                                                                   const RuntimeOptions &        options);
+typedef std::unique_ptr<NeuropodBackend> (*BackendFactoryFunction)(const std::string &   neuropod_path,
+                                                                   const RuntimeOptions &options);
 
 // A template to create a factory for any backend
 // This is used in the macro below
 template <typename T>
-std::unique_ptr<NeuropodBackend> createNeuropodBackend(const std::string &           neuropod_path,
-                                                       std::unique_ptr<ModelConfig> &config,
-                                                       const RuntimeOptions &        options)
+std::unique_ptr<NeuropodBackend> createNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
 {
-    return stdx::make_unique<T>(neuropod_path, config, options);
+    return stdx::make_unique<T>(neuropod_path, options);
 }
 
 // Register a backend for a set of specific types

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -135,7 +135,8 @@ public:
                                 const std::string &control_queue_name,
                                 bool               free_memory_every_cycle,
                                 bool               wait_for_load = true)
-        : control_queue_name_(control_queue_name),
+        : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path),
+          control_queue_name_(control_queue_name),
           free_memory_every_cycle_(free_memory_every_cycle),
           control_channel_(control_queue_name, MAIN_PROCESS)
     {

--- a/source/neuropod/neuropod.cc
+++ b/source/neuropod/neuropod.cc
@@ -21,24 +21,19 @@ Neuropod::Neuropod(const std::string &neuropod_path, const RuntimeOptions &optio
 Neuropod::Neuropod(const std::string &                                 neuropod_path,
                    const std::unordered_map<std::string, std::string> &default_backend_overrides,
                    const RuntimeOptions &                              options)
-    : model_config_(load_model_config(neuropod_path)),
-      backend_(get_backend_for_type(default_backend_overrides,
-                                    model_config_->platform)(neuropod_path, model_config_, options))
+    : backend_(get_backend_for_type(default_backend_overrides,
+                                    load_model_config(neuropod_path)->platform)(neuropod_path, options))
 {
 }
 
 // Load the neuropod using the specified backend
 Neuropod::Neuropod(const std::string &neuropod_path, const std::string &backend_name, const RuntimeOptions &options)
-    : model_config_(load_model_config(neuropod_path)),
-      backend_(get_backend_by_name(backend_name)(neuropod_path, model_config_, options))
+    : backend_(get_backend_by_name(backend_name)(neuropod_path, options))
 {
 }
 
 // Load the model config and use the backend that was provided by the user
-Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBackend> backend)
-    : model_config_(load_model_config(neuropod_path)), backend_(backend)
-{
-}
+Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBackend> backend) : backend_(backend) {}
 
 Neuropod::~Neuropod() = default;
 
@@ -52,12 +47,12 @@ std::unique_ptr<NeuropodValueMap> Neuropod::infer(const NeuropodValueMap &      
 
 const std::vector<TensorSpec> &Neuropod::get_inputs() const
 {
-    return model_config_->inputs;
+    return backend_->get_inputs();
 }
 
 const std::vector<TensorSpec> &Neuropod::get_outputs() const
 {
-    return model_config_->outputs;
+    return backend_->get_outputs();
 }
 
 std::shared_ptr<NeuropodTensorAllocator> Neuropod::get_tensor_allocator()

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -43,9 +43,6 @@ struct RuntimeOptions
 class Neuropod
 {
 private:
-    // The neuropod model config
-    std::unique_ptr<ModelConfig> model_config_;
-
     // The backend used to load and run the neuropod
     std::shared_ptr<NeuropodBackend> backend_;
 

--- a/source/neuropod/tests/test_test_backend.cc
+++ b/source/neuropod/tests/test_test_backend.cc
@@ -9,10 +9,8 @@
 
 TEST(test_test_backend, init)
 {
-    // Make sure we can load a neuropod with garbage data and run inference without crashing
-    auto config =
-        neuropod::stdx::make_unique<neuropod::ModelConfig>(neuropod::ModelConfig{"name", "platform", {}, {}, {}, {}});
-    neuropod::TestNeuropodBackend backend("somepath", config, {});
+    // Make sure we can create a TestNeuropodBackend and run inference without crashing
+    neuropod::TestNeuropodBackend backend("somepath", {});
     neuropod::NeuropodValueMap    inputs;
     backend.infer(inputs);
 }


### PR DESCRIPTION
This PR moves some configuration responsibility from `Neuropod` to `NeuropodBackend`.

`Neuropod` should be a very thin layer that has the job of finding and delegating to the right backend implementation. This will be made more clear in future PRs.

This PR also enables some future changes around the ability to lazily load models (i.e. not in the constructor) and cleaner OPE initialization.