### PR TITLE
[Docs] Fix rendering of C++ tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -309,6 +309,7 @@ int main()
     const auto out_shape  = out_tensor->get_dims();
 }
 ```
+
 !!! note
     This shows basic usage of the C++ API. For more flexible and memory-efficient usage, please see the API docs
 


### PR DESCRIPTION
Fix rendering of the C++ inference example in the tutorial by inserting a newline after the code snippet