### PR TITLE
Add a NEUROPOD_ERROR_HH macro

### DIFF
--- a/source/neuropod/backends/neuropod_backend.cc
+++ b/source/neuropod/backends/neuropod_backend.cc
@@ -5,6 +5,7 @@
 #include "neuropod/backends/neuropod_backend.hh"
 
 #include "neuropod/internal/config_utils.hh"
+#include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/neuropod_loader.hh"
 
 namespace neuropod

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -5,6 +5,7 @@
 #include "python_bridge.hh"
 
 #include "neuropod/bindings/python_bindings.hh"
+#include "neuropod/internal/error_utils.hh"
 
 #include <exception>
 #include <sstream>

--- a/source/neuropod/backends/tensorflow/tf_tensor.hh
+++ b/source/neuropod/backends/tensorflow/tf_tensor.hh
@@ -6,6 +6,7 @@
 
 #include "neuropod/backends/tensorflow/type_utils.hh"
 #include "neuropod/internal/deleter.hh"
+#include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/logging.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
 #include "tensorflow/core/framework/tensor.h"

--- a/source/neuropod/backends/torchscript/torch_tensor.hh
+++ b/source/neuropod/backends/torchscript/torch_tensor.hh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "neuropod/internal/deleter.hh"
+#include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
 
 #include <caffe2/core/macros.h>

--- a/source/neuropod/bindings/python_bindings.cc
+++ b/source/neuropod/bindings/python_bindings.cc
@@ -4,6 +4,7 @@
 
 #include "neuropod/bindings/python_bindings.hh"
 
+#include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
 #include "neuropod/internal/neuropod_tensor_raw_data_access.hh"
 #include "neuropod/neuropod.hh"

--- a/source/neuropod/conversions/eigen.hh
+++ b/source/neuropod/conversions/eigen.hh
@@ -6,6 +6,7 @@
 
 // Utilities used to access data in neuropod tensor objects as Eigen library Matrices and Vectors
 
+#include "neuropod/internal/error_utils_header_only.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
 
 #include <Eigen/Dense>
@@ -22,9 +23,9 @@ Eigen::Map<const Eigen::Matrix<_Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::R
 
     if (dims.size() > 2)
     {
-        NEUROPOD_ERROR("Only tensors with rank of 1 or 2 are supported by this function. "
-                       "Tensor has rank of {}.",
-                       dims.size());
+        NEUROPOD_ERROR_HH("Only tensors with rank of 1 or 2 are supported by this function. "
+                          "Tensor has rank of {}.",
+                          dims.size());
     }
 
     const auto rows = dims[0];
