### PR TITLE
[OPE] Add IPC message queue implementation

### DIFF
--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -199,6 +199,16 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "blocking_spsc_queue",
+    hdrs = [
+        "blocking_spsc_queue.hh",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+)
+
 # Package all the header files
 pkg_tar(
     name = "libneuropod_internal_hdrs",

--- a/source/neuropod/internal/blocking_spsc_queue.hh
+++ b/source/neuropod/internal/blocking_spsc_queue.hh
@@ -1,0 +1,89 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+
+namespace neuropod
+{
+
+// A bounded blocking single producer single consumer (SPSC) queue
+template <typename T>
+class BlockingSPSCQueue
+{
+private:
+    std::queue<T>           queue_;
+    std::condition_variable full_cv_;
+    std::condition_variable empty_cv_;
+    std::mutex              mutex_;
+
+    size_t capacity_;
+
+public:
+    BlockingSPSCQueue(size_t capacity) : capacity_(capacity) {}
+    ~BlockingSPSCQueue() = default;
+
+    bool try_emplace(T &&item)
+    {
+        bool success = false;
+
+        // Lock the mutex and add to the queue if we have capacity
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (queue_.size() < capacity_)
+            {
+                queue_.emplace(std::forward<T>(item));
+                success = true;
+            }
+        }
+
+        // Notify any waiting read threads if we need to
+        if (success)
+        {
+            empty_cv_.notify_all();
+        }
+
+        return success;
+    }
+
+    void emplace(T &&item)
+    {
+        // Lock the mutex and add to the queue (or wait until we have capacity)
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (queue_.size() >= capacity_)
+            {
+                full_cv_.wait(lock, [&] { return queue_.size() < capacity_; });
+            }
+
+            queue_.emplace(std::forward<T>(item));
+        }
+
+        // Notify any waiting read threads
+        empty_cv_.notify_all();
+    }
+
+    void pop(T &item)
+    {
+        // Lock the mutex and get an item from the queue (or wait until we have an item)
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (queue_.empty())
+            {
+                empty_cv_.wait(lock, [&] { return !queue_.empty(); });
+            }
+
+            item = std::move(queue_.front());
+            queue_.pop();
+        }
+
+        // Notify any waiting write threads
+        full_cv_.notify_all();
+    }
+};
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/BUILD
+++ b/source/neuropod/multiprocess/mq/BUILD
@@ -6,11 +6,14 @@ cc_library(
     name = "mq",
     hdrs = [
         "heartbeat.hh",
+        "ipc_message_queue.hh",
+        "ipc_message_queue_impl.hh",
         "transferrables.hh",
         "wire_format.hh",
         "wire_format_impl.hh",
     ],
     srcs = [
+        "ipc_message_queue.cc",
         "wire_format.cc",
         "transferrables.cc",
     ],
@@ -18,6 +21,7 @@ cc_library(
         "//neuropod:__subpackages__",
     ],
     deps = [
+        "//neuropod/internal:blocking_spsc_queue",
         "//neuropod/multiprocess/shm",
         "//neuropod/multiprocess/serialization",
         "@boost_repo//:boost",

--- a/source/neuropod/multiprocess/mq/ipc_message_queue.cc
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue.cc
@@ -1,0 +1,25 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/multiprocess/mq/ipc_message_queue.hh"
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// Used to generate IDs for messages
+std::atomic_uint64_t msg_counter;
+
+} // namespace detail
+
+void cleanup_control_channels(const std::string &control_queue_name)
+{
+    // Delete the control channels
+    ipc::message_queue::remove(("neuropod_" + control_queue_name + "_tw").c_str());
+    ipc::message_queue::remove(("neuropod_" + control_queue_name + "_fw").c_str());
+}
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/mq/ipc_message_queue.hh
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue.hh
@@ -1,0 +1,137 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/internal/blocking_spsc_queue.hh"
+#include "neuropod/internal/error_utils.hh"
+#include "neuropod/internal/memory_utils.hh"
+#include "neuropod/multiprocess/mq/heartbeat.hh"
+#include "neuropod/multiprocess/mq/wire_format.hh"
+
+#include <boost/interprocess/ipc/message_queue.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <thread>
+#include <unordered_map>
+
+namespace ipc = boost::interprocess;
+
+namespace neuropod
+{
+
+// Forward declare IPCMessageQueue
+template <typename>
+class IPCMessageQueue;
+
+// This is the user-facing queue message type
+// UserPayloadType should be an enum that specifies types of payloads
+template <typename UserPayloadType>
+class QueueMessage
+{
+private:
+    // A pointer to the underlying data
+    std::shared_ptr<detail::WireFormat<UserPayloadType>> data_;
+
+    // Note: The constructor is private and only used in `IPCMessageQueue`
+    template <typename>
+    friend class IPCMessageQueue;
+
+    // Constructor used when receiving messages
+    QueueMessage(std::shared_ptr<detail::WireFormat<UserPayloadType>> data) : data_(std::move(data)) {}
+
+public:
+    ~QueueMessage() = default;
+
+    // Get a payload of type `Payload` from this message
+    template <typename Payload>
+    void get(Payload &out)
+    {
+        detail::deserialize_payload(*data_, out);
+    }
+
+    // Get the type of the user-defined payload included in this message
+    // This should only be used when it is known that this message contains
+    // a user-defined payload
+    UserPayloadType get_payload_type() { return data_->payload_type; }
+};
+
+// The type of the process creating the message queue
+enum ProcessType
+{
+    WORKER_PROCESS,
+    MAIN_PROCESS,
+};
+
+// A bidirectional IPC message queue that supports cross-process moves or copies of payloads.
+// Includes an implementation of heartbeats and message acknowledgement (in the form of DONE messages)
+// This class starts a thread for reading from the underlying `recv_queue` and uses a `HeartbeatController`
+// to start a thread for sending heartbeats.
+template <typename UserPayloadType>
+class IPCMessageQueue : public std::enable_shared_from_this<IPCMessageQueue<UserPayloadType>>
+{
+private:
+    using WireFormat = detail::WireFormat<UserPayloadType>;
+
+    // A queue to store output messages received by the read thread
+    BlockingSPSCQueue<std::unique_ptr<WireFormat>> out_queue_;
+
+    // Internal IPC queues to communicate with the other process
+    std::string                         control_queue_name_;
+    std::unique_ptr<ipc::message_queue> send_queue_;
+    std::unique_ptr<ipc::message_queue> recv_queue_;
+
+    // Responsible for periodically sending a heartbeat
+    friend class detail::HeartbeatController;
+    std::unique_ptr<detail::HeartbeatController> heartbeat_controller_;
+
+    // Responsible for keeping things in scope during cross-process moves
+    std::unique_ptr<detail::TransferrableController> transferrable_controller_;
+
+    // Whether or not a shutdown is in progress
+    bool shutdown_started_ = false;
+
+    // A thread that handles incoming messages
+    std::thread read_worker_;
+
+    // The worker loop for the message reading thread
+    void read_worker_loop();
+
+    // Send a message to the other process
+    void send_message(const WireFormat &msg);
+
+public:
+    IPCMessageQueue(const std::string &control_queue_name, ProcessType type);
+
+    ~IPCMessageQueue();
+
+    // Send a message with a payload
+    // Note: this is threadsafe
+    template <typename Payload>
+    void send_message(UserPayloadType payload_type, const Payload &payload);
+
+    // Send a message with a payload and ensure `payload` stays in
+    // scope until the other process is done using the message.
+    // Note: this is threadsafe
+    template <typename Payload>
+    void send_message_move(UserPayloadType payload_type, Payload payload);
+
+    // Send a message with just a payload_type
+    // Note: this is threadsafe
+    void send_message(UserPayloadType payload_type);
+
+    // Get a message. Blocks if the queue is empty.
+    // Note: this is _NOT_ threadsafe. There should only be one thread calling `recv_message`
+    // at a time.
+    QueueMessage<UserPayloadType> recv_message();
+};
+
+// Cleanup control channels for the queue with name `control_queue_name`
+void cleanup_control_channels(const std::string &control_queue_name);
+
+} // namespace neuropod
+
+#include "neuropod/multiprocess/mq/ipc_message_queue_impl.hh"

--- a/source/neuropod/multiprocess/mq/ipc_message_queue_impl.hh
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue_impl.hh
@@ -1,0 +1,287 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include "neuropod/multiprocess/mq/ipc_message_queue.hh"
+
+namespace ipc = boost::interprocess;
+
+namespace neuropod
+{
+
+namespace detail
+{
+
+// Used to generate IDs for messages
+extern std::atomic_uint64_t msg_counter;
+
+// The max size for the send and recv control queues
+constexpr auto MAX_QUEUE_SIZE = 20;
+
+template <typename UserPayloadType>
+inline std::unique_ptr<ipc::message_queue> make_queue(const std::string &control_queue_name_, const std::string &suffix)
+{
+    return stdx::make_unique<ipc::message_queue>(ipc::open_or_create,
+                                                 ("neuropod_" + control_queue_name_ + suffix).c_str(),
+                                                 MAX_QUEUE_SIZE,
+                                                 sizeof(WireFormat<UserPayloadType>));
+}
+
+template <typename UserPayloadType>
+inline std::unique_ptr<ipc::message_queue> make_send_queue(const std::string &control_queue_name_, ProcessType type)
+{
+    // Change the suffix depending on if this is the main process or worker process
+    return make_queue<UserPayloadType>(control_queue_name_, type == MAIN_PROCESS ? "_tw" : "_fw");
+}
+
+template <typename UserPayloadType>
+inline std::unique_ptr<ipc::message_queue> make_recv_queue(const std::string &control_queue_name_, ProcessType type)
+{
+    // Change the suffix depending on if this is the main process or worker process
+    return make_queue<UserPayloadType>(control_queue_name_, type == WORKER_PROCESS ? "_tw" : "_fw");
+}
+
+} // namespace detail
+
+// The worker loop for the message reading thread
+template <typename UserPayloadType>
+void IPCMessageQueue<UserPayloadType>::read_worker_loop()
+{
+    while (true)
+    {
+        // Compute the timeout
+        auto timeout_at = boost::interprocess::microsec_clock::universal_time() +
+                          boost::posix_time::milliseconds(detail::MESSAGE_TIMEOUT_MS);
+
+        // Get a message
+        auto         received = stdx::make_unique<WireFormat>();
+        size_t       received_size;
+        unsigned int priority;
+        bool         successful_read =
+            recv_queue_->timed_receive(received.get(), sizeof(WireFormat), received_size, priority, timeout_at);
+
+        if (!successful_read)
+        {
+            // We timed out
+            NEUROPOD_ERROR("Timed out waiting for a response from worker process. "
+                           "Didn't receive a message in {}ms, but expected a heartbeat every {}ms.",
+                           detail::MESSAGE_TIMEOUT_MS,
+                           detail::HEARTBEAT_INTERVAL_MS);
+        }
+
+        if (received->type == detail::USER_PAYLOAD)
+        {
+            SPDLOG_TRACE("OPE: Read thread received user payload {}.", received->payload_type);
+        }
+        else
+        {
+            SPDLOG_TRACE("OPE: Read thread received IPC control message {}.", received->type);
+        }
+
+        if (received->type == detail::HEARTBEAT)
+        {
+            // This is a heartbeat message so continue
+            continue;
+        }
+        else if (received->type == detail::DONE)
+        {
+            // Handle DONE messages by erasing all the in_transit items for that message
+            uint64_t acked_id;
+            detail::deserialize_payload(*received, acked_id);
+
+            transferrable_controller_->done(acked_id);
+        }
+        else if (received->type == detail::SHUTDOWN_QUEUES)
+        {
+            // Start a shutdown.
+            shutdown_started_ = true;
+
+            // Note: we're using the `try_` variant to avoid blocking shutdown here
+            // Note: out_queue_ should only have one listener at any given time
+            // (since recv isn't threadsafe). Because of this, this message should
+            // wake up a user thread that is blocked (if any)
+            out_queue_.try_emplace(std::move(received));
+        }
+        else
+        {
+            // This is a user-handled message
+            out_queue_.emplace(std::move(received));
+        }
+
+        if (shutdown_started_)
+        {
+            // Only shutdown once we've received DONEs for all the messages we've sent
+            const auto in_transit_count = transferrable_controller_->size();
+            if (in_transit_count == 0)
+            {
+                // We can finish shutting down
+                break;
+            }
+            else
+            {
+                SPDLOG_TRACE("OPE: Tried to shut down read worker thread, but still waiting on {} `DONE` messages.",
+                             in_transit_count);
+            }
+        }
+    }
+}
+
+// Send a message to the other process
+template <typename UserPayloadType>
+void IPCMessageQueue<UserPayloadType>::send_message(const WireFormat &msg)
+{
+    if (msg.type == detail::USER_PAYLOAD)
+    {
+        SPDLOG_TRACE("OPE: Sending user payload of type: {}", msg.payload_type);
+    }
+    else
+    {
+        SPDLOG_TRACE("OPE: Sending IPC control message {}.", msg.type);
+    }
+
+    send_queue_->send(&msg, sizeof(msg), 0);
+}
+
+template <typename UserPayloadType>
+IPCMessageQueue<UserPayloadType>::IPCMessageQueue(const std::string &control_queue_name, ProcessType type)
+    : out_queue_(detail::MAX_QUEUE_SIZE),
+      control_queue_name_(control_queue_name),
+      send_queue_(detail::make_send_queue<UserPayloadType>(control_queue_name_, type)),
+      recv_queue_(detail::make_recv_queue<UserPayloadType>(control_queue_name_, type)),
+      heartbeat_controller_(stdx::make_unique<detail::HeartbeatController>(*this)),
+      transferrable_controller_(stdx::make_unique<detail::TransferrableController>()),
+      read_worker_(&IPCMessageQueue<UserPayloadType>::read_worker_loop, this)
+{
+}
+
+template <typename UserPayloadType>
+IPCMessageQueue<UserPayloadType>::~IPCMessageQueue()
+{
+    heartbeat_controller_.reset();
+
+    // Send a shutdown message to ourselves
+    WireFormat msg;
+    msg.type = detail::SHUTDOWN_QUEUES;
+    SPDLOG_TRACE("OPE: Shutting down read thread...");
+    recv_queue_->send(&msg, sizeof(msg), 0);
+
+    // Join the read thread
+    read_worker_.join();
+}
+
+// Send a message with a payload
+// Note: this is threadsafe
+template <typename UserPayloadType>
+template <typename Payload>
+void IPCMessageQueue<UserPayloadType>::send_message(UserPayloadType payload_type, const Payload &payload)
+{
+    // Create a message
+    WireFormat msg;
+    msg.id           = detail::msg_counter++;
+    msg.type         = detail::USER_PAYLOAD;
+    msg.payload_type = payload_type;
+
+    // Set the payload
+    detail::Transferrables transferrables;
+    detail::serialize_payload(payload, msg, transferrables);
+
+    // Check if there are any transferrable items attached
+    if (!transferrables.empty())
+    {
+        transferrable_controller_->add(msg.id, transferrables);
+        msg.requires_done_msg = true;
+    }
+
+    // Send the message
+    send_message(msg);
+}
+
+// Send a message with a payload and ensure `payload` stays in
+// scope until the other process is done using the message.
+// Note: this is threadsafe
+template <typename UserPayloadType>
+template <typename Payload>
+void IPCMessageQueue<UserPayloadType>::send_message_move(UserPayloadType payload_type, Payload payload)
+{
+    // Create a message
+    WireFormat msg;
+    msg.id           = detail::msg_counter++;
+    msg.type         = detail::USER_PAYLOAD;
+    msg.payload_type = payload_type;
+
+    // Set the payload
+    detail::Transferrables transferrables;
+    detail::serialize_payload(payload, msg, transferrables);
+
+    // Add the payload to transferrables
+    transferrables.emplace_back(std::move(payload));
+
+    // Check if there are any transferrable items attached
+    if (!transferrables.empty())
+    {
+        transferrable_controller_->add(msg.id, transferrables);
+        msg.requires_done_msg = true;
+    }
+
+    // Send the message
+    send_message(msg);
+}
+
+// Send a message with just a payload_type
+// Note: this is threadsafe
+template <typename UserPayloadType>
+void IPCMessageQueue<UserPayloadType>::send_message(UserPayloadType payload_type)
+{
+    WireFormat msg;
+    msg.type         = detail::USER_PAYLOAD;
+    msg.payload_type = payload_type;
+    send_message(msg);
+}
+
+// Get a message. Blocks if the queue is empty.
+// Note: this is _NOT_ threadsafe. There should only be one thread calling `recv_message`
+// at a time.
+template <typename UserPayloadType>
+QueueMessage<UserPayloadType> IPCMessageQueue<UserPayloadType>::recv_message()
+{
+    // Read the message
+    std::unique_ptr<WireFormat> out;
+    out_queue_.pop(out);
+    SPDLOG_TRACE(
+        "OPE: Received user payload of type: {} (requires done: {})", out->payload_type, out->requires_done_msg);
+
+    // Convert this to a shared ptr with a deleter that acks the message
+    auto                        shared_this = this->shared_from_this();
+    std::shared_ptr<WireFormat> received_shared(out.release(), [shared_this](WireFormat *msg) {
+        if (msg->requires_done_msg)
+        {
+            // Notify the other process that this message is done being read from
+            // and any associated resources can be freed
+
+            // Create a message to ack `msg`
+            WireFormat ack_msg;
+            ack_msg.type = detail::DONE;
+
+            // Serialize the payload
+            detail::Transferrables transferrables;
+            detail::serialize_payload(msg->id, ack_msg, transferrables);
+
+            if (!transferrables.empty())
+            {
+                // This must be empty otherwise we'll have an infinite DONE chain
+                NEUROPOD_ERROR("[OPE] Transferrables must be empty when sending a `DONE` message.");
+            }
+
+            // Send the message
+            shared_this->send_message(ack_msg);
+        }
+
+        delete msg;
+    });
+
+    return QueueMessage<UserPayloadType>(std::move(received_shared));
+}
+
+} // namespace neuropod

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -282,6 +282,18 @@ cc_test(
 )
 
 cc_test(
+    name = "test_ipc_message_queue",
+    srcs = [
+        "test_ipc_message_queue.cc",
+    ],
+    deps = [
+        "@gtest//:main",
+        "//neuropod/multiprocess/mq",
+        "//neuropod/multiprocess:ipc_control_channel",
+    ],
+)
+
+cc_test(
     name = "test_multiprocess_worker",
     srcs = [
         "test_multiprocess_worker.cc",

--- a/source/neuropod/tests/test_ipc_control_channel.cc
+++ b/source/neuropod/tests/test_ipc_control_channel.cc
@@ -20,7 +20,7 @@ TEST(test_ipc_control_channel, simple)
     const std::vector<int64_t> dims      = {2, 4, 8, 16};
 
     // TODO(vip): maybe dynamically generate a queue name?
-    constexpr auto              queue_name = "neuropod_test_message_queue_simple";
+    constexpr auto              queue_name = "neuropod_test_control_channel_simple";
     neuropod::IPCControlChannel main_control_channel(queue_name, neuropod::MAIN_PROCESS);
     neuropod::IPCControlChannel worker_control_channel(queue_name, neuropod::WORKER_PROCESS);
 
@@ -44,7 +44,7 @@ TEST(test_ipc_control_channel, simple)
 
     // Receive the tensors
     neuropod::NeuropodValueMap recvd_map;
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
         // Get a message
         neuropod::ControlMessage received;
@@ -96,7 +96,7 @@ TEST(test_ipc_control_channel, no_tensors)
     neuropod::NeuropodValueMap sender_map;
 
     // TODO(vip): maybe dynamically generate a queue name?
-    constexpr auto              queue_name = "neuropod_test_message_queue_no_tensors";
+    constexpr auto              queue_name = "neuropod_test_control_channel_no_tensors";
     neuropod::IPCControlChannel main_control_channel(queue_name, neuropod::MAIN_PROCESS);
     neuropod::IPCControlChannel worker_control_channel(queue_name, neuropod::WORKER_PROCESS);
 
@@ -107,7 +107,7 @@ TEST(test_ipc_control_channel, no_tensors)
     main_control_channel.send_message(neuropod::INFER);
 
     // Receive the tensors
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
         // Get a message
         neuropod::ControlMessage received;

--- a/source/neuropod/tests/test_ipc_message_queue.cc
+++ b/source/neuropod/tests/test_ipc_message_queue.cc
@@ -1,0 +1,150 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "gtest/gtest.h"
+#include "neuropod/multiprocess/control_messages.hh"
+#include "neuropod/multiprocess/mq/ipc_message_queue.hh"
+#include "neuropod/multiprocess/shm_tensor.hh"
+
+// TODO(vip): These tests are basically identical to the ones in `test_ipc_control_channel`
+// Delete these tests once ipc_control_channel is using ipc_message_queue
+TEST(test_ipc_message_queue, simple)
+{
+    // TODO(vip): maybe dynamically generate a queue name?
+    constexpr auto queue_name = "neuropod_test_message_queue_simple";
+    {
+        // A tensor allocator that allocates tensors in shared memory
+        std::unique_ptr<neuropod::NeuropodTensorAllocator> allocator =
+            neuropod::stdx::make_unique<neuropod::DefaultTensorAllocator<neuropod::SHMNeuropodTensor>>();
+
+        // Store tensors we allocate so they don't go out of scope
+        neuropod::NeuropodValueMap sender_map;
+
+        // Sample data
+        constexpr size_t           num_items = 1024;
+        const std::vector<int64_t> dims      = {2, 4, 8, 16};
+
+        auto main_control_channel =
+            std::make_shared<neuropod::IPCMessageQueue<neuropod::MessageType>>(queue_name, neuropod::MAIN_PROCESS);
+        auto worker_control_channel =
+            std::make_shared<neuropod::IPCMessageQueue<neuropod::MessageType>>(queue_name, neuropod::WORKER_PROCESS);
+
+        // Allocate some tensors
+        for (uint8_t i = 0; i < 16; i++)
+        {
+            const uint8_t some_data[num_items] = {i};
+
+            // Allocate some memory and copy in data
+            auto tensor = allocator->allocate_tensor<uint8_t>(dims);
+            tensor->copy_from(some_data, num_items);
+
+            sender_map[std::to_string(i)] = tensor;
+        }
+
+        // Send the tensors
+        main_control_channel->send_message(neuropod::LOAD_NEUROPOD);
+        main_control_channel->send_message(neuropod::LOAD_SUCCESS);
+        main_control_channel->send_message_move(neuropod::ADD_INPUT, sender_map);
+        main_control_channel->send_message(neuropod::INFER);
+
+        // Receive the tensors
+        neuropod::NeuropodValueMap recvd_map;
+        for (int i = 0; i < 4; i++)
+        {
+            // Get a message
+            auto received = worker_control_channel->recv_message();
+            auto msg_type = received.get_payload_type();
+
+            switch (i)
+            {
+            case 0:
+                EXPECT_EQ(msg_type, neuropod::LOAD_NEUROPOD);
+                break;
+            case 1:
+                EXPECT_EQ(msg_type, neuropod::LOAD_SUCCESS);
+                break;
+            case 2:
+                EXPECT_EQ(msg_type, neuropod::ADD_INPUT);
+                received.get(recvd_map);
+                break;
+            default:
+                EXPECT_EQ(msg_type, neuropod::INFER);
+                break;
+            }
+        }
+
+        // Make sure the received tensors are what we expect
+        EXPECT_EQ(recvd_map.size(), sender_map.size());
+        for (const auto &item : recvd_map)
+        {
+            auto i      = static_cast<uint8_t>(std::stoi(item.first));
+            auto tensor = item.second->as_typed_tensor<uint8_t>();
+
+            // Make sure dims match
+            auto actual_dims = tensor->get_dims();
+            EXPECT_EQ(actual_dims, dims);
+
+            // Make sure the data is what we expect
+            const uint8_t expected_data[num_items] = {i};
+            auto          actual_data              = tensor->get_raw_data_ptr();
+            EXPECT_EQ(memcmp(actual_data, expected_data, num_items * sizeof(uint8_t)), 0);
+        }
+    }
+
+    // Cleanup
+    neuropod::cleanup_control_channels(queue_name);
+}
+
+TEST(test_ipc_message_queue, no_tensors)
+{
+    // TODO(vip): maybe dynamically generate a queue name?
+    constexpr auto queue_name = "neuropod_test_message_queue_no_tensors";
+    {
+        // An empty map to send
+        neuropod::NeuropodValueMap sender_map;
+
+        auto main_control_channel =
+            std::make_shared<neuropod::IPCMessageQueue<neuropod::MessageType>>(queue_name, neuropod::MAIN_PROCESS);
+        auto worker_control_channel =
+            std::make_shared<neuropod::IPCMessageQueue<neuropod::MessageType>>(queue_name, neuropod::WORKER_PROCESS);
+
+        // Send an empty map of tensors
+        main_control_channel->send_message(neuropod::LOAD_NEUROPOD);
+        main_control_channel->send_message(neuropod::LOAD_SUCCESS);
+        main_control_channel->send_message_move(neuropod::ADD_INPUT, sender_map);
+        main_control_channel->send_message(neuropod::INFER);
+
+        // Receive the tensors
+        for (int i = 0; i < 4; i++)
+        {
+            // Get a message
+            auto received = worker_control_channel->recv_message();
+            auto msg_type = received.get_payload_type();
+
+            switch (i)
+            {
+            case 0:
+                EXPECT_EQ(msg_type, neuropod::LOAD_NEUROPOD);
+                break;
+            case 1:
+                EXPECT_EQ(msg_type, neuropod::LOAD_SUCCESS);
+                break;
+            case 2: {
+                // We need a new scope here because of the `tmp` variable declaration
+                EXPECT_EQ(msg_type, neuropod::ADD_INPUT);
+                neuropod::NeuropodValueMap tmp;
+                received.get(tmp);
+                EXPECT_EQ(tmp.size(), 0);
+                break;
+            }
+            default:
+                EXPECT_EQ(msg_type, neuropod::INFER);
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    neuropod::cleanup_control_channels(queue_name);
+}


### PR DESCRIPTION
Adds a bidirectional IPC message queue that supports cross-process copies and transfers of generic user-specified payloads. The only requirement is that the payload must be serializable using `ipc_serialize`. The message queue also uses heartbeats in both directions to ensure that both processes are alive.