### PR TITLE
Fix Mac CI by pinning to a specific version of virtualenv

### DIFF
--- a/build/ci/travis_build.sh
+++ b/build/ci/travis_build.sh
@@ -21,7 +21,7 @@ if [[ $(uname -s) == 'Darwin' ]]; then
 fi
 
 # Do everything in a virtualenv
-sudo ${NEUROPOD_PYTHON_BINARY} -m pip install virtualenv
+sudo ${NEUROPOD_PYTHON_BINARY} -m pip install virtualenv==16.7.9
 ${NEUROPOD_PYTHON_BINARY} -m virtualenv /tmp/neuropod_venv
 source /tmp/neuropod_venv/bin/activate
 


### PR DESCRIPTION
A new version of `virtualenv` was released today and it breaks Mac Travis CI builds.

To fix this issue, we pin to an earlier release.