### PR TITLE
Refactor NeuropodBackend to introduce an infer_internal method

### DIFF
--- a/source/neuropod/backends/neuropod_backend.cc
+++ b/source/neuropod/backends/neuropod_backend.cc
@@ -43,14 +43,21 @@ const std::vector<TensorSpec> &NeuropodBackend::get_outputs() const
 std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap &        inputs,
                                                          const std::vector<std::string> &requested_outputs)
 {
+    // Run inference
+    return infer_internal(inputs, requested_outputs);
+}
+
+std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer_internal(const NeuropodValueMap &        inputs,
+                                                                  const std::vector<std::string> &requested_outputs)
+{
     // We're not doing any filtering
     if (requested_outputs.size() == 0)
     {
-        return infer(inputs);
+        return infer_internal(inputs);
     }
 
     // Run inference and get all the outputs
-    auto data = infer(inputs);
+    auto data = infer_internal(inputs);
     auto out  = stdx::make_unique<NeuropodValueMap>();
 
     // Filter to the requested outputs
@@ -66,6 +73,11 @@ std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap 
     }
 
     return out;
+}
+
+std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer_internal(const NeuropodValueMap &inputs)
+{
+    NEUROPOD_ERROR("Backend implementations must provide a `infer_internal` implementation");
 }
 
 } // namespace neuropod

--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -35,14 +35,9 @@ public:
     // Returns an allocator that can allocate tensors compatible with this backend
     virtual std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator() = 0;
 
-    // Run inference
-    virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs) = 0;
-
     // Run inference and get a subset of the outputs
-    // The default implementation runs inference, gets all the outputs, and then filters the outputs
-    // Backends can override this to more efficiently generate only the requested outputs
-    virtual std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
-                                                    const std::vector<std::string> &requested_outputs);
+    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
+                                            const std::vector<std::string> &requested_outputs = {});
 
     // Get the inputs and outputs of this model
     const std::vector<TensorSpec> &get_inputs() const;
@@ -54,6 +49,16 @@ protected:
 
     // The neuropod model config
     std::unique_ptr<ModelConfig> model_config_;
+
+    // Run inference and get a subset of the outputs
+    // The default implementation runs inference, gets all the outputs, and then filters the outputs
+    // Backends can override this to more efficiently generate only the requested outputs
+    virtual std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &        inputs,
+                                                             const std::vector<std::string> &requested_outputs);
+
+    // Run inference
+    // Backends must provide an implementation of infer_internal (either this signature or the one above)
+    virtual std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
 };
 
 template <template <class> class TensorImpl>

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -117,7 +117,7 @@ PythonBridge::~PythonBridge()
 }
 
 // Run inference
-std::unique_ptr<NeuropodValueMap> PythonBridge::infer(const NeuropodValueMap &inputs)
+std::unique_ptr<NeuropodValueMap> PythonBridge::infer_internal(const NeuropodValueMap &inputs)
 {
     // Acquire the GIL
     py::gil_scoped_acquire gil;

--- a/source/neuropod/backends/python_bridge/python_bridge.hh
+++ b/source/neuropod/backends/python_bridge/python_bridge.hh
@@ -44,8 +44,9 @@ public:
 
     ~PythonBridge();
 
+protected:
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
+    std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
 };
 
 } // namespace neuropod

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -249,14 +249,9 @@ int64_t TensorflowNeuropodBackend::get_callable(const std::map<std::string, tens
     return handle;
 }
 
-std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer(const NeuropodValueMap &inputs)
-{
-    return infer(inputs, {});
-}
-
 // Run inference with a set of requested outputs
-std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer(const NeuropodValueMap &        inputs,
-                                                                   const std::vector<std::string> &requested_outputs)
+std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer_internal(
+    const NeuropodValueMap &inputs, const std::vector<std::string> &requested_outputs)
 {
     // In TensorFlow, a callable is a way of running a subgraph given a set of inputs and
     // outputs. It's very similar to `session_->Run` except it has support for more fine-grained

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -49,12 +49,10 @@ public:
 
     ~TensorflowNeuropodBackend();
 
-    // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
-
+protected:
     // Run inference with a set of requested outputs
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
-                                            const std::vector<std::string> &requested_outputs);
+    std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &        inputs,
+                                                     const std::vector<std::string> &requested_outputs);
 };
 
 } // namespace neuropod

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.cc
@@ -12,7 +12,7 @@ TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, const
 TestNeuropodBackend::~TestNeuropodBackend() = default;
 
 // Run inference
-std::unique_ptr<NeuropodValueMap> TestNeuropodBackend::infer(const NeuropodValueMap &inputs)
+std::unique_ptr<NeuropodValueMap> TestNeuropodBackend::infer_internal(const NeuropodValueMap &inputs)
 {
     return stdx::make_unique<NeuropodValueMap>();
 }

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.hh
@@ -21,7 +21,8 @@ public:
     TestNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options);
     ~TestNeuropodBackend();
 
+protected:
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
+    std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
 };
 } // namespace neuropod

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -228,7 +228,7 @@ torch::Device TorchNeuropodBackend::get_torch_device(NeuropodDeviceType target_d
 #endif
 
 // Run inference
-std::unique_ptr<NeuropodValueMap> TorchNeuropodBackend::infer(const NeuropodValueMap &inputs)
+std::unique_ptr<NeuropodValueMap> TorchNeuropodBackend::infer_internal(const NeuropodValueMap &inputs)
 {
     torch::NoGradGuard guard;
 

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -44,8 +44,9 @@ public:
 
     ~TorchNeuropodBackend();
 
+protected:
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs);
+    std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
 };
 
 } // namespace neuropod

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -234,11 +234,10 @@ public:
         }
     }
 
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &inputs) { return infer(inputs, {}); }
-
+protected:
     // Run inference
-    std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
-                                            const std::vector<std::string> &requested_outputs)
+    std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &        inputs,
+                                                     const std::vector<std::string> &requested_outputs)
     {
         // Add inputs
         control_channel_.send_message(ADD_INPUT, inputs);


### PR DESCRIPTION
This renames the existing virtual `infer` method in `NeuropodBackend` to `infer_internal`.

A new non-virtual `infer` method is introduced in `NeuropodBackend` to let us extract common functionality in the future (e.g. shape/type checking, etc).

This mirrors the design of the python implementation