### PR TITLE
[OPE] Add OPE to RuntimeOptions

### DIFF
--- a/docs/advanced/ope.md
+++ b/docs/advanced/ope.md
@@ -3,14 +3,12 @@
 Neuropod can run models in different processes using an optimized shared memory implementation with extremely low overhead (~100 to 500 microseconds).
 
 
-To run a model in another process, modify your loading code as follows:
+To run a model in another process, set the `use_ope` option when loading a model:
 
 ```cpp
-#include <neuropod/multiprocess/multiprocess.hh>
-
-...
-
-auto neuropod = neuropod::load_neuropod_in_new_process(neuropod_path);
+neuropod::RuntimeOptions opts;
+opts.use_ope = true;
+Neuropod model(neuropod_path, opts);
 ```
 
 Nothing else should need to change.
@@ -24,5 +22,7 @@ There are many potential benefits of this approach:
 
 The worker process can also be run in a docker container to provide even more isolation.
 
+
+For more details and options, see the `OPEOptions` struct inside `RuntimeOptions`.
 
 TODO(vip): OPE string tensor support

--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -54,7 +54,6 @@ pkg_tar(
         "//neuropod/internal:libneuropod_internal_hdrs",
         "//neuropod/backends:libneuropod_backends_hdrs",
         "//neuropod/serialization:libneuropod_serialization_hdrs",
-        "//neuropod/multiprocess:libneuropod_multiprocess_hdrs",
     ],
 )
 

