### PR TITLE
[Torch] Add support for returning Named Tuples

### DIFF
--- a/source/neuropod/python/tests/test_torchscript_packaging.py
+++ b/source/neuropod/python/tests/test_torchscript_packaging.py
@@ -2,6 +2,8 @@
 # Uber, Inc. (c) 2018
 #
 
+import collections
+import numpy as np
 import os
 import torch
 import unittest
@@ -90,6 +92,21 @@ class MixedReturnTypesModelDuplicateItem(torch.jit.ScriptModule):
         return tensor_output, string_output, tensor_output_2
 
 
+SomeNamedTuple = collections.namedtuple(
+    "SomeNamedTuple", ["sum", "difference", "product"]
+)
+
+
+class NamedTupleModel(torch.jit.ScriptModule):
+    """
+    This model returns a named tuple
+    """
+
+    @torch.jit.script_method
+    def forward(self, x, y):
+        return SomeNamedTuple(sum=x + y, difference=x - y, product=x * y)
+
+
 class TestTorchScriptPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False):
         for model in [AdditionModel, AdditionModelDictInput, AdditionModelTensorOutput]:
@@ -120,8 +137,7 @@ class TestTorchScriptPackaging(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.package_simple_addition_model(do_fail=True)
 
-    def test_mixed_types_model(self):
-        # Tests a model that returns both tensors and "string tensors"
+    def package_mixed_types_model(self, do_fail=False):
         with TemporaryDirectory() as test_dir:
             neuropod_path = os.path.join(test_dir, "test_neuropod")
 
@@ -133,25 +149,17 @@ class TestTorchScriptPackaging(unittest.TestCase):
                 model_name="mixed_types_model",
                 module=MixedReturnTypesModel(),
                 # Get the input/output spec along with test data
-                **get_mixed_model_spec()
+                **get_mixed_model_spec(do_fail=do_fail)
             )
+
+    def test_mixed_types_model(self):
+        # Tests a model that returns both tensors and "string tensors"
+        self.package_mixed_types_model()
 
     def test_mixed_types_model_failure(self):
         # Tests a model that returns both tensors and "string tensors"
         with self.assertRaises(ValueError):
-            with TemporaryDirectory() as test_dir:
-                neuropod_path = os.path.join(test_dir, "test_neuropod")
-
-                # `create_torchscript_neuropod` runs inference with the test data immediately
-                # after creating the neuropod. Raises a ValueError if the model output
-                # does not match the expected output.
-                create_torchscript_neuropod(
-                    neuropod_path=neuropod_path,
-                    model_name="mixed_types_model",
-                    module=MixedReturnTypesModel(),
-                    # Get the input/output spec along with test data
-                    **get_mixed_model_spec(do_fail=True)
-                )
+            self.package_mixed_types_model(do_fail=True)
 
     def test_mixed_types_model_failure_duplicate_item(self):
         # Tests a model that returns duplicate items across multiple dictionaries
@@ -171,6 +179,60 @@ class TestTorchScriptPackaging(unittest.TestCase):
                     # Get the input/output spec along with test data
                     **get_mixed_model_spec()
                 )
+
+    def package_named_tuple_model(self, do_fail=False):
+        with TemporaryDirectory() as test_dir:
+            neuropod_path = os.path.join(test_dir, "test_neuropod")
+
+            # `create_torchscript_neuropod` runs inference with the test data immediately
+            # after creating the neuropod. Raises a ValueError if the model output
+            # does not match the expected output.
+            create_torchscript_neuropod(
+                neuropod_path=neuropod_path,
+                model_name="named_tuple_model",
+                module=NamedTupleModel(),
+                input_spec=[
+                    {"name": "x", "dtype": "float32", "shape": ("batch_size",)},
+                    {"name": "y", "dtype": "float32", "shape": ("batch_size",)},
+                ],
+                output_spec=[
+                    {"name": "sum", "dtype": "float32", "shape": ("batch_size",)},
+                    {
+                        "name": "difference",
+                        "dtype": "float32",
+                        "shape": ("batch_size",),
+                    },
+                    {"name": "product", "dtype": "float32", "shape": ("batch_size",)},
+                ],
+                test_input_data={
+                    "x": np.arange(5, dtype=np.float32),
+                    "y": np.arange(5, dtype=np.float32),
+                },
+                test_expected_out={
+                    "sum": np.zeros(5) if do_fail else np.arange(5) + np.arange(5),
+                    "difference": np.zeros(5)
+                    if do_fail
+                    else np.arange(5) - np.arange(5),
+                    "product": np.zeros(5) if do_fail else np.arange(5) * np.arange(5),
+                },
+            )
+
+    @unittest.skipIf(
+        torch.__version__.startswith("1.2.") or torch.__version__.startswith("1.1."),
+        "TorchScript namedtuple support only works in torch >= 1.3.0",
+    )
+    def test_named_tuple_model(self):
+        # Tests a model that returns both tensors and "string tensors"
+        self.package_named_tuple_model()
+
+    @unittest.skipIf(
+        torch.__version__.startswith("1.2.") or torch.__version__.startswith("1.1."),
+        "TorchScript namedtuple support only works in torch >= 1.3.0",
+    )
+    def test_named_tuple_model_failure(self):
+        # Tests a model that returns both tensors and "string tensors"
+        with self.assertRaises(ValueError):
+            self.package_named_tuple_model(do_fail=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Starting with Torch 1.3.0, TorchScript has support for `namedtuples`. This PR allows `namedtuples` to be returned from models