### PR TITLE
[OPE] Add WireFormat along with heartbeat and transferrables

### DIFF
--- a/source/neuropod/multiprocess/mq/BUILD
+++ b/source/neuropod/multiprocess/mq/BUILD
@@ -1,0 +1,25 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+cc_library(
+    name = "mq",
+    hdrs = [
+        "heartbeat.hh",
+        "transferrables.hh",
+        "wire_format.hh",
+        "wire_format_impl.hh",
+    ],
+    srcs = [
+        "wire_format.cc",
+        "transferrables.cc",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        "//neuropod/multiprocess/shm",
+        "//neuropod/multiprocess/serialization",
+        "@boost_repo//:boost",
+    ],
+)

--- a/source/neuropod/multiprocess/mq/heartbeat.hh
+++ b/source/neuropod/multiprocess/mq/heartbeat.hh
@@ -1,0 +1,76 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/multiprocess/mq/wire_format.hh"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// The interval at which each process should send a heartbeat
+constexpr int HEARTBEAT_INTERVAL_MS = 2000;
+
+// The timeout for a process to receive a message on a queue
+// This is generous since heartbeats are sent every 2 seconds (defined above)
+constexpr int MESSAGE_TIMEOUT_MS = 5000;
+
+// Ensure the timeout is larger than the heartbeat interval
+static_assert(MESSAGE_TIMEOUT_MS > HEARTBEAT_INTERVAL_MS, "Message timeout must be larger than the heartbeat interval");
+
+// Starts a new thread to send a heartbeat
+class HeartbeatController
+{
+private:
+    // State needed for the heartbeat thread
+    std::atomic_bool        send_heartbeat_{true};
+    std::condition_variable cv_;
+    std::mutex              mutex_;
+    std::thread             heartbeat_thread_;
+
+public:
+    template <typename MessageQueue>
+    HeartbeatController(MessageQueue &control_channel)
+        : send_heartbeat_(true), heartbeat_thread_([this, &control_channel]() {
+              // Send a heartbeat periodically
+              while (send_heartbeat_)
+              {
+                  // Send a heartbeat message
+                  typename MessageQueue::WireFormat msg;
+                  msg.type = detail::HEARTBEAT;
+                  control_channel.send_message(msg);
+
+                  // Using a condition variable lets us wake up while we're waiting
+                  std::unique_lock<std::mutex> lk(mutex_);
+                  cv_.wait_for(
+                      lk, std::chrono::milliseconds(HEARTBEAT_INTERVAL_MS), [&] { return send_heartbeat_ != true; });
+              }
+          })
+    {
+    }
+
+    ~HeartbeatController()
+    {
+        // Join the heartbeat thread
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            send_heartbeat_ = false;
+        }
+
+        cv_.notify_all();
+        heartbeat_thread_.join();
+    }
+};
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/transferrables.cc
+++ b/source/neuropod/multiprocess/mq/transferrables.cc
@@ -1,0 +1,58 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/mq/transferrables.hh"
+
+#include "neuropod/internal/logging.hh"
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+TransferrableController::TransferrableController() = default;
+TransferrableController::~TransferrableController()
+{
+    if (!in_transit_.empty())
+    {
+        SPDLOG_WARN("OPE: Transferrables not empty at shutdown");
+    }
+}
+
+void TransferrableController::add(uint64_t msg_id, Transferrables items)
+{
+    // Check if there are any transferrable items attached
+    if (!items.empty())
+    {
+        SPDLOG_TRACE("OPE: Adding {} transferrables for msg with id {}", items.size(), msg_id);
+        // Insert the transferrables into our map of items to store
+        std::lock_guard<std::mutex> lock(in_transit_mutex_);
+        for (auto &transferrable : items)
+        {
+            in_transit_.emplace(msg_id, std::move(transferrable));
+        }
+    }
+}
+
+void TransferrableController::done(uint64_t msg_id)
+{
+    SPDLOG_TRACE("OPE: Clearing transferrables for msg with id {}", msg_id);
+    std::lock_guard<std::mutex> lock(in_transit_mutex_);
+    in_transit_.erase(msg_id);
+}
+
+size_t TransferrableController::size()
+{
+    std::lock_guard<std::mutex> lock(in_transit_mutex_);
+    return in_transit_.size();
+}
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/transferrables.hh
+++ b/source/neuropod/multiprocess/mq/transferrables.hh
@@ -1,0 +1,54 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include <boost/any.hpp>
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// `Transferrables` are items that must be kept in scope while a message is in transit
+// Usually, these contain data that is stored in shared memory and is
+// used to ensure the sending process maintains a reference to the
+// data until the receiving process is done loading it.
+// This is used to implement cross-process "moves" of data in shared memory
+using Transferrables = std::vector<boost::any>;
+
+// Used to keep track of items in transit and free them when we receive a DONE message
+class TransferrableController
+{
+private:
+    // Stores items in transit
+    // A mapping from message_id to items that need to be kept in scope
+    // until a DONE message is received for that message id
+    std::unordered_multimap<uint64_t, boost::any> in_transit_;
+    std::mutex                                    in_transit_mutex_;
+
+public:
+    TransferrableController();
+    ~TransferrableController();
+
+    // Adds transferrables for a message with id `msg_id`
+    void add(uint64_t msg_id, Transferrables items);
+
+    // Mark a message as "done". This removes any transferrables that were
+    // associated with that message
+    void done(uint64_t msg_id);
+
+    // Returns how many messages with transferrable items are still
+    // in transit
+    size_t size();
+};
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/wire_format.cc
+++ b/source/neuropod/multiprocess/mq/wire_format.cc
@@ -1,0 +1,18 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/mq/wire_format.hh"
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// The allocator used to allocate SHM for serialization/deserialization into the wire format
+SHMAllocator wire_format_shm_allocator;
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/wire_format.hh
+++ b/source/neuropod/multiprocess/mq/wire_format.hh
@@ -1,0 +1,36 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/multiprocess/mq/transferrables.hh"
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// The on-the-wire format of the data
+// UserPayloadType should be an enum that specifies types of user payloads
+template <typename UserPayloadType>
+struct WireFormat;
+
+// Serialize a payload into `data` and add any created transferrables to `transferrables`
+// If the payload is small enough (less than the size of `payload_` in the wire format), it will be
+// stored inline in the message. Otherwise it'll be serialized and put into a shared memory
+// block. That block will be added to `transferrables` to ensure it stays in scope while the message
+// is in transit.
+template <typename Payload, typename UserPayloadType>
+void serialize_payload(const Payload &payload, WireFormat<UserPayloadType> &data, Transferrables &transferrables);
+
+// Get a payload of type `Payload` from a message
+template <typename Payload, typename UserPayloadType>
+void deserialize_payload(const WireFormat<UserPayloadType> &data, Payload &out);
+
+} // namespace detail
+
+} // namespace neuropod
+
+#include "neuropod/multiprocess/mq/wire_format_impl.hh"