@@ -43,9 +44,9 @@ Eigen::Map<Eigen::Matrix<_Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajo
 
     if (dims.size() > 2)
     {
-        NEUROPOD_ERROR("Only tensors with rank of 1 or 2 are supported by this function. "
-                       "Tensor has rank of {}.",
-                       dims.size());
+        NEUROPOD_ERROR_HH("Only tensors with rank of 1 or 2 are supported by this function. "
+                          "Tensor has rank of {}.",
+                          dims.size());
     }
 
     const auto rows = dims[0];

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -132,6 +132,10 @@ cc_library(
     name = "error_utils",
     hdrs = [
         "error_utils.hh",
+        "error_utils_header_only.hh",
+    ],
+    srcs = [
+        "error_utils_header_only.cc",
     ],
     visibility = [
         "//neuropod:__subpackages__",

--- a/source/neuropod/internal/error_utils.hh
+++ b/source/neuropod/internal/error_utils.hh
@@ -11,14 +11,26 @@
 namespace neuropod
 {
 
+namespace detail
+{
+
+template <typename... Params>
+[[noreturn]] void throw_error(const char *file, int line, const char *function, Params &&... params)
+{
+    // Log the error
+    // (this is effectively what the SPDLOG_ERROR macro expands to)
+    spdlog::default_logger_raw()->log(
+        spdlog::source_loc{file, line, function}, spdlog::level::err, std::forward<Params>(params)...);
+
+    // Throw a runtime error
+    throw std::runtime_error("Neuropod Error: " + fmt::format(std::forward<Params>(params)...));
+}
+
+} // namespace detail
+
 // A helper macro that lets us do things like
 // NEUROPOD_ERROR("Expected value {}, but got {}", a, b);
 // This will log the error message and then throw an exception
-#define NEUROPOD_ERROR(...)                                                      \
-    do                                                                           \
-    {                                                                            \
-        SPDLOG_ERROR(__VA_ARGS__);                                               \
-        throw std::runtime_error("Neuropod Error: " + fmt::format(__VA_ARGS__)); \
-    } while (0);
+#define NEUROPOD_ERROR(...) neuropod::detail::throw_error(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__);
 
 } // namespace neuropod

--- a/source/neuropod/internal/error_utils_header_only.cc
+++ b/source/neuropod/internal/error_utils_header_only.cc
@@ -1,0 +1,33 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/internal/error_utils_header_only.hh"
+
+#include "neuropod/internal/error_utils.hh"
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+void throw_error_hh(const char *file, int line, const char *function, const std::string &message)
+{
+    throw_error(file, line, function, message);
+}
+
+void throw_error_hh(const char *file, int line, const char *function, const std::string &message, size_t size)
+{
+    throw_error(file, line, function, message, size);
+}
+
+void throw_error_hh(
+    const char *file, int line, const char *function, const std::string &message, size_t size1, size_t size2)
+{
+    throw_error(file, line, function, message, size1, size2);
+}
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/internal/error_utils_header_only.hh
+++ b/source/neuropod/internal/error_utils_header_only.hh
@@ -1,0 +1,28 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include <string>
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+[[noreturn]] void throw_error_hh(const char *file, int line, const char *function, const std::string &message);
+[[noreturn]] void throw_error_hh(
+    const char *file, int line, const char *function, const std::string &message, size_t size);
+[[noreturn]] void throw_error_hh(
+    const char *file, int line, const char *function, const std::string &message, size_t size1, size_t size2);
+
+// An error macro for use in user-facing header files. This is done to avoid
+// having the release packages depend on fmt and spdlog being in the user's environment
+// See error_utils.hh for more
+#define NEUROPOD_ERROR_HH(...) neuropod::detail::throw_error_hh(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__);
+
+} // namespace detail
+
+} // namespace neuropod

--- a/source/neuropod/internal/neuropod_tensor.cc
+++ b/source/neuropod/internal/neuropod_tensor.cc
@@ -4,6 +4,8 @@
 
 #include "neuropod/internal/neuropod_tensor.hh"
 
+#include "neuropod/internal/error_utils.hh"
+
 namespace neuropod
 {
 
@@ -39,6 +41,22 @@ size_t compute_num_elements(const std::vector<int64_t> &dims)
 }
 
 } // namespace
+
+namespace detail
+{
+
+void throw_error_hh(const char *file, int line, const char *function, const std::string &message, TensorType type)
+{
+    throw_error(file, line, function, message, type);
+}
+
+void throw_error_hh(
+    const char *file, int line, const char *function, const std::string &message, TensorType type1, TensorType type2)
+{
+    throw_error(file, line, function, message, type1, type2);
+}
+
+} // namespace detail
 
 NeuropodTensor::NeuropodTensor(TensorType tensor_type, const std::vector<int64_t> dims)
     : NeuropodValue(true),

--- a/source/neuropod/multiprocess/shm_tensor.hh
+++ b/source/neuropod/multiprocess/shm_tensor.hh
@@ -6,6 +6,7 @@
 
 #include "neuropod/backends/tensor_allocator.hh"
 #include "neuropod/internal/deleter.hh"
+#include "neuropod/internal/error_utils.hh"
 #include "neuropod/internal/neuropod_tensor.hh"
 #include "neuropod/multiprocess/shm/shm_allocator.hh"
 


### PR DESCRIPTION
Introduces a separate error macro for use in user-facing header files. This lets us avoid having the release package depend on `fmt` and `spdlog`

Fixes #293 

