### PR TITLE
Add option to manually load model after backend construction

### DIFF
--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -27,6 +27,10 @@ using NeuropodValueMap = std::unordered_map<std::string, std::shared_ptr<Neuropo
 // The interface that every neuropod backend implements
 class NeuropodBackend
 {
+private:
+    // Whether or not the underlying model has already been loaded
+    bool is_model_loaded_ = false;
+
 public:
     NeuropodBackend();
     NeuropodBackend(const std::string &neuropod_path);
@@ -43,12 +47,18 @@ public:
     const std::vector<TensorSpec> &get_inputs() const;
     const std::vector<TensorSpec> &get_outputs() const;
 
+    // Load the model if it has not already been loaded
+    void load_model();
+
 protected:
     // Used to load files in a Neuropod
     std::unique_ptr<NeuropodLoader> loader_;
 
     // The neuropod model config
     std::unique_ptr<ModelConfig> model_config_;
+
+    // The neuropod path (if one was provided in the constructor)
+    std::string neuropod_path_;
 
     // Run inference and get a subset of the outputs
     // The default implementation runs inference, gets all the outputs, and then filters the outputs
@@ -59,6 +69,9 @@ protected:
     // Run inference
     // Backends must provide an implementation of infer_internal (either this signature or the one above)
     virtual std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
+
+    // A method that loads the underlying model
+    virtual void load_model_internal() = 0;
 };
 
 template <template <class> class TensorImpl>

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -88,6 +88,14 @@ PythonBridge::PythonBridge(const std::string &             neuropod_path,
     // Modify PYTHONPATH
     set_python_path(python_path_additions);
 
+    if (options.load_model_at_construction)
+    {
+        load_model();
+    }
+}
+
+void PythonBridge::load_model_internal()
+{
     // Acquire the GIL
     py::gil_scoped_acquire gil;
 

--- a/source/neuropod/backends/python_bridge/python_bridge.hh
+++ b/source/neuropod/backends/python_bridge/python_bridge.hh
@@ -47,6 +47,9 @@ public:
 protected:
     // Run inference
     std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
+
+    // A method that loads the underlying model
+    void load_model_internal();
 };
 
 } // namespace neuropod

--- a/source/neuropod/backends/tensorflow/BUILD
+++ b/source/neuropod/backends/tensorflow/BUILD
@@ -23,6 +23,7 @@ cc_binary(
         "//neuropod:__subpackages__",
     ],
     deps = [
+        "//neuropod:neuropod_hdrs",
         "//neuropod/backends:neuropod_backend",
         "//neuropod/internal:deleter",
         "//neuropod/internal:logging",

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -122,6 +122,14 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &neuropod
     : NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>(neuropod_path),
       session_(tensorflow::NewSession(get_tf_opts(options)))
 {
+    if (options.load_model_at_construction)
+    {
+        load_model();
+    }
+}
+
+void TensorflowNeuropodBackend::load_model_internal()
+{
     // Load custom ops (if any)
     for (const auto &item : model_config_->custom_ops)
     {
@@ -154,7 +162,7 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &neuropod
     graph_stream->read(buffer.data(), graph_length);
     if (graph_stream->fail())
     {
-        NEUROPOD_ERROR("Error reading TensorFlow GraphDef for neuropod {}", neuropod_path);
+        NEUROPOD_ERROR("Error reading TensorFlow GraphDef for neuropod {}", neuropod_path_);
     }
 
     // Read the GraphDef

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -6,6 +6,7 @@
 
 #include "neuropod/backends/neuropod_backend.hh"
 #include "neuropod/backends/tensorflow/tf_tensor.hh"
+#include "neuropod/neuropod.hh"
 
 #include <map>
 #include <string>
@@ -53,6 +54,9 @@ protected:
     // Run inference with a set of requested outputs
     std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &        inputs,
                                                      const std::vector<std::string> &requested_outputs);
+
+    // A method that loads the underlying model
+    void load_model_internal();
 };
 
 } // namespace neuropod

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.cc
@@ -7,9 +7,19 @@
 namespace neuropod
 {
 
-TestNeuropodBackend::TestNeuropodBackend() = default;
-TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options) {}
+TestNeuropodBackend::TestNeuropodBackend()
+{
+    load_model();
+}
+
+TestNeuropodBackend::TestNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
+{
+    load_model();
+}
+
 TestNeuropodBackend::~TestNeuropodBackend() = default;
+
+void TestNeuropodBackend::load_model_internal() {}
 
 // Run inference
 std::unique_ptr<NeuropodValueMap> TestNeuropodBackend::infer_internal(const NeuropodValueMap &inputs)

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.hh
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.hh
@@ -24,5 +24,8 @@ public:
 protected:
     // Run inference
     std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
+
+    // A method that loads the underlying model. For this backend, it is a noop
+    void load_model_internal();
 };
 } // namespace neuropod

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -142,6 +142,14 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, con
       options_(options),
       input_device_mapping_(model_config_->input_tensor_device)
 {
+    if (options.load_model_at_construction)
+    {
+        load_model();
+    }
+}
+
+void TorchNeuropodBackend::load_model_internal()
+{
     // Get the model from the neuropod
     auto graph_stream = loader_->get_istream_for_file("0/data/model.pt");
 
@@ -171,7 +179,7 @@ TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, con
 
     if (!model_)
     {
-        NEUROPOD_ERROR("Failed to load TorchScript graph for neuropod {}", neuropod_path);
+        NEUROPOD_ERROR("Failed to load TorchScript graph for neuropod {}", neuropod_path_);
     }
 
     for (const auto &tensor_spec : model_config_->outputs)

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -47,6 +47,9 @@ public:
 protected:
     // Run inference
     std::unique_ptr<NeuropodValueMap> infer_internal(const NeuropodValueMap &inputs);
+
+    // A method that loads the underlying model
+    void load_model_internal();
 };
 
 } // namespace neuropod

--- a/source/neuropod/neuropod.cc
+++ b/source/neuropod/neuropod.cc
@@ -37,6 +37,11 @@ Neuropod::Neuropod(const std::string &neuropod_path, std::shared_ptr<NeuropodBac
 
 Neuropod::~Neuropod() = default;
 
+void Neuropod::load_model()
+{
+    backend_->load_model();
+}
+
 std::unique_ptr<NeuropodValueMap> Neuropod::infer(const NeuropodValueMap &        inputs,
                                                   const std::vector<std::string> &requested_outputs)
 {

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -38,6 +38,11 @@ struct RuntimeOptions
     //
     // To attempt to run the model on CPU, set this to `Device::CPU`
     NeuropodDevice visible_device = Device::GPU0;
+
+    // Sometimes, it's important to be able to instantiate a Neuropod without
+    // immediately loading the model. If this is set to `false`, the model will
+    // not be loaded until the `load_model` method is called on the Neuropod.
+    bool load_model_at_construction = true;
 };
 
 class Neuropod
@@ -89,6 +94,10 @@ public:
     // Run inference
     std::unique_ptr<NeuropodValueMap> infer(const NeuropodValueMap &        inputs,
                                             const std::vector<std::string> &requested_outputs = {});
+
+    // If `load_model_at_construction` is false in the RuntimeOptions passed into the constructor,
+    // this method loads the model
+    void load_model();
 
     // Get the inputs and outputs of the loaded Neuropod
     const std::vector<TensorSpec> &get_inputs() const;

--- a/source/neuropod/tests/test_utils.hh
+++ b/source/neuropod/tests/test_utils.hh
@@ -107,15 +107,15 @@ void test_addition_model(neuropod::Neuropod &neuropod)
 void test_addition_model(const std::string &neuropod_path, const std::string &backend)
 {
     // Load the neuropod
-    neuropod::Neuropod neuropod(neuropod_path, backend);
-    test_addition_model(neuropod);
-}
+    neuropod::RuntimeOptions opts;
+    opts.load_model_at_construction = false;
+    neuropod::Neuropod neuropod(neuropod_path, backend, opts);
 
-void test_addition_model(const std::string &                                 neuropod_path,
-                         const std::unordered_map<std::string, std::string> &default_backend_overrides)
-{
-    // Load the neuropod
-    neuropod::Neuropod neuropod(neuropod_path, default_backend_overrides);
+    // Should fail because we haven't loaded the model yet
+    EXPECT_ANY_THROW(test_addition_model(neuropod));
+
+    // Load the model and try again
+    neuropod.load_model();
     test_addition_model(neuropod);
 }
 
@@ -165,15 +165,15 @@ void test_strings_model(neuropod::Neuropod &neuropod)
 void test_strings_model(const std::string &neuropod_path, const std::string &backend)
 {
     // Load the neuropod
-    neuropod::Neuropod neuropod(neuropod_path, backend);
-    test_strings_model(neuropod);
-}
+    neuropod::RuntimeOptions opts;
+    opts.load_model_at_construction = false;
+    neuropod::Neuropod neuropod(neuropod_path, backend, opts);
 
-void test_strings_model(const std::string &                                 neuropod_path,
-                        const std::unordered_map<std::string, std::string> &default_backend_overrides)
-{
-    // Load the neuropod
-    neuropod::Neuropod neuropod(neuropod_path, default_backend_overrides);
+    // Should fail because we haven't loaded the model yet
+    EXPECT_ANY_THROW(test_strings_model(neuropod));
+
+    // Load the model and try again
+    neuropod.load_model();
     test_strings_model(neuropod);
 }
 


### PR DESCRIPTION
Instead of automatically loading the underlying model in the constructors of the various `NeuropodBackend` implementations, we add support for users to manually trigger the load after construction.

By setting the `load_model_at_construction` option to false, users can construct a Neuropod without loading the model and then explicitly call the `load_model` method before running inference.