### PR TITLE
Validate tensors against specs from C++

### DIFF
--- a/source/neuropod/backends/neuropod_backend.cc
+++ b/source/neuropod/backends/neuropod_backend.cc
@@ -4,12 +4,150 @@
 
 #include "neuropod/backends/neuropod_backend.hh"
 
+#include "fmt/ranges.h"
 #include "neuropod/internal/config_utils.hh"
 #include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/neuropod_loader.hh"
 
 namespace neuropod
 {
+
+void validate_tensors_against_specs(const NeuropodValueMap &       tensors,
+                                    const std::vector<TensorSpec> &specs,
+                                    const std::string &            debug_spec_name)
+{
+    // A vector of all the tensor names in the spec.
+    // This is used to check for extra tensors that were provided,
+    // but not in the spec
+    std::unordered_set<std::string> spec_tensor_names;
+
+    // All instances of a symbol in a specification must
+    // resolve to the same value at runtime. See below for more detail
+    std::unordered_map<std::string, int64_t> symbol_actual_map;
+
+    for (const auto &spec : specs)
+    {
+        // Add the item's name to a set used to check for extra tensors
+        spec_tensor_names.emplace(spec.name);
+
+        // Try to find a tensor with the same name as this item
+        auto tensor_it = tensors.find(spec.name);
+        if (tensor_it == tensors.end())
+        {
+            // For now, all tensors are optional
+            // TODO(vip): Fix this once we have a better way of marking items as optional
+            continue;
+        }
+
+        // Get the tensor
+        const auto &tensor = tensor_it->second->as_tensor();
+
+        // Validate data type
+        if (tensor->get_tensor_type() != spec.type)
+        {
+            // Throw an error
+            NEUROPOD_ERROR("Tensor '{}' in the {} is expected to be of type {}, but was of type {}",
+                           spec.name,
+                           debug_spec_name,
+                           spec.type,
+                           tensor->get_tensor_type());
+        }
+
+        // Validate the number of dimensions
+        if (tensor->get_dims().size() != spec.dims.size())
+        {
+            // Throw an error
+            NEUROPOD_ERROR("Tensor '{}' in the {} is expected to have {} dimensions, but had {}",
+                           spec.name,
+                           debug_spec_name,
+                           spec.dims.size(),
+                           tensor->get_dims().size());
+        }
+
+        // Validate the shape
+        for (int i = 0; i < spec.dims.size(); i++)
+        {
+            auto dim      = tensor->get_dims()[i];
+            auto expected = spec.dims[i];
+
+            if (expected.value == -1)
+            {
+                // Any value of dim is okay
+                continue;
+            }
+            else if (expected.value > 0)
+            {
+                // Check that we have the expected number of items
+                if (dim != expected.value)
+                {
+                    // Throw an error
+                    NEUROPOD_ERROR("Dim {} of tensor '{}' in the {} is expected to be of size {}, but was of size {}",
+                                   i,
+                                   spec.name,
+                                   debug_spec_name,
+                                   expected.value,
+                                   dim);
+                }
+            }
+            else if (expected.value < -1)
+            {
+                // `expected` is a symbol.
+                // Every instance of `expected` should have the same value
+                // For example, if a symbol of "num_classes" is used multiple times in the spec,
+                // all instances must have the same value
+                auto actual_it = symbol_actual_map.find(expected.symbol);
+                if (actual_it != symbol_actual_map.end())
+                {
+                    // We've seen this symbol before
+                    auto actual_value = actual_it->second;
+
+                    // Make sure this usage matches the previous value
+                    if (dim != actual_value)
+                    {
+                        // Throw an error
+                        NEUROPOD_ERROR(
+                            "All dims with symbol '{}' should be the same size. "
+                            "Dim {} of tensor '{}' in the {} was expected to be of size {}, but was of size {}",
+                            expected.symbol,
+                            i,
+                            spec.name,
+                            debug_spec_name,
+                            actual_value,
+                            dim);
+                    }
+                }
+                else
+                {
+                    // This is the first time we're seeing this symbol
+                    // Add it to the map so we can check future occurrances of this symbol
+                    symbol_actual_map[expected.symbol] = dim;
+                }
+            }
+            else
+            {
+                // Throw an error
+                NEUROPOD_ERROR(
+                    "Invalid value of expected shape for item in the {}: {}", debug_spec_name, expected.value);
+            }
+        }
+    }
+
+    // Check for extra tensors that are not included in the spec
+    std::vector<std::string> unexpected_tensors;
+    for (const auto &item : tensors)
+    {
+        if (spec_tensor_names.find(item.first) == spec_tensor_names.end())
+        {
+            unexpected_tensors.emplace_back(item.first);
+        }
+    }
+
+    if (unexpected_tensors.size() > 0)
+    {
+        // Throw an error
+        NEUROPOD_ERROR("Tensor name(s) '{}' are not found in the {}", unexpected_tensors, debug_spec_name);
+    }
+}
 
 NeuropodBackend::NeuropodBackend()  = default;
 NeuropodBackend::~NeuropodBackend() = default;
@@ -77,8 +215,16 @@ std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer(const NeuropodValueMap 
                        "`load_model_at_construction` was set to false and `load_model()` was not explicitly called");
     }
 
