### PR TITLE
Improve error messages by printing enum names

### DIFF
--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -54,6 +54,7 @@ cc_library(
     name = "neuropod_tensor",
     srcs = [
         "neuropod_tensor.cc",
+        "tensor_types.cc",
     ],
     hdrs = [
         "tensor_accessor.hh",

--- a/source/neuropod/internal/tensor_types.cc
+++ b/source/neuropod/internal/tensor_types.cc
@@ -1,0 +1,37 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/internal/tensor_types.hh"
+
+namespace neuropod
+{
+
+// Used to print out the enum names rather than just a number
+std::ostream &operator<<(std::ostream &out, const TensorType value)
+{
+    const char *s = 0;
+#define GENERATE_CASE(item) \
+    case (item):            \
+        s = #item;          \
+        break;
+    switch (value)
+    {
+        GENERATE_CASE(FLOAT_TENSOR);
+        GENERATE_CASE(DOUBLE_TENSOR);
+        GENERATE_CASE(STRING_TENSOR);
+        GENERATE_CASE(INT8_TENSOR);
+        GENERATE_CASE(INT16_TENSOR);
+        GENERATE_CASE(INT32_TENSOR);
+        GENERATE_CASE(INT64_TENSOR);
+        GENERATE_CASE(UINT8_TENSOR);
+        GENERATE_CASE(UINT16_TENSOR);
+        GENERATE_CASE(UINT32_TENSOR);
+        GENERATE_CASE(UINT64_TENSOR);
+    }
+#undef GENERATE_CASE
+
+    return out << s;
+}
+
+} // namespace neuropod

--- a/source/neuropod/internal/tensor_types.hh
+++ b/source/neuropod/internal/tensor_types.hh
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <ostream>
+
 namespace neuropod
 {
 
@@ -24,5 +26,8 @@ enum TensorType
     UINT32_TENSOR,
     UINT64_TENSOR,
 };
+
+// Used to print out the enum names rather than just a number
+std::ostream &operator<<(std::ostream &out, const TensorType value);
 
 } // namespace neuropod


### PR DESCRIPTION
This PR improves error messages by printing out the name of `TensorType` enums rather than their values.

For example:

```
Tried to downcast tensor of type 0 to a TypedNeuropodTensor of type 3
```

turns into 

```
Tried to downcast tensor of type FLOAT_TENSOR to a TypedNeuropodTensor of type INT8_TENSOR
```