--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -2,8 +2,6 @@
 # Uber, Inc. (c) 2019
 #
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-
 cc_library(
     name = "shm_tensor",
     srcs = [
@@ -106,15 +104,5 @@ cc_library(
         "//neuropod/backends:neuropod_backend",
         "//neuropod/internal:deleter",
         "@boost_repo//:boost",
-    ],
-)
-
-# Package all the header files
-pkg_tar(
-    name = "libneuropod_multiprocess_hdrs",
-    package_dir = "multiprocess/",
-    srcs = glob(["*.hh"]),
-    visibility = [
-        "//visibility:public",
     ],
 )

--- a/source/neuropod/multiprocess/multiprocess.hh
+++ b/source/neuropod/multiprocess/multiprocess.hh
@@ -11,33 +11,7 @@
 namespace neuropod
 {
 
-// Start a worker process and run the neuropod in the worker
-// (using shared memory to communicate between the processes)
-// See the comment about `free_memory_every_cycle` below.
-//
-// This function starts a new worker process and loads a neuropod in it.
-// The below function loads a neuropod in an existing worker process.
-std::unique_ptr<Neuropod> load_neuropod_in_new_process(const std::string &   neuropod_path,
-                                                       const RuntimeOptions &options                 = {},
-                                                       bool                  free_memory_every_cycle = true);
-
-// Run the neuropod in an existing worker
-// (using shared memory to communicate between the processes)
-// Internally, this uses a shared memory allocator that reuses blocks of memory if possible.
-// Therefore memory isn't necessarily allocated during each cycle as blocks may be reused.
-//
-// If free_memory_every_cycle is set, then unused shared memory will be freed every cycle
-// This is useful for simple inference, but for code that is pipelined
-// (e.g. generating inputs for cycle t + 1 during the inference of cycle t), this may not
-// be desirable.
-//
-// If free_memory_every_cycle is false, the user is responsible for periodically calling
-// neuropod::free_unused_shm_blocks()
-//
-// This function loads a neuropod in an existing worker process.
-// The above function starts a new worker process and loads a neuropod in it.
-std::unique_ptr<Neuropod> load_neuropod_in_worker(const std::string &neuropod_path,
-                                                  const std::string &control_queue_name,
-                                                  bool               free_memory_every_cycle = true);
+// Load a neuropod using out of process execution. See the comments in `RuntimeOptions` for more details
+std::unique_ptr<NeuropodBackend> load_neuropod_ope(const std::string &neuropod_path, const RuntimeOptions &options);
 
 } // namespace neuropod

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -32,6 +32,31 @@ constexpr int GPU7 = 7;
 
 struct RuntimeOptions
 {
+    // Whether or not to use out-of-process execution
+    // (using shared memory to communicate between the processes)
+    bool use_ope = false;
+
+    // These options are only used if use_ope is set to true
+    struct OPEOptions
+    {
+        // Internally, OPE uses a shared memory allocator that reuses blocks of memory if possible.
+        // Therefore memory isn't necessarily allocated during each inference cycle as blocks may
+        // be reused.
+        //
+        // If free_memory_every_cycle is set, then unused shared memory will be freed every cycle
+        // This is useful for simple inference, but for code that is pipelined
+        // (e.g. generating inputs for cycle t + 1 during the inference of cycle t), this may not
+        // be desirable.
+        //
+        // If free_memory_every_cycle is false, the user is responsible for periodically calling
+        // neuropod::free_unused_shm_blocks()
+        bool free_memory_every_cycle = true;
+
+        // This option can be used to run the neuropod in an existing worker process
+        // If this string is empty, a new worker will be started.
+        std::string control_queue_name;
+    } ope_options;
+
     // The device to run this Neuropod on.
     // Some devices are defined in the namespace above. For machines with more
     // than 8 GPUs, passing in an index will also work (e.g. `9` for `GPU9`).

--- a/source/neuropod/python/utils/eval_utils.py
+++ b/source/neuropod/python/utils/eval_utils.py
@@ -65,10 +65,10 @@ def load_and_test_native(
     # Converts unicode to ascii for Python 3
     test_input_data = maybe_convert_bindings_types(test_input_data)
 
-    from neuropod_native import load_neuropod_in_new_process
+    from neuropod_native import Neuropod
 
     # Load the model using native out-of-process execution
-    model = load_neuropod_in_new_process(neuropod_path, **neuropod_load_args)
+    model = Neuropod(neuropod_path, use_ope=True, **neuropod_load_args)
     out = model.infer(test_input_data)
 
     # Check the output

--- a/source/neuropod/tests/benchmark_multiprocess.cc
+++ b/source/neuropod/tests/benchmark_multiprocess.cc
@@ -6,7 +6,6 @@
 // NEUROPOD_CI_SKIP_INFER
 
 #include "benchmark/benchmark.h"
-#include "neuropod/multiprocess/multiprocess.hh"
 #include "neuropod/neuropod.hh"
 
 namespace
@@ -24,7 +23,9 @@ struct load_out_of_process
 {
     std::unique_ptr<neuropod::Neuropod> operator()(const std::string &path)
     {
-        return neuropod::load_neuropod_in_new_process(path);
+        neuropod::RuntimeOptions opts;
+        opts.use_ope = true;
+        return neuropod::stdx::make_unique<neuropod::Neuropod>(path, opts);
     }
 };
 

--- a/source/neuropod/tests/test_multiprocess.cc
+++ b/source/neuropod/tests/test_multiprocess.cc
@@ -2,47 +2,40 @@
 // Uber, Inc. (c) 2019
 //
 
-#include "neuropod/multiprocess/multiprocess.hh"
 #include "neuropod/tests/test_utils.hh"
 
 TEST(test_multiprocess_backend, test_pytorch_addition_model)
 {
     // Test the PyTorch addition model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/pytorch_addition_model/");
-    test_addition_model(*neuropod);
+    test_addition_model_ope("neuropod/tests/test_data/pytorch_addition_model/");
 }
 
 TEST(test_multiprocess_backend, test_pytorch_strings_model)
 {
     // Test the PyTorch strings model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/pytorch_strings_model/");
-    test_strings_model(*neuropod);
+    test_strings_model_ope("neuropod/tests/test_data/pytorch_strings_model/");
 }
 
 TEST(test_multiprocess_backend, test_torchscript_addition_model)
 {
     // Test the TorchScript addition model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/torchscript_addition_model/");
-    test_addition_model(*neuropod);
+    test_addition_model_ope("neuropod/tests/test_data/torchscript_addition_model/");
 }
 
 TEST(test_multiprocess_backend, test_torchscript_strings_model)
 {
     // Test the TorchScript strings model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/torchscript_strings_model/");
-    test_strings_model(*neuropod);
+    test_strings_model_ope("neuropod/tests/test_data/torchscript_strings_model/");
 }
 
 TEST(test_multiprocess_backend, test_tensorflow_addition_model)
 {
     // Test the TensorFlow addition model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/tf_addition_model/");
-    test_addition_model(*neuropod);
+    test_addition_model_ope("neuropod/tests/test_data/tf_addition_model/");
 }
 
 TEST(test_multiprocess_backend, test_tensorflow_strings_model)
 {
     // Test the TensorFlow strings model in another process
-    auto neuropod = neuropod::load_neuropod_in_new_process("neuropod/tests/test_data/tf_strings_model/");
-    test_strings_model(*neuropod);
+    test_strings_model_ope("neuropod/tests/test_data/tf_strings_model/");
 }

--- a/source/neuropod/tests/test_utils.hh
+++ b/source/neuropod/tests/test_utils.hh
@@ -131,6 +131,15 @@ void test_addition_model(const std::string &neuropod_path)
     test_addition_model(neuropod);
 }
 
+void test_addition_model_ope(const std::string &neuropod_path)
+{
+    // Load the neuropod
+    neuropod::RuntimeOptions opts;
+    opts.use_ope = true;
+    neuropod::Neuropod neuropod(neuropod_path, opts);
+    test_addition_model(neuropod);
+}
+
 void test_strings_model(neuropod::Neuropod &neuropod)
 {
     // Tests a model that concatenates string tensors
@@ -186,5 +195,14 @@ void test_strings_model(const std::string &neuropod_path)
 {
     // Load the neuropod
     neuropod::Neuropod neuropod(neuropod_path);
+    test_strings_model(neuropod);
+}
+
+void test_strings_model_ope(const std::string &neuropod_path)
+{
+    // Load the neuropod
+    neuropod::RuntimeOptions opts;
+    opts.use_ope = true;
+    neuropod::Neuropod neuropod(neuropod_path, opts);
     test_strings_model(neuropod);
 }


### PR DESCRIPTION
Instead of having users call a separate `load_neuropod_in_new_process` function to use OPE, it is now just part of `RuntimeOptions`.