+    // Validate inputs
+    validate_tensors_against_specs(inputs, get_inputs(), "input spec");
+
     // Run inference
-    return infer_internal(inputs, requested_outputs);
+    auto out = infer_internal(inputs, requested_outputs);
+
+    // Validate outputs
+    validate_tensors_against_specs(*out, get_outputs(), "output spec");
+
+    return out;
 }
 
 std::unique_ptr<NeuropodValueMap> NeuropodBackend::infer_internal(const NeuropodValueMap &        inputs,

--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -92,4 +92,10 @@ public:
     std::shared_ptr<NeuropodTensorAllocator> get_tensor_allocator() { return allocator_; }
 };
 
+// A utility for validating tensors against a vector of specs. Throws an error if validation fails
+// Note: This function is exposed in order to properly unit test it and should not be directly used
+void validate_tensors_against_specs(const NeuropodValueMap &       tensors,
+                                    const std::vector<TensorSpec> &specs,
+                                    const std::string &            debug_spec_name = "spec");
+
 } // namespace neuropod

--- a/source/neuropod/internal/config_utils.cc
+++ b/source/neuropod/internal/config_utils.cc
@@ -65,12 +65,13 @@ TensorType convert_to_tensor_type(const Json::Value &dtype)
     }
 }
 
-std::vector<int64_t> get_dims_from_json(const Json::Value &json_shape)
+std::vector<Dimension> get_dims_from_json(const Json::Value &json_shape)
 {
     // Make sure that the shape is an array
     if (json_shape.isArray())
     {
-        std::vector<int64_t> out;
+        // The dims to return
+        std::vector<Dimension> out;
         for (const auto &item : json_shape)
         {
             // Get the number and do some validation
@@ -86,9 +87,8 @@ std::vector<int64_t> get_dims_from_json(const Json::Value &json_shape)
             }
             else if (item.isString())
             {
-                // TODO: In the future, named dimensions will be assigned unique negative values,
-                // but for now we always assign -2
-                out.emplace_back(-2);
+                // It is a symbol
+                out.emplace_back(item.asString());
             }
             else
             {
@@ -107,7 +107,22 @@ std::vector<int64_t> get_dims_from_json(const Json::Value &json_shape)
 
 } // namespace
 
-TensorSpec::TensorSpec(const std::string &name, const std::vector<int64_t> dims, const TensorType type)
+Dimension::Dimension(int64_t value) : value(value) {}
+Dimension::Dimension(std::string symbol) : value(-2), symbol(symbol) {}
+Dimension::~Dimension() = default;
+
+bool Dimension::operator==(const Dimension &other) const
+{
+    if (value == other.value)
+    {
+        // If it's a symbol, make sure the symbol name matches
+        return value == -2 ? symbol == other.symbol : true;
+    }
+
+    return false;
+}
+
+TensorSpec::TensorSpec(const std::string &name, const std::vector<Dimension> dims, const TensorType type)
     : name(name), dims(dims), type(type)
 {
 }

--- a/source/neuropod/internal/config_utils.hh
+++ b/source/neuropod/internal/config_utils.hh
@@ -23,15 +23,33 @@ constexpr int CPU = 0;
 constexpr int GPU = 1;
 }; // namespace DeviceType
 
+// A struct that stores the value of a dimension
+struct Dimension
+{
+    Dimension(int64_t value);
+    Dimension(std::string symbol);
+    ~Dimension();
+
+    bool operator==(const Dimension &other) const;
+
+    // The value
+    // -1 == Any value is allowed (None/null)
+    // -2 == Symbol
+    int64_t value;
+
+    // The name of this symbol (if it is a symbol)
+    std::string symbol;
+};
+
 // A struct that stores a specification for a tensor
 struct TensorSpec
 {
-    TensorSpec(const std::string &name, const std::vector<int64_t> dims, const TensorType type);
+    TensorSpec(const std::string &name, const std::vector<Dimension> dims, const TensorType type);
     ~TensorSpec();
 
-    const std::string          name;
-    const std::vector<int64_t> dims;
-    const TensorType           type;
+    const std::string            name;
+    const std::vector<Dimension> dims;
+    const TensorType             type;
 };
 
 // A struct that stores the expected inputs and outputs of a model

--- a/source/neuropod/internal/neuropod_tensor.cc
+++ b/source/neuropod/internal/neuropod_tensor.cc
@@ -133,13 +133,13 @@ bool NeuropodTensor::operator==(const NeuropodTensor &other) const
 NeuropodTensor *NeuropodValue::as_tensor()
 {
     assure_tensor();
-    return dynamic_cast<NeuropodTensor *>(this);
+    return static_cast<NeuropodTensor *>(this);
 }
 
 const NeuropodTensor *NeuropodValue::as_tensor() const
 {
     assure_tensor();
-    return dynamic_cast<const NeuropodTensor *>(this);
+    return static_cast<const NeuropodTensor *>(this);
 }
 
 template <typename T>

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -208,6 +208,18 @@ cc_test(
 )
 
 cc_test(
+    name = "test_tensor_validation",
+    srcs = [
+        "test_tensor_validation.cc",
+    ],
+    deps = [
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
     name = "test_accessor",
     srcs = [
         "test_accessor.cc",

--- a/source/neuropod/tests/test_config_utils.cc
+++ b/source/neuropod/tests/test_config_utils.cc
@@ -43,10 +43,12 @@ TEST(test_config_utils, valid_config)
     auto               model_config = neuropod::load_model_config(config);
     EXPECT_EQ("x", model_config->inputs[0].name);
     EXPECT_EQ(neuropod::TensorType::FLOAT_TENSOR, model_config->inputs[0].type);
-    EXPECT_EQ(std::vector<int64_t>({-1, 2, -2}), model_config->inputs[0].dims);
+    EXPECT_EQ(std::vector<neuropod::Dimension>({-1, 2, neuropod::Dimension("some_symbol")}),
+              model_config->inputs[0].dims);
     EXPECT_EQ("y", model_config->outputs[0].name);
     EXPECT_EQ(neuropod::TensorType::FLOAT_TENSOR, model_config->outputs[0].type);
-    EXPECT_EQ(std::vector<int64_t>({-1, 2, -2}), model_config->outputs[0].dims);
+    EXPECT_EQ(std::vector<neuropod::Dimension>({-1, 2, neuropod::Dimension("some_symbol")}),
+              model_config->outputs[0].dims);
 }
 
 TEST(test_config_utils, invalid_name)

--- a/source/neuropod/tests/test_data/torchscript_addition_model_single_output/config.json
+++ b/source/neuropod/tests/test_data/torchscript_addition_model_single_output/config.json
@@ -3,7 +3,8 @@
         {
             "dtype": "float32", 
             "shape": [
-                "batch_size"
+                "batch_size",
+                null
             ], 
             "name": "out"
         }
@@ -13,14 +14,16 @@
         {
             "dtype": "float32", 
             "shape": [
-                "batch_size"
+                "batch_size",
+                null
             ], 
             "name": "x"
         }, 
         {
             "dtype": "float32", 
             "shape": [
-                "batch_size"
+                "batch_size",
+                null
             ], 
             "name": "y"
         }, 

--- a/source/neuropod/tests/test_tensor_validation.cc
+++ b/source/neuropod/tests/test_tensor_validation.cc
@@ -1,0 +1,182 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "gtest/gtest.h"
+#include "neuropod/backends/neuropod_backend.hh"
+#include "neuropod/backends/test_backend/test_neuropod_backend.hh"
+
+namespace
+{
+
+const std::vector<neuropod::TensorSpec> TEST_SPEC = {
+    // (None, 2)
+    {"x", {-1, 2}, neuropod::FLOAT_TENSOR},
+
+    // (None, 2)
+    {"y", {-1, 2}, neuropod::FLOAT_TENSOR},
+};
+
+} // namespace
+
+TEST(test_spec_validation, test_correct_inputs)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({2, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2, 2});
+
+    // The tensors match the specs so we don't expect an error
+    neuropod::validate_tensors_against_specs(inputs, TEST_SPEC);
+}
+
+// For now, all tensors are optional
+// TEST(test_spec_validation, test_missing_tensor)
+// {
+//     neuropod::TestNeuropodBackend backend;
+//     auto allocator = backend.get_tensor_allocator();
+
+//     neuropod::NeuropodValueMap inputs;
+//     inputs["x"] = allocator->allocate_tensor<float>({2, 2});
+//     EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+// }
+
+// For now, all tensors are optional
+// TEST(test_spec_validation, test_missing_tensors)
+// {
+//     neuropod::TestNeuropodBackend backend;
+//     auto allocator = backend.get_tensor_allocator();
+
+//     neuropod::NeuropodValueMap inputs;
+//     EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+// }
+
+TEST(test_spec_validation, test_bogus_tensor_name)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"]     = allocator->allocate_tensor<float>({2, 2});
+    inputs["bogus"] = allocator->allocate_tensor<float>({2, 2});
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_incorrect_dtype)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<int32_t>({2, 2});
+    inputs["y"] = allocator->allocate_tensor<int32_t>({2, 2});
+
+    // Incorrect dtype (expected float, got int32)
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_invalid_num_dims)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({2, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2});
+
+    // "y" only has one dim
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_invalid_shape)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({2, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2, 1});
+
+    // Dim 1 of "y" is incorrect
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, TEST_SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_correct_symbol)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({3, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2, 3});
+
+    const std::vector<neuropod::TensorSpec> SPEC = {
+        // ("some_symbol", 2)
+        {"x", {-2, 2}, neuropod::FLOAT_TENSOR},
+
+        // (None, "some_symbol")
+        {"y", {-1, -2}, neuropod::FLOAT_TENSOR},
+    };
+
+    // The tensors matches the specs so we don't expect an error
+    neuropod::validate_tensors_against_specs(inputs, SPEC);
+}
+
+TEST(test_spec_validation, test_incorrect_symbol)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({1, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2, 3});
+
+    const std::vector<neuropod::TensorSpec> SPEC = {
+        // ("some_symbol", 2)
+        {"x", {-2, 2}, neuropod::FLOAT_TENSOR},
+
+        // (None, "some_symbol")
+        {"y", {-1, -2}, neuropod::FLOAT_TENSOR},
+    };
+
+    // Dim 1 of y should be the same as dim 0 of x (2 != 1)
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_invalid_shape_entry)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<float>({2, 2});
+    inputs["y"] = allocator->allocate_tensor<float>({2, 2});
+
+    const std::vector<neuropod::TensorSpec> SPEC = {
+        {"x", {0, 2}, neuropod::FLOAT_TENSOR},
+
+        // (None, 2)
+        {"y", {-1, 2}, neuropod::FLOAT_TENSOR},
+    };
+
+    // `0` is an invalid dim size in the spec
+    EXPECT_THROW(neuropod::validate_tensors_against_specs(inputs, SPEC), std::runtime_error);
+}
+
+TEST(test_spec_validation, test_string_tensors)
+{
+    neuropod::TestNeuropodBackend backend;
+    auto                          allocator = backend.get_tensor_allocator();
+
+    neuropod::NeuropodValueMap inputs;
+    inputs["x"] = allocator->allocate_tensor<std::string>({1, 3});
+
+    const std::vector<neuropod::TensorSpec> SPEC = {
+        {"x", {1, 3}, neuropod::STRING_TENSOR},
+    };
+
+    // The tensor matches the spec so we don't expect an error
+    neuropod::validate_tensors_against_specs(inputs, SPEC);
+}


### PR DESCRIPTION
Validate the shapes and types of tensors passed to `infer`. This mirrors the logic and implementation of the current Python tensor validation code.