### PR TITLE
[OPE] Add LOAD_SUCCESS message

### DIFF
--- a/source/neuropod/multiprocess/control_messages.cc
+++ b/source/neuropod/multiprocess/control_messages.cc
@@ -18,6 +18,7 @@ std::ostream &operator<<(std::ostream &out, const MessageType value)
     switch (value)
     {
         GENERATE_CASE(LOAD_NEUROPOD);
+        GENERATE_CASE(LOAD_SUCCESS);
         GENERATE_CASE(ADD_INPUT);
         GENERATE_CASE(INFER);
         GENERATE_CASE(REQUEST_OUTPUT);

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -15,8 +15,13 @@ namespace neuropod
 enum MessageType
 {
     // Sent by the main process with the neuropod path
-    // Valid next messages: ADD_INPUT
+    // Valid next messages: LOAD_SUCCESS
     LOAD_NEUROPOD,
+
+    // Sent by the worker process to confirm that the model has been successfully
+    // loaded.
+    // Valid next messages: ADD_INPUT
+    LOAD_SUCCESS,
 
     // Sent by the main process when passing tensors to the worker process
     // Valid next messages: ADD_INPUT, REQUEST_OUTPUT, INFER

--- a/source/neuropod/multiprocess/ipc_control_channel.cc
+++ b/source/neuropod/multiprocess/ipc_control_channel.cc
@@ -38,7 +38,8 @@ void TransitionVerifier::assert_transition_allowed(MessageType current_type)
     // Using `set` instead of `unordered_set` because it doesn't require the type to be
     // hashable
     static const std::set<std::pair<MessageType, MessageType>> allowed_transitions = {
-        std::make_pair(LOAD_NEUROPOD, ADD_INPUT),
+        std::make_pair(LOAD_NEUROPOD, LOAD_SUCCESS),
+        std::make_pair(LOAD_SUCCESS, ADD_INPUT),
         std::make_pair(ADD_INPUT, ADD_INPUT),
         std::make_pair(ADD_INPUT, REQUEST_OUTPUT),
         std::make_pair(ADD_INPUT, INFER),

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -5,6 +5,7 @@
 #include "neuropod/multiprocess/multiprocess.hh"
 
 #include "neuropod/backends/neuropod_backend.hh"
+#include "neuropod/internal/logging.hh"
 #include "neuropod/multiprocess/control_messages.hh"
 #include "neuropod/multiprocess/ipc_control_channel.hh"
 #include "neuropod/multiprocess/shm_tensor.hh"
@@ -95,10 +96,45 @@ private:
     // Control channel for interacting with the worker
     IPCControlChannel control_channel_;
 
+    void wait_for_load_confirmation(const std::string &neuropod_path)
+    {
+        // Wait for confirmation that the model was loaded
+        while (true)
+        {
+            // Get a message from the worker
+            control_message received;
+            bool            successful_read = control_channel_.recv_message(received, MESSAGE_TIMEOUT_MS);
+            if (!successful_read)
+            {
+                // We timed out
+                NEUROPOD_ERROR("Timed out waiting for the worker process to load: "
+                               << neuropod_path << ". Didn't receive a message in " << MESSAGE_TIMEOUT_MS
+                               << "ms, but expected a heartbeat every " << HEARTBEAT_INTERVAL_MS << "ms.");
+            }
+
+            if (received.type == LOAD_SUCCESS)
+            {
+                // The model was successfully loaded
+                break;
+            }
+
+            if (received.type == HEARTBEAT)
+            {
+                // TODO(vip): Also periodically check for a heartbeat
+                continue;
+            }
+
+            // We got an unexpected message
+            NEUROPOD_ERROR(
+                "Expected LOAD_SUCCESS, but got unexpected message from the worker process:" << received.type)
+        }
+    }
+
 public:
     MultiprocessNeuropodBackend(const std::string &neuropod_path,
                                 const std::string &control_queue_name,
-                                bool               free_memory_every_cycle)
+                                bool               free_memory_every_cycle,
+                                bool               wait_for_load = true)
         : control_queue_name_(control_queue_name),
           free_memory_every_cycle_(free_memory_every_cycle),
           control_channel_(control_queue_name, MAIN_PROCESS)
@@ -116,14 +152,22 @@ public:
 
         // Send the message
         control_channel_.send_message(msg);
+
+        if (wait_for_load)
+        {
+            // Wait until the worker process confirms it has loaded the model
+            wait_for_load_confirmation(neuropod_path);
+        }
     }
 
     // Generate a control queue name and start a worker
     MultiprocessNeuropodBackend(const std::string &   neuropod_path,
                                 const RuntimeOptions &options,
                                 bool                  free_memory_every_cycle)
-        : MultiprocessNeuropodBackend(
-              neuropod_path, boost::uuids::to_string(boost::uuids::random_generator()()), free_memory_every_cycle)
+        : MultiprocessNeuropodBackend(neuropod_path,
+                                      boost::uuids::to_string(boost::uuids::random_generator()()),
+                                      free_memory_every_cycle,
+                                      false)
     {
         auto env = get_env_map();
 
@@ -147,6 +191,9 @@ public:
 
         // Start the worker process
         child_pid_ = start_worker_process(control_queue_name_, env_vec);
+
+        // Wait until the worker process confirms it has loaded the model
+        wait_for_load_confirmation(neuropod_path);
     }
 
     ~MultiprocessNeuropodBackend()
@@ -207,6 +254,7 @@ public:
         while (true)
         {
             // Get a message from the worker
+            SPDLOG_DEBUG("OPE: Waiting for load confirmation from worker...");
             control_message received;
             bool            successful_read = control_channel_.recv_message(received, MESSAGE_TIMEOUT_MS);
             if (!successful_read)

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -99,6 +99,7 @@ void multiprocess_worker_loop(const std::string &control_queue_name)
             allocator = neuropod->get_tensor_allocator();
             inputs.clear();
             last_outputs.clear();
+            control_channel.send_message(LOAD_SUCCESS);
         }
         else if (received.type == ADD_INPUT)
         {

--- a/source/neuropod/tests/test_ipc_control_channel.cc
+++ b/source/neuropod/tests/test_ipc_control_channel.cc
@@ -38,12 +38,13 @@ TEST(test_ipc_control_channel, simple)
 
     // Send the tensors
     main_control_channel.send_message(neuropod::LOAD_NEUROPOD);
+    main_control_channel.send_message(neuropod::LOAD_SUCCESS);
     main_control_channel.send_message(neuropod::ADD_INPUT, sender_map);
     main_control_channel.send_message(neuropod::INFER);
 
     // Receive the tensors
     neuropod::NeuropodValueMap recvd_map;
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < 3; i++)
     {
         // Get a message
         neuropod::control_message received;
@@ -55,6 +56,9 @@ TEST(test_ipc_control_channel, simple)
             EXPECT_EQ(received.type, neuropod::LOAD_NEUROPOD);
             break;
         case 1:
+            EXPECT_EQ(received.type, neuropod::LOAD_SUCCESS);
+            break;
+        case 2:
             EXPECT_EQ(received.type, neuropod::ADD_INPUT);
             for (int i = 0; i < received.num_tensors; i++)
             {
@@ -105,11 +109,12 @@ TEST(test_ipc_control_channel, no_tensors)
 
     // Send an empty map of tensors
     main_control_channel.send_message(neuropod::LOAD_NEUROPOD);
+    main_control_channel.send_message(neuropod::LOAD_SUCCESS);
     main_control_channel.send_message(neuropod::ADD_INPUT, sender_map);
     main_control_channel.send_message(neuropod::INFER);
 
     // Receive the tensors
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < 3; i++)
     {
         // Get a message
         neuropod::control_message received;
@@ -121,6 +126,9 @@ TEST(test_ipc_control_channel, no_tensors)
             EXPECT_EQ(received.type, neuropod::LOAD_NEUROPOD);
             break;
         case 1:
+            EXPECT_EQ(received.type, neuropod::LOAD_SUCCESS);
+            break;
+        case 2:
             EXPECT_EQ(received.type, neuropod::ADD_INPUT);
             EXPECT_EQ(received.num_tensors, 0);
             break;

--- a/source/neuropod/tests/test_multiprocess_allowed_transitions.cc
+++ b/source/neuropod/tests/test_multiprocess_allowed_transitions.cc
@@ -10,6 +10,7 @@ TEST(test_multiprocess_allowed_transitions, simple)
     neuropod::TransitionVerifier verifier;
 
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
+    verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
 
@@ -34,6 +35,7 @@ TEST(test_multiprocess_allowed_transitions, shutdown)
     neuropod::TransitionVerifier verifier;
 
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
+    verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
 
@@ -54,6 +56,7 @@ TEST(test_multiprocess_allowed_transitions, invalid)
     neuropod::TransitionVerifier verifier;
 
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
+    verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
 
@@ -67,6 +70,7 @@ TEST(test_multiprocess_allowed_transitions, new_infer)
 
     // Load a neuropod and run inference
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
+    verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::INFER);
     verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
@@ -83,6 +87,7 @@ TEST(test_multiprocess_allowed_transitions, load_neuropod)
 
     // Load a neuropod and run inference
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
+    verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::INFER);
     verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);


### PR DESCRIPTION
Wait for the worker process to confirm that a model was loaded successfully before returning from the constructor of `MultiprocessNeuropodBackend`

This is useful for unit tests that make sure a model can correctly be loaded using OPE