### PR TITLE
[OPE] Send a heartbeat from the main process as well

### DIFF
--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -60,6 +60,20 @@ cc_library(
 )
 
 cc_library(
+    name = "heartbeat_controller",
+    srcs = [
+        "heartbeat_controller.cc",
+        "heartbeat_controller.hh",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        ":ipc_control_channel",
+    ],
+)
+
+cc_library(
     name = "multiprocess_worker",
     hdrs = [
         "multiprocess_worker.hh",
@@ -73,6 +87,7 @@ cc_library(
     ],
     deps = [
         ":ipc_control_channel",
+        ":heartbeat_controller",
         "//neuropod:neuropod_hdrs",
         "//neuropod/internal:neuropod_tensor_raw_data_access",
     ],
@@ -123,6 +138,7 @@ cc_library(
     ],
     deps = [
         ":ipc_control_channel",
+        ":heartbeat_controller",
         "//neuropod:neuropod_hdrs",
         "//neuropod/backends:neuropod_backend",
         "//neuropod/internal:deleter",

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -52,8 +52,7 @@ enum MessageType
     // Valid next messages: ADD_INPUT, LOAD_NEUROPOD
     INFER_COMPLETE,
 
-    // A noop message sent by the worker process used to ensure that the worker
-    // is alive
+    // A noop message that is perioidically sent by both processes
     // Note: it is valid to send this message at any time.
     HEARTBEAT,
 

--- a/source/neuropod/multiprocess/heartbeat_controller.cc
+++ b/source/neuropod/multiprocess/heartbeat_controller.cc
@@ -1,0 +1,63 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/heartbeat_controller.hh"
+
+#include "neuropod/multiprocess/ipc_control_channel.hh"
+
+namespace neuropod
+{
+
+// Starts a new thread to send a heartbeat
+HeartbeatController::HeartbeatController(IPCControlChannel &control_channel, size_t interval_ms)
+    : send_heartbeat_(true), heartbeat_thread_([this, &control_channel, interval_ms]() {
+          // Send a heartbeat every 2 seconds
+          while (send_heartbeat_)
+          {
+              // Note: we're using `try_send_message` instead of `send_message` because
+              // we don't want to block if the message queue is full.
+              // This is important because it could prevent shutdown and cause the worker
+              // and main process to hang.
+              //
+              // For example:
+              // - The main process loads a neuropod using the multiprocess backend (but does not run inference)
+              // - The (worker -> main process) message queue fills up with HEARTBEAT messages
+              //   (because messages are only read from that queue during inference)
+              //
+              // - This thread blocks on sending the next HEARTBEAT message
+              // - The main process sends a SHUTDOWN message and waits for the worker to shut down
+              // - The destructor of `HeartbeatController` runs and runs `join` on this thread
+              //
+              // This will cause both processes to hang forever because the worker is still blocked on the message
+              // queue and the main process is waiting for this process to shutdown.
+
+              // try_send_message is threadsafe so we don't need synchronization here
+              control_message msg;
+              msg.type = HEARTBEAT;
+              if (!control_channel.try_send_message(msg))
+              {
+                  SPDLOG_DEBUG("OPE: Message queue full - skipped sending heartbeat");
+              }
+
+              // This lets us break out of waiting if we're told to shutdown
+              std::unique_lock<std::mutex> lk(mutex_);
+              cv_.wait_for(lk, std::chrono::milliseconds(interval_ms), [&] { return send_heartbeat_ != true; });
+          }
+      })
+{
+}
+
+HeartbeatController::~HeartbeatController()
+{
+    // Join the heartbeat thread
+    {
+        std::lock_guard<std::mutex> lk(mutex_);
+        send_heartbeat_ = false;
+    }
+
+    cv_.notify_all();
+    heartbeat_thread_.join();
+}
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/heartbeat_controller.hh
+++ b/source/neuropod/multiprocess/heartbeat_controller.hh
@@ -1,0 +1,32 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/ipc_control_channel.hh"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace neuropod
+{
+
+// Starts a new thread to periodically send a heartbeat
+class HeartbeatController
+{
+private:
+    std::atomic_bool        send_heartbeat_;
+    std::condition_variable cv_;
+    std::mutex              mutex_;
+    std::thread             heartbeat_thread_;
+
+public:
+    // Start a heartbeat thread
+    HeartbeatController(IPCControlChannel &control_channel, size_t interval_ms);
+
+    // Shutdown the heartbeat thread
+    ~HeartbeatController();
+};
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -4,6 +4,7 @@
 
 #include "neuropod/internal/logging.hh"
 #include "neuropod/multiprocess/control_messages.hh"
+#include "neuropod/multiprocess/heartbeat_controller.hh"
 #include "neuropod/multiprocess/ipc_control_channel.hh"
 #include "neuropod/multiprocess/shm_tensor.hh"
 #include "neuropod/multiprocess/tensor_utils.hh"
@@ -18,72 +19,6 @@
 
 namespace neuropod
 {
-
-namespace
-{
-
-// Starts a new thread to send a heartbeat
-class HeartbeatController
-{
-private:
-    std::atomic_bool        send_heartbeat_;
-    std::condition_variable cv_;
-    std::mutex              mutex_;
-    std::thread             heartbeat_thread_;
-
-public:
-    HeartbeatController(IPCControlChannel &control_channel, size_t interval_ms)
-        : send_heartbeat_(true), heartbeat_thread_([this, &control_channel, interval_ms]() {
-              // Send a heartbeat every 2 seconds
-              while (send_heartbeat_)
-              {
-                  // Note: we're using `try_send_message` instead of `send_message` because
-                  // we don't want to block if the message queue is full.
-                  // This is important because it could prevent shutdown and cause the worker
-                  // and main process to hang.
-                  //
-                  // For example:
-                  // - The main process loads a neuropod using the multiprocess backend (but does not run inference)
-                  // - The (worker -> main process) message queue fills up with HEARTBEAT messages
-                  //   (because messages are only read from that queue during inference)
-                  //
-                  // - This thread blocks on sending the next HEARTBEAT message
-                  // - The main process sends a SHUTDOWN message and waits for the worker to shut down
-                  // - The destructor of `HeartbeatController` runs and runs `join` on this thread
-                  //
-                  // This will cause both processes to hang forever because the worker is still blocked on the message
-                  // queue and the main process is waiting for this process to shutdown.
-
-                  // try_send_message is threadsafe so we don't need synchronization here
-                  control_message msg;
-                  msg.type = HEARTBEAT;
-                  if (!control_channel.try_send_message(msg))
-                  {
-                      SPDLOG_DEBUG("OPE: Message queue full - skipped sending heartbeat");
-                  }
-
-                  // This lets us break out of waiting if we're told to shutdown
-                  std::unique_lock<std::mutex> lk(mutex_);
-                  cv_.wait_for(lk, std::chrono::milliseconds(interval_ms), [&] { return send_heartbeat_ != true; });
-              }
-          })
-    {
-    }
-
-    ~HeartbeatController()
-    {
-        // Join the heartbeat thread
-        {
-            std::lock_guard<std::mutex> lk(mutex_);
-            send_heartbeat_ = false;
-        }
-
-        cv_.notify_all();
-        heartbeat_thread_.join();
-    }
-};
-
-} // namespace
 
 // The main loop for a worker that runs a neuropod
 void multiprocess_worker_loop(const std::string &control_queue_name)
@@ -111,9 +46,17 @@ void multiprocess_worker_loop(const std::string &control_queue_name)
 
     while (true)
     {
-        // Get a message
+        // Get a message with a timeout
         control_message received;
-        control_channel.recv_message(received);
+        bool            successful_read = control_channel.recv_message(received, MESSAGE_TIMEOUT_MS);
+        if (!successful_read)
+        {
+            // We timed out. This usually means the main process died.
+            NEUROPOD_ERROR("Timed out waiting for a heartbeat from the main process. "
+                           "Didn't receive a message in {}ms, but expected a heartbeat every {}ms.",
+                           MESSAGE_TIMEOUT_MS,
+                           HEARTBEAT_INTERVAL_MS);
+        }
 
         if (received.type == LOAD_NEUROPOD)
         {


### PR DESCRIPTION
Previously, if the main process was killed, it was possible for the worker process to live on forever. This PR introduces an additional heartbeat from the main process to the worker process in order to avoid this case