### PR TITLE
Move the definition of NeuropodValueMap to neuropod_tensor.hh

### DIFF
--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -20,10 +20,6 @@
 namespace neuropod
 {
 
-// A map from a tensor name to a pointer to a NeuropodValue
-// This is the input and output type of `infer`
-using NeuropodValueMap = std::unordered_map<std::string, std::shared_ptr<NeuropodValue>>;
-
 // The interface that every neuropod backend implements
 class NeuropodBackend
 {

--- a/source/neuropod/internal/neuropod_tensor.hh
+++ b/source/neuropod/internal/neuropod_tensor.hh
@@ -465,4 +465,8 @@ public:
     virtual T get_native_data() = 0;
 };
 
+// A map from a tensor name to a pointer to a NeuropodValue
+// This is the input and output type of `infer`
+using NeuropodValueMap = std::unordered_map<std::string, std::shared_ptr<NeuropodValue>>;
+
 } // namespace neuropod


### PR DESCRIPTION
`NeuropodValueMap` is now defined alongside `NeuropodValue` so we no longer have to include `neuropod_backend.hh` just for a single alias definition