--- a/source/neuropod/multiprocess/mq/wire_format_impl.hh
+++ b/source/neuropod/multiprocess/mq/wire_format_impl.hh
@@ -1,0 +1,159 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/internal/logging.hh"
+#include "neuropod/multiprocess/mq/wire_format.hh"
+#include "neuropod/multiprocess/serialization/ipc_serialization.hh"
+#include "neuropod/multiprocess/shm/shm_allocator.hh"
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// The maximum size of an inline payload
+constexpr size_t INLINE_PAYLOAD_SIZE_BYTES = 8192;
+
+enum QueueMessageType
+{
+    // Contains user defined data. The payload of this type of message is
+    // not handled by the queue directly and is added to `out_queue_`
+    USER_PAYLOAD,
+
+    // A heartbeat message
+    HEARTBEAT,
+
+    // A DONE message sent to signify that the specified message id
+    // went out of scope in the sending process (i.e. that the sending process is "done"
+    // with that message). This means we can drop our references to any transferrables
+    // tied to that message
+    DONE,
+
+    // Shutdown the queues
+    SHUTDOWN_QUEUES,
+};
+
+// The on-the-wire format of the data
+// UserPayloadType should be an enum that specifies types of payloads
+template <typename UserPayloadType>
+struct __attribute__((__packed__)) WireFormat
+{
+    // The ID of the message
+    uint64_t id;
+
+    // The type of the message
+    QueueMessageType type;
+
+    // Whether or not this message requires a DONE message
+    // to be sent when it goes out of scope in the receiving
+    // process
+    bool requires_done_msg = false;
+
+    // Whether or not the payload is inline
+    bool is_inline;
+
+    // The size of the payload in bytes
+    uint32_t payload_size;
+
+    // A user-defined type of the payload
+    // Note: this field is only checked if `type` is USER_PAYLOAD
+    UserPayloadType payload_type;
+
+    union {
+        // An inline payload
+        char payload[INLINE_PAYLOAD_SIZE_BYTES];
+
+        // An SHM id of the actual payload
+        // This is used for large messages that are serialized and put in
+        // shm
+        char payload_id[24];
+    };
+
+    WireFormat() = default;
+
+    // Delete the copy constructor and the copy assignment operator
+    WireFormat(const WireFormat<UserPayloadType> &) = delete;
+    WireFormat &operator=(const WireFormat<UserPayloadType> &other) = delete;
+
+    // Keep the move constructor and move assignment operator
+    WireFormat(WireFormat<UserPayloadType> &&) = default;
+    WireFormat &operator=(WireFormat<UserPayloadType> &&other) = default;
+};
+
+// The allocator used to allocate any SHM for the wire format
+extern SHMAllocator wire_format_shm_allocator;
+
+// Serialize a payload into `data` and add any created transferrables to `transferrables`
+// If the payload is small enough (less than the size of `payload_` in the wire format), it will be
+// stored inline in the message. Otherwise it'll be serialized and put into a shared memory
+// block. That block will be added to `transferrables` to ensure it stays in scope while the message
+// is in transit.
+template <typename Payload, typename UserPayloadType>
+void serialize_payload(const Payload &payload, WireFormat<UserPayloadType> &data, Transferrables &transferrables)
+{
+    // Serialize the payload
+    std::stringstream ss;
+    ipc_serialize(ss, payload);
+
+    // Set the size
+    auto size_bytes   = ss.tellp();
+    data.payload_size = size_bytes;
+
+    if (size_bytes <= sizeof(data.payload))
+    {
+        // We can store this message inline
+        ss.read(data.payload, size_bytes);
+        data.is_inline = true;
+    }
+    else
+    {
+        // Store in SHM and set msg.payload_id
+        SPDLOG_DEBUG("Could not fit data in inline message. Sending via SHM. Requested size: {}", size_bytes);
+        SHMBlockID block_id;
+
+        auto block = wire_format_shm_allocator.allocate_shm(size_bytes, block_id);
+
+        // Write the serialized message into the block
+        ss.read(static_cast<char *>(block.get()), size_bytes);
+
+        // Copy the block id into the message
+        memcpy(data.payload_id, block_id.data(), sizeof(data.payload_id));
+        data.is_inline = false;
+
+        // Add this block to our list of transferrables so it stays in scope until
+        // the other process reads the message
+        transferrables.emplace_back(std::move(block));
+    }
+}
+
+// Get a payload of type `Payload` from a message
+template <typename Payload, typename UserPayloadType>
+void deserialize_payload(const WireFormat<UserPayloadType> &data, Payload &out)
+{
+    std::stringstream ss;
+    if (data.is_inline)
+    {
+        // The message is inline so we can just read it
+        ss.write(data.payload, data.payload_size);
+    }
+    else
+    {
+        // The message is stored in SHM
+        SHMBlockID block_id;
+        memcpy(block_id.data(), data.payload_id, sizeof(data.payload_id));
+
+        // Load the block and get the data
+        auto block = wire_format_shm_allocator.load_shm(block_id);
+        ss.write(static_cast<char *>(block.get()), data.payload_size);
+    }
+
+    ipc_deserialize(ss, out);
+}
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -107,6 +107,39 @@ cc_test(
 )
 
 cc_test(
+    name = "test_ope_wire_format",
+    srcs = [
+        "test_ope_wire_format.cc",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropod/multiprocess/mq",
+    ],
+)
+
+cc_test(
+    name = "test_ope_heartbeat",
+    srcs = [
+        "test_ope_heartbeat.cc",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropod/multiprocess/mq",
+    ],
+)
+
+cc_test(
+    name = "test_ope_transferrables",
+    srcs = [
+        "test_ope_transferrables.cc",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropod/multiprocess/mq",
+    ],
+)
+
+cc_test(
     name = "test_python_bridge",
     srcs = [
         "test_python_bridge.cc",

--- a/source/neuropod/tests/test_ope_heartbeat.cc
+++ b/source/neuropod/tests/test_ope_heartbeat.cc
@@ -1,0 +1,58 @@
+//
+// Uber, In (c) 2020
+//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "neuropod/multiprocess/mq/heartbeat.hh"
+
+namespace
+{
+
+// A simple "message queue" that just waits for two heartbeat messages
+// to be sent before it can shutdown
+class TestChannel
+{
+private:
+    std::mutex              mutex_;
+    std::condition_variable cv_;
+
+    size_t num_heartbeats_;
+
+public:
+    struct WireFormat
+    {
+        neuropod::detail::QueueMessageType type;
+    };
+
+    TestChannel() = default;
+
+    ~TestChannel()
+    {
+        std::unique_lock<std::mutex> lk(mutex_);
+        cv_.wait(lk, [&]() { return num_heartbeats_ >= 2; });
+    };
+
+    void send_message(WireFormat msg)
+    {
+        if (msg.type == neuropod::detail::HEARTBEAT)
+        {
+            std::lock_guard<std::mutex> lk(mutex_);
+            num_heartbeats_++;
+            cv_.notify_all();
+        }
+    }
+};
+
+} // namespace
+
+TEST(test_ope_heartbeat, basic)
+{
+    auto test_channel = neuropod::stdx::make_unique<TestChannel>();
+
+    // Create a controller
+    neuropod::detail::HeartbeatController controller(*test_channel);
+
+    // Try to destroy the channel (which will only happen once two heartbeat messages have been sent)
+    test_channel.reset();
+}

--- a/source/neuropod/tests/test_ope_transferrables.cc
+++ b/source/neuropod/tests/test_ope_transferrables.cc
@@ -1,0 +1,57 @@
+//
+// Uber, In (c) 2020
+//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "neuropod/multiprocess/mq/transferrables.hh"
+
+namespace
+{
+
+int item_counter = 0;
+
+// A class that increments a counter on construction and decrements it on deletion
+// Note: this doesn't need to be threadsafe
+struct Item
+{
+    Item() { item_counter++; }
+    Item(const Item &) { item_counter++; }
+    Item(Item &&) { item_counter++; }
+
+    ~Item() { item_counter--; }
+};
+
+} // namespace
+
+TEST(test_ope_transferrables, basic)
+{
+    // Create a controller
+    neuropod::detail::TransferrableController controller;
+    EXPECT_EQ(0, controller.size());
+
+    // Add one item
+    controller.add(42, {Item()});
+    EXPECT_EQ(1, item_counter);
+    EXPECT_EQ(1, controller.size());
+
+    // Add two items
+    controller.add(23, {Item(), Item()});
+    EXPECT_EQ(3, item_counter);
+    EXPECT_EQ(3, controller.size());
+
+    // Clear a non-existing msg_id (which should have no impact)
+    controller.done(25);
+    EXPECT_EQ(3, item_counter);
+    EXPECT_EQ(3, controller.size());
+
+    // Clear the first msg_id (and we should have two items left)
+    controller.done(42);
+    EXPECT_EQ(2, item_counter);
+    EXPECT_EQ(2, controller.size());
+
+    // Clear the second msg_id (and we should have freed all our items)
+    controller.done(23);
+    EXPECT_EQ(0, item_counter);
+    EXPECT_EQ(0, controller.size());
+}

--- a/source/neuropod/tests/test_ope_wire_format.cc
+++ b/source/neuropod/tests/test_ope_wire_format.cc
@@ -1,0 +1,60 @@
+//
+// Uber, In (c) 2020
+//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "neuropod/multiprocess/mq/wire_format.hh"
+
+namespace
+{
+
+// An enum for user payload types
+// This is not being used as part of the test so we don't specify any payload types
+enum MessageType
+{
+};
+
+} // namespace
+
+TEST(test_ope_wire_format, small_payload)
+{
+    // Something that fits inline within the payload
+    std::vector<std::string> expected = {"some", "vector", "of", "strings"};
+
+    neuropod::detail::WireFormat<MessageType> msg;
+    neuropod::detail::Transferrables          transferrables;
+    neuropod::detail::serialize_payload(expected, msg, transferrables);
+
+    // This payload should fit within the message so transferrables should
+    // be empty
+    EXPECT_TRUE(transferrables.empty());
+
+    // Get the payload
+    std::vector<std::string> actual;
+    neuropod::detail::deserialize_payload(msg, actual);
+
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(test_ope_wire_format, large_payload)
+{
+    // Something that's too large to fit inline within the payload
+    std::string large_string(10000, ' ');
+
+    std::vector<std::string> expected = {large_string};
+
+    neuropod::detail::WireFormat<MessageType> msg;
+    neuropod::detail::Transferrables          transferrables;
+    neuropod::detail::serialize_payload(expected, msg, transferrables);
+
+    // This payload should not fit within the message so transferrables should
+    // contain exactly one item
+    EXPECT_EQ(1, transferrables.size());
+
+    // Get the payload
+    std::vector<std::string> actual;
+    neuropod::detail::deserialize_payload(msg, actual);
+
+    EXPECT_EQ(expected, actual);
+}


### PR DESCRIPTION
This PR adds some utility classes that will be used as part of a refactor of the IPC message queues