### PR TITLE
[OPE] Use try_send_message when sending heartbeat messages

### DIFF
--- a/source/neuropod/multiprocess/ipc_control_channel.cc
+++ b/source/neuropod/multiprocess/ipc_control_channel.cc
@@ -95,6 +95,15 @@ void IPCControlChannel::send_message(control_message &msg)
     send_queue_->send(&msg, sizeof(control_message), 0);
 }
 
+// Does not block if the message queue is full
+bool IPCControlChannel::try_send_message(control_message &msg)
+{
+    // Make sure that it is valid to go from the previous message type to the current one
+    verifier_.assert_transition_allowed(msg.type);
+    SPDLOG_DEBUG("OPE: (non-blocking) Sending message {}", msg.type);
+    return send_queue_->try_send(&msg, sizeof(control_message), 0);
+}
+
 // Utility to send a message with no content to a message queue
 void IPCControlChannel::send_message(MessageType type)
 {

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -56,6 +56,13 @@ public:
     // Note: this is threadsafe
     void send_message(control_message &msg);
 
+    // Utility to send a message to a message queue
+    // Does not block if the message queue is full
+    // This must be used when sending messages to the main process outside of the
+    // normal inference process (e.g. HEARTBEAT messages)
+    // Note: this is threadsafe
+    bool try_send_message(control_message &msg);
+
     // Utility to send a message with no content to a message queue
     // Note: this is threadsafe
     void send_message(MessageType type);


### PR DESCRIPTION
When running a model using OPE, the following situation could cause the main and worker processes to hang forever:

1. The main process loads a model using OPE (but does not run inference)
2. It waits > 40 seconds (enough for 20 `HEARTBEAT` messages)
3. It tries to destruct the Neuropod and shutdown the worker

This causes the following to happen:
1. The `worker -> main process` message queue fills up with `HEARTBEAT` messages (because the main process only reads from this queue during inference)
2. The heartbeat thread in `HeartbeatController` blocks when trying to send the next `HEARTBEAT` message
3. Once the worker receives a `SHUTDOWN` message, the destructor of `HeartbeatController` attempts to join the heartbeat thread and blocks (because the heartbeat thread is blocked)
4. The main process blocks waiting for the worker process to shutdown

To fix this issue, this PR modifies the heartbeat thread to use a non-blocking form of `send_message`.