### PR TITLE
[OPE] Add serialization for IPC

### DIFF
--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "//neuropod/backends:neuropod_backend",
         "//neuropod/internal:deleter",
         "//neuropod/multiprocess/shm",
+        "//neuropod/multiprocess/serialization",
     ],
 )
 
@@ -25,10 +26,12 @@ cc_library(
     hdrs = [
         "ipc_control_channel.hh",
         "control_messages.hh",
+        "ope_load_config.hh",
     ],
     srcs = [
         "ipc_control_channel.cc",
         "control_messages.cc",
+        "ope_load_config.cc",
     ],
     visibility = [
         "//neuropod:__subpackages__",

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -80,11 +80,4 @@ constexpr int MESSAGE_TIMEOUT_MS = 5000;
 // Ensure the timeout is larger than the heartbeat interval
 static_assert(MESSAGE_TIMEOUT_MS > HEARTBEAT_INTERVAL_MS, "Message timeout must be larger than the heartbeat interval");
 
-// Contains everything needed to load a model in the worker process
-struct ope_load_config
-{
-    // The path of the model to load
-    std::string neuropod_path;
-};
-
 } // namespace neuropod

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -6,6 +6,7 @@
 
 #include "neuropod/backends/neuropod_backend.hh"
 #include "neuropod/multiprocess/control_messages.hh"
+#include "neuropod/multiprocess/ope_load_config.hh"
 
 #include <boost/interprocess/ipc/message_queue.hpp>
 

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -8,6 +8,7 @@
 #include "neuropod/internal/logging.hh"
 #include "neuropod/multiprocess/control_messages.hh"
 #include "neuropod/multiprocess/ipc_control_channel.hh"
+#include "neuropod/multiprocess/ope_load_config.hh"
 #include "neuropod/multiprocess/shm_tensor.hh"
 
 #include <boost/date_time/microsec_time_clock.hpp>

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -5,6 +5,7 @@
 #include "neuropod/internal/logging.hh"
 #include "neuropod/multiprocess/control_messages.hh"
 #include "neuropod/multiprocess/ipc_control_channel.hh"
+#include "neuropod/multiprocess/ope_load_config.hh"
 #include "neuropod/multiprocess/shm_tensor.hh"
 #include "neuropod/multiprocess/tensor_utils.hh"
 #include "neuropod/neuropod.hh"

--- a/source/neuropod/multiprocess/ope_load_config.cc
+++ b/source/neuropod/multiprocess/ope_load_config.cc
@@ -1,0 +1,22 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/ope_load_config.hh"
+
+namespace neuropod
+{
+
+template <>
+void ipc_serialize(std::ostream &out, const ope_load_config &data)
+{
+    ipc_serialize(out, data.neuropod_path);
+}
+
+template <>
+void ipc_deserialize(std::istream &in, ope_load_config &data)
+{
+    ipc_deserialize(in, data.neuropod_path);
+}
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/ope_load_config.hh
+++ b/source/neuropod/multiprocess/ope_load_config.hh
@@ -1,0 +1,26 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/multiprocess/serialization/ipc_serialization.hh"
+
+namespace neuropod
+{
+
+// Contains everything needed to load a model in the worker process
+struct ope_load_config
+{
+    // The path of the model to load
+    std::string neuropod_path;
+};
+
+// Serialization specializations for ope_load_config
+template <>
+void ipc_serialize(std::ostream &out, const ope_load_config &data);
+
+template <>
+void ipc_deserialize(std::istream &in, ope_load_config &data);
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/serialization/BUILD
+++ b/source/neuropod/multiprocess/serialization/BUILD
@@ -1,0 +1,17 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+cc_library(
+    name = "serialization",
+    hdrs = [
+        "ipc_serialization.hh",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        "//neuropod/backends:neuropod_backend",
+        "@boost_repo//:boost",
+    ],
+)

--- a/source/neuropod/multiprocess/serialization/ipc_serialization.hh
+++ b/source/neuropod/multiprocess/serialization/ipc_serialization.hh
@@ -1,0 +1,194 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/internal/error_utils.hh"
+#include "neuropod/internal/memory_utils.hh"
+
+#include <istream>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// Utilities for checked reads and writes to and from streams
+template <typename... Params>
+inline void checked_write(std::ostream &stream, Params &&... params)
+{
+    stream.write(std::forward<Params>(params)...);
+    if (!stream)
+    {
+        NEUROPOD_ERROR("Writing to stream failed during IPC serialization");
+    }
+}
+
+template <typename... Params>
+inline void checked_read(std::istream &stream, Params &&... params)
+{
+    stream.read(std::forward<Params>(params)...);
+    if (!stream)
+    {
+        NEUROPOD_ERROR("Reading from stream failed during IPC serialization");
+    }
+}
+
+} // namespace detail
+
+// Serialization used for IPC
+// This type of serialization has less strict requirements than normal serialization
+// because the data is transient and will be written and read in different processes
+// on the same machine (so we don't need to worry about things like endianness).
+//
+// These methods handle primitive types (other than bool)
+template <typename T>
+inline void ipc_serialize(std::ostream &out, const T &item)
+{
+    static_assert(std::is_integral<T>::value, "The ipc_serialize function must be specialized for the requested type");
+
+    detail::checked_write(out, reinterpret_cast<const char *>(&item), sizeof(item));
+}
+
+template <typename T>
+inline void ipc_deserialize(std::istream &in, T &item)
+{
+    static_assert(std::is_integral<T>::value,
+                  "The ipc_deserialize function must be specialized for the requested type");
+
+    detail::checked_read(in, reinterpret_cast<char *>(&item), sizeof(item));
+}
+
+// Specialization for bool
+template <>
+inline void ipc_serialize(std::ostream &out, const bool &item)
+{
+    uint8_t value = item;
+    ipc_serialize(out, value);
+}
+
+template <>
+inline void ipc_deserialize(std::istream &in, bool &item)
+{
+    uint8_t value;
+    ipc_deserialize(in, value);
+    item = value;
+}
+
+// Specialization for strings
+template <>
+inline void ipc_serialize(std::ostream &out, const std::string &item)
+{
+    // Write the length
+    const size_t length = item.length();
+    ipc_serialize(out, length);
+
+    // Write the content
+    detail::checked_write(out, item.c_str(), length);
+}
+
+template <>
+inline void ipc_deserialize(std::istream &in, std::string &item)
+{
+    // A thread local buffer used for reading in strings of less than a certain size
+    static thread_local char static_buffer[2048];
+
+    // Get the length
+    size_t length;
+    ipc_deserialize(in, length);
+
+    // Read the string into a buffer
+    if (length < sizeof(static_buffer))
+    {
+        detail::checked_read(in, static_buffer, length);
+
+        // Set the content of `item`
+        item.assign(static_buffer, length);
+    }
+    else
+    {
+        // We need to allocate a larger buffer
+        auto buffer = stdx::make_unique<char[]>(length);
+        detail::checked_read(in, buffer.get(), length);
+
+        // Set the content of `item`
+        item.assign(buffer.get(), length);
+    }
+}
+
+// Specialization for vector
+template <typename T>
+inline void ipc_serialize(std::ostream &out, const std::vector<T> &item)
+{
+    // Write the size
+    const size_t size = item.size();
+    ipc_serialize(out, size);
+
+    // Write the content
+    for (const auto &elem : item)
+    {
+        ipc_serialize(out, elem);
+    }
+}
+
+template <typename T>
+inline void ipc_deserialize(std::istream &in, std::vector<T> &item)
+{
+    // Get the size
+    size_t size;
+    ipc_deserialize(in, size);
+
+    // Get the content
+    for (int i = 0; i < size; i++)
+    {
+        T elem;
+        ipc_deserialize(in, elem);
+        item.emplace_back(std::move(elem));
+    }
+}
+
+// Specialization for unordered_map
+template <typename K, typename V>
+inline void ipc_serialize(std::ostream &out, const std::unordered_map<K, V> &data)
+{
+    // Write the number of items
+    size_t num_items = data.size();
+    ipc_serialize(out, num_items);
+
+    for (const auto &entry : data)
+    {
+        // Write the key
+        ipc_serialize(out, entry.first);
+
+        // Write the value
+        ipc_serialize(out, entry.second);
+    }
+}
+
+template <typename K, typename V>
+inline void ipc_deserialize(std::istream &in, std::unordered_map<K, V> &data)
+{
+    // Read the number of items
+    size_t num_items;
+    ipc_deserialize(in, num_items);
+
+    for (int i = 0; i < num_items; i++)
+    {
+        // Read the key
+        K key;
+        ipc_deserialize(in, key);
+
+        // Read the value
+        V value;
+        ipc_deserialize(in, value);
+        data[key] = std::move(value);
+    }
+}
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/shm_tensor.hh
+++ b/source/neuropod/multiprocess/shm_tensor.hh
@@ -7,6 +7,7 @@
 #include "neuropod/backends/tensor_allocator.hh"
 #include "neuropod/internal/deleter.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
+#include "neuropod/multiprocess/serialization/ipc_serialization.hh"
 #include "neuropod/multiprocess/shm/shm_allocator.hh"
 
 #include <cassert>
@@ -230,5 +231,14 @@ protected:
         return std::string(wrapper->data, wrapper->data + wrapper->length);
     }
 };
+
+// Serialization specializations for SHMNeuropodTensor
+// Note: the specialization is for `shared_ptr<NeuropodValue>`, but we check internally
+// that the item is a SHMNeuropodTensor
+template <>
+void ipc_serialize(std::ostream &out, const std::shared_ptr<NeuropodValue> &data);
+
+template <>
+void ipc_deserialize(std::istream &in, std::shared_ptr<NeuropodValue> &data);
 
 } // namespace neuropod

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -92,6 +92,21 @@ cc_test(
 )
 
 cc_test(
+    name = "test_ipc_serialization",
+    srcs = [
+        "test_ipc_serialization.cc",
+        "//neuropod:libneuropod.so",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropod:neuropod_hdrs",
+        "//neuropod/multiprocess/serialization",
+        "//neuropod/multiprocess:ipc_control_channel",
+        "//neuropod/multiprocess:shm_tensor",
+    ],
+)
+
+cc_test(
     name = "test_python_bridge",
     srcs = [
         "test_python_bridge.cc",

--- a/source/neuropod/tests/test_ipc_serialization.cc
+++ b/source/neuropod/tests/test_ipc_serialization.cc
@@ -1,0 +1,113 @@
+//
+// Uber, In (c) 2020
+//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "neuropod/multiprocess/ope_load_config.hh"
+#include "neuropod/multiprocess/serialization/ipc_serialization.hh"
+#include "neuropod/multiprocess/shm_tensor.hh"
+
+namespace
+{
+
+template <typename T>
+T serialize_deserialize(const T &item)
+{
+    // Serialize the item
+    std::stringstream ss;
+    neuropod::ipc_serialize(ss, item);
+
+    // Deserialize the item
+    T out;
+    neuropod::ipc_deserialize(ss, out);
+    return std::move(out);
+}
+
+} // namespace
+
+TEST(test_ipc_serialization, vector)
+{
+    std::vector<std::string> expected = {"some", "vector", "of", "strings"};
+    const auto               actual   = serialize_deserialize(expected);
+
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(test_ipc_serialization, primitive_type)
+{
+    uint64_t   expected = 42;
+    const auto actual   = serialize_deserialize(expected);
+
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(test_ipc_serialization, bool)
+{
+    {
+        bool       expected = true;
+        const auto actual   = serialize_deserialize(expected);
+        EXPECT_EQ(expected, actual);
+    }
+    {
+        bool       expected = false;
+        const auto actual   = serialize_deserialize(expected);
+        EXPECT_EQ(expected, actual);
+    }
+}
+
+TEST(test_ipc_serialization, ope_load_config)
+{
+    neuropod::ope_load_config expected;
+    expected.neuropod_path = "/some/path";
+
+    const auto actual = serialize_deserialize(expected);
+
+    EXPECT_EQ(expected.neuropod_path, actual.neuropod_path);
+}
+
+TEST(test_ipc_serialization, neuropod_value_map)
+{
+    // A tensor allocator that allocates tensors in shared memory
+    std::unique_ptr<neuropod::NeuropodTensorAllocator> allocator =
+        neuropod::stdx::make_unique<neuropod::DefaultTensorAllocator<neuropod::SHMNeuropodTensor>>();
+
+    const std::shared_ptr<neuropod::NeuropodValue> float_tensor_1D =
+        allocator->allocate_tensor({3}, neuropod::FLOAT_TENSOR);
+    float_tensor_1D->as_typed_tensor<float>()->copy_from({0.0, 0.1, 0.2});
+
+    const std::shared_ptr<neuropod::NeuropodValue> string_tensor_2D =
+        allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
+    string_tensor_2D->as_typed_tensor<std::string>()->set({"A", "B", "C", "D"});
+
+    const std::shared_ptr<neuropod::NeuropodValue> int_tensor_2D =
+        allocator->allocate_tensor({2, 3}, neuropod::INT32_TENSOR);
+    int_tensor_2D->as_typed_tensor<int32_t>()->copy_from({0, 1, 2, 3, 4, 5});
+
+    // Create a map
+    neuropod::NeuropodValueMap expected;
+    expected["int"]    = int_tensor_2D;
+    expected["string"] = string_tensor_2D;
+    expected["float"]  = float_tensor_1D;
+
+    const auto actual = serialize_deserialize(expected);
+
+    EXPECT_EQ(*int_tensor_2D, *actual.at("int"));
+    EXPECT_EQ(*string_tensor_2D, *actual.at("string"));
+    EXPECT_EQ(*float_tensor_1D, *actual.at("float"));
+}
+
+TEST(test_ipc_serialization, empty_neuropod_value_map)
+{
+    neuropod::NeuropodValueMap expected;
+    const auto                 actual = serialize_deserialize(expected);
+
+    EXPECT_TRUE(actual.empty());
+}
+
+TEST(test_ipc_serialization, large_string)
+{
+    std::string expected(5000, 'a');
+    const auto  actual = serialize_deserialize(expected);
+    EXPECT_EQ(expected, actual);
+}


### PR DESCRIPTION
Serialization for IPC has less strict requirements than normal serialization because the data is transient and will be written and read in different processes on the same machine (so we don't need to worry about things like endianness).

This PR introduces some basic serialization for IPC that will be used in an upcoming PR