### PR TITLE
[TF] Remove unnecessary RTLD_GLOBAL promotion

### DIFF
--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -122,15 +122,6 @@ TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &neuropod
     : NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>(neuropod_path),
       session_(tensorflow::NewSession(get_tf_opts(options)))
 {
-#ifndef __APPLE__
-    // We need to do this so the custom ops can see the symbols from TF
-    void *libtensorflow = dlopen("libtensorflow_framework.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
-    if (libtensorflow == nullptr)
-    {
-        NEUROPOD_ERROR("Failed to promote libtensorflow to RTLD_GLOBAL. Error from dlopen: " << dlerror());
-    }
-#endif
-
     // Load custom ops (if any)
     for (const auto &item : model_config_->custom_ops)
     {


### PR DESCRIPTION
Promoting `libtensorflow_framework.so` to RTLD_GLOBAL is not necessary as TF custom ops that are correctly built include a `DT_NEEDED` entry for this library.

This was originally introduced because Neuropod was being used in an environment with custom ops that didn't have this dependency