### PR TITLE
Remove lazy allocator initialization

### DIFF
--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -54,22 +54,16 @@ class NeuropodBackendWithDefaultAllocator : public NeuropodBackend
 {
 private:
     std::shared_ptr<NeuropodTensorAllocator> allocator_;
-    std::mutex                               allocator_lock_;
 
 public:
-    NeuropodBackendWithDefaultAllocator() = default;
-    NeuropodBackendWithDefaultAllocator(const std::string &neuropod_path) : NeuropodBackend(neuropod_path) {}
+    NeuropodBackendWithDefaultAllocator() : allocator_(std::make_shared<DefaultTensorAllocator<TensorImpl>>()) {}
 
-    std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator()
+    NeuropodBackendWithDefaultAllocator(const std::string &neuropod_path)
+        : NeuropodBackend(neuropod_path), allocator_(std::make_shared<DefaultTensorAllocator<TensorImpl>>())
     {
-        std::lock_guard<std::mutex> lock(allocator_lock_);
-        if (!allocator_)
-        {
-            allocator_ = std::make_shared<DefaultTensorAllocator<TensorImpl>>();
-        }
-
-        return allocator_;
     }
+
+    std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator() { return allocator_; }
 };
 
 } // namespace neuropod


### PR DESCRIPTION
This PR removes lazy allocator creation from `NeuropodBackendWithDefaultAllocator` for the following reasons:

1. Instantiating a `DefaultTensorAllocator` is pretty lightweight
2. If a `NeuropodBackendWithDefaultAllocator` is instantiated, it's a pretty good assumption that `get_tensor_allocator` will be called on it at some point
3. Removing lazy creation lets us avoid locking a mutex