### PR TITLE
Add a trace log level

### DIFF
--- a/source/neuropod/internal/logging.cc
+++ b/source/neuropod/internal/logging.cc
@@ -21,6 +21,11 @@ spdlog::level::level_enum get_default_log_level()
     }
 
     std::string log_level(log_level_cstr);
+    if (log_level == "TRACE")
+    {
+        return spdlog::level::trace;
+    }
+
     if (log_level == "DEBUG")
     {
         return spdlog::level::debug;


### PR DESCRIPTION
This PR lets users set the log level to trace by setting the `NEUROPOD_LOG_LEVEL` environment variable to `TRACE`