### PR TITLE
[OPE] Finish OPE message queue refactor

### DIFF
--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -36,6 +36,7 @@ cc_library(
     ],
     deps = [
         ":shm_tensor",
+        "//neuropod/multiprocess/mq",
     ],
 )
 

--- a/source/neuropod/multiprocess/control_messages.cc
+++ b/source/neuropod/multiprocess/control_messages.cc
@@ -21,12 +21,9 @@ std::ostream &operator<<(std::ostream &out, const MessageType value)
         GENERATE_CASE(LOAD_SUCCESS);
         GENERATE_CASE(ADD_INPUT);
         GENERATE_CASE(INFER);
-        GENERATE_CASE(REQUEST_OUTPUT);
         GENERATE_CASE(RETURN_OUTPUT);
-        GENERATE_CASE(END_OUTPUT);
-        GENERATE_CASE(INFER_COMPLETE);
-        GENERATE_CASE(HEARTBEAT);
         GENERATE_CASE(SHUTDOWN);
+        GENERATE_CASE(EXCEPTION);
     }
 #undef GENERATE_CASE
 

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include "neuropod/internal/error_utils.hh"
-
-#include <set>
+#include <ostream>
 
 namespace neuropod
 {
@@ -20,17 +18,12 @@ enum MessageType
 
     // Sent by the worker process to confirm that the model has been successfully
     // loaded.
-    // Valid next messages: ADD_INPUT
+    // Valid next messages: ADD_INPUT, LOAD_NEUROPOD
     LOAD_SUCCESS,
 
     // Sent by the main process when passing tensors to the worker process
-    // Valid next messages: ADD_INPUT, REQUEST_OUTPUT, INFER
+    // Valid next messages: INFER
     ADD_INPUT,
-
-    // Sent by the main process to the worker process to request a subset
-    // of the outputs
-    // Valid next messages: REQUEST_OUTPUT, INFER
-    REQUEST_OUTPUT,
 
     // Sent by the main process once all inputs have been added and we're ready
     // to run inference
@@ -38,46 +31,19 @@ enum MessageType
     INFER,
 
     // Sent by the worker process when passing tensors to the main process
-    // Valid next messages: RETURN_OUTPUT, END_OUTPUT
-    RETURN_OUTPUT,
-
-    // Sent by the worker process once inference is completed and all outputs
-    // have been sent to the main process
-    // Valid next messages: INFER_COMPLETE
-    END_OUTPUT,
-
-    // Sent by the main process once inference is complete
-    // This is used to notify the worker process that it no longer needs to store
-    // the model outputs.
     // Valid next messages: ADD_INPUT, LOAD_NEUROPOD
-    INFER_COMPLETE,
-
-    // A noop message sent by the worker process used to ensure that the worker
-    // is alive
-    // Note: it is valid to send this message at any time.
-    HEARTBEAT,
+    RETURN_OUTPUT,
 
     // A message sent by the main process to ask the worker to terminate
     // Note: it is valid to send this message at any time.
     SHUTDOWN,
+
+    // A message sent by the worker process to let the main process know there was an exception
+    // Note: it is valid to send this message at any time.
+    EXCEPTION,
 };
 
 // Used to print out the enum names rather than just a number
 std::ostream &operator<<(std::ostream &out, const MessageType value);
-
-// We can batch multiple tensors into a single message in order to minimize
-// communication overhead. This is the maximum number of tensors we can include
-// in a single message
-constexpr int MAX_NUM_TENSORS_PER_MESSAGE = 20;
-
-// The worker process should send a heartbeat every 2 seconds
-constexpr int HEARTBEAT_INTERVAL_MS = 2000;
-
-// 5 second timeout for the main process to receive a message from the worker
-// This is generous since the worker sends heartbeats every 2 seconds (defined above)
-constexpr int MESSAGE_TIMEOUT_MS = 5000;
-
-// Ensure the timeout is larger than the heartbeat interval
-static_assert(MESSAGE_TIMEOUT_MS > HEARTBEAT_INTERVAL_MS, "Message timeout must be larger than the heartbeat interval");
 
 } // namespace neuropod

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -4,15 +4,10 @@
 
 #pragma once
 
-#include "neuropod/backends/neuropod_backend.hh"
 #include "neuropod/multiprocess/control_messages.hh"
-#include "neuropod/multiprocess/ope_load_config.hh"
-
-#include <boost/interprocess/ipc/message_queue.hpp>
+#include "neuropod/multiprocess/mq/ipc_message_queue.hh"
 
 #include <mutex>
-
-namespace ipc = boost::interprocess;
 
 namespace neuropod
 {
@@ -31,68 +26,19 @@ public:
     void assert_transition_allowed(MessageType current_type);
 };
 
-// Used when creating an IPCControlChannel
-enum ProcessType
-{
-    WORKER_PROCESS,
-    MAIN_PROCESS,
-};
-
-// The user facing interface for IPC control messages
-class ControlMessage
-{
-private:
-    // Forward declare the internal control_message struct
-    struct control_message_internal;
-
-    // A pointer to the underlying struct
-    std::unique_ptr<control_message_internal> msg_;
-
-    friend class IPCControlChannel;
-
-public:
-    ControlMessage();
-    ~ControlMessage();
-
-    // Get the type of the message
-    MessageType get_type();
-
-    // Get a vector of tensor names from the message.
-    // This adds items to `data` without clearing it
-    void get_tensor_names(std::vector<std::string> &data);
-
-    // Get a the map data in the message
-    // This adds items to `data` without clearing it
-    void get_valuemap(NeuropodValueMap &data);
-
-    // Get a load_config message from this ControlMessage
-    void get_load_config(ope_load_config &data);
-};
-
 class IPCControlChannel
 {
 private:
+    using MessageQueue = IPCMessageQueue<MessageType>;
+
+    // The name of the control queue;
+    std::string control_queue_name_;
+
     // Control channels for communicating between the main process and worker process
-    std::string                         control_queue_name_;
-    std::unique_ptr<ipc::message_queue> send_queue_;
-    std::unique_ptr<ipc::message_queue> recv_queue_;
+    std::shared_ptr<MessageQueue> queue_;
 
     // Verifies that the state machine is operating as expected
     TransitionVerifier verifier_;
-
-    // Alias used in the implementation
-    using control_message = ControlMessage::control_message_internal;
-
-    // Utility to send a message to a message queue
-    // Note: this is threadsafe
-    void send_message(control_message &msg);
-
-    // Utility to send a message to a message queue
-    // Does not block if the message queue is full
-    // This must be used when sending messages to the main process outside of the
-    // normal inference process (e.g. HEARTBEAT messages)
-    // Note: this is threadsafe
-    bool try_send_message(control_message &msg);
 
 public:
     IPCControlChannel(const std::string &control_queue_name, ProcessType type);
@@ -102,31 +48,32 @@ public:
     // Note: this is threadsafe
     void send_message(MessageType type);
 
-    // Utility to send a message to a message queue
-    // Does not block if the message queue is full
-    // This must be used when sending messages to the main process outside of the
-    // normal inference process (e.g. HEARTBEAT messages)
+    // Utility to send a payload to a message queue
     // Note: this is threadsafe
-    bool try_send_message(MessageType type);
+    template <typename Payload>
+    void send_message(MessageType payload_type, const Payload &payload)
+    {
+        verifier_.assert_transition_allowed(payload_type);
+        queue_->send_message(payload_type, payload);
+    }
 
-    // Utility to send a vector of tensor names to a message queue
-    // Note: this is threadsafe
-    void send_message(MessageType type, const std::vector<std::string> &data);
-
-    // Utility to send a NeuropodValueMap to a message queue
-    // Note: this is threadsafe
-    void send_message(MessageType type, const NeuropodValueMap &data);
-
-    // Utility to send a `ope_load_config` struct to a message queue
-    void send_message(MessageType type, const ope_load_config &data);
+    template <typename Payload>
+    void send_message_move(MessageType payload_type, Payload payload)
+    {
+        verifier_.assert_transition_allowed(payload_type);
+        queue_->send_message_move(payload_type, std::move(payload));
+    }
 
     // Receive a message
-    void recv_message(ControlMessage &received);
+    QueueMessage<MessageType> recv_message()
+    {
+        auto msg = queue_->recv_message();
+        verifier_.assert_transition_allowed(msg.get_payload_type());
 
-    // Receive a message with a timeout
-    bool recv_message(ControlMessage &received, size_t timeout_ms);
+        return msg;
+    }
 
-    // Cleanup the message queues
+    // Shutdown the control channel and cleanup the IPC queues
     void cleanup();
 };
 

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -20,70 +20,6 @@
 namespace neuropod
 {
 
-namespace
-{
-
-// Starts a new thread to send a heartbeat
-class HeartbeatController
-{
-private:
-    std::atomic_bool        send_heartbeat_;
-    std::condition_variable cv_;
-    std::mutex              mutex_;
-    std::thread             heartbeat_thread_;
-
-public:
-    HeartbeatController(IPCControlChannel &control_channel, size_t interval_ms)
-        : send_heartbeat_(true), heartbeat_thread_([this, &control_channel, interval_ms]() {
-              // Send a heartbeat every 2 seconds
-              while (send_heartbeat_)
-              {
-                  // Note: we're using `try_send_message` instead of `send_message` because
-                  // we don't want to block if the message queue is full.
-                  // This is important because it could prevent shutdown and cause the worker
-                  // and main process to hang.
-                  //
-                  // For example:
-                  // - The main process loads a neuropod using the multiprocess backend (but does not run inference)
-                  // - The (worker -> main process) message queue fills up with HEARTBEAT messages
-                  //   (because messages are only read from that queue during inference)
-                  //
-                  // - This thread blocks on sending the next HEARTBEAT message
-                  // - The main process sends a SHUTDOWN message and waits for the worker to shut down
-                  // - The destructor of `HeartbeatController` runs and runs `join` on this thread
-                  //
-                  // This will cause both processes to hang forever because the worker is still blocked on the message
-                  // queue and the main process is waiting for this process to shutdown.
-
-                  // try_send_message is threadsafe so we don't need synchronization here
-                  if (!control_channel.try_send_message(HEARTBEAT))
-                  {
-                      SPDLOG_DEBUG("OPE: Message queue full - skipped sending heartbeat");
-                  }
-
-                  // This lets us break out of waiting if we're told to shutdown
-                  std::unique_lock<std::mutex> lk(mutex_);
-                  cv_.wait_for(lk, std::chrono::milliseconds(interval_ms), [&] { return send_heartbeat_ != true; });
-              }
-          })
-    {
-    }
-
-    ~HeartbeatController()
-    {
-        // Join the heartbeat thread
-        {
-            std::lock_guard<std::mutex> lk(mutex_);
-            send_heartbeat_ = false;
-        }
-
-        cv_.notify_all();
-        heartbeat_thread_.join();
-    }
-};
-
-} // namespace
-
 // The main loop for a worker that runs a neuropod
 void multiprocess_worker_loop(const std::string &control_queue_name)
 {
@@ -97,95 +33,88 @@ void multiprocess_worker_loop(const std::string &control_queue_name)
     // A map to store the inputs
     NeuropodValueMap inputs;
 
-    // A vector of requested outputs
-    std::vector<std::string> requested_outputs;
-
-    // The last outputs
-    // We need to keep these around so there isn't a race condition when returning
-    // data back to the main process
-    NeuropodValueMap last_outputs;
-
-    // Send a heartbeat periodically
-    HeartbeatController heartbeat_controller(control_channel, HEARTBEAT_INTERVAL_MS);
-
     while (true)
     {
         // Get a message
-        ControlMessage received;
-        control_channel.recv_message(received);
+        auto received = control_channel.recv_message();
+        auto msg_type = received.get_payload_type();
 
-        auto msg_type = received.get_type();
-
-        if (msg_type == LOAD_NEUROPOD)
+        try
         {
-            ope_load_config config;
-            received.get_load_config(config);
-
-            // Load a neuropod
-            neuropod  = stdx::make_unique<Neuropod>(config.neuropod_path);
-            allocator = neuropod->get_tensor_allocator();
-            inputs.clear();
-            last_outputs.clear();
-            control_channel.send_message(LOAD_SUCCESS);
-        }
-        else if (msg_type == ADD_INPUT)
-        {
-            NeuropodValueMap tmp;
-            received.get_valuemap(tmp);
-
-            for (auto &item : tmp)
+            if (msg_type == LOAD_NEUROPOD)
             {
-                // Wrap in a tensor type that this neuropod expects
-                inputs[item.first] =
-                    wrap_existing_tensor(*allocator, std::dynamic_pointer_cast<NeuropodTensor>(item.second));
+                ope_load_config config;
+                received.get(config);
+
+                // Load a neuropod
+                neuropod  = stdx::make_unique<Neuropod>(config.neuropod_path);
+                allocator = neuropod->get_tensor_allocator();
+                inputs.clear();
+                control_channel.send_message(LOAD_SUCCESS);
+            }
+            else if (msg_type == ADD_INPUT)
+            {
+                NeuropodValueMap tmp;
+                received.get(tmp);
+
+                for (auto &item : tmp)
+                {
+                    // Wrap in a tensor type that this neuropod expects
+                    inputs[item.first] =
+                        wrap_existing_tensor(*allocator, std::dynamic_pointer_cast<NeuropodTensor>(item.second));
+                }
+            }
+            else if (msg_type == INFER)
+            {
+                // Get the requested tensor names
+                std::vector<std::string> requested_outputs;
+                received.get(requested_outputs);
+
+                // Run inference
+                auto outputs = neuropod->infer(inputs, requested_outputs);
+
+                // Turn these "native" tensors into shm tensors
+                NeuropodValueMap transformed_outputs;
+                for (const auto &entry : *outputs)
+                {
+                    // Unfortunately, this requires a copy (done within SHMNeuropodTensor)
+                    auto shm_tensor = wrap_existing_tensor<SHMNeuropodTensor>(
+                        std::dynamic_pointer_cast<NeuropodTensor>(entry.second));
+
+                    // This ensures that the tensor stays around long enough for the other process to load it
+                    transformed_outputs[entry.first] = shm_tensor;
+                }
+
+                control_channel.send_message_move(RETURN_OUTPUT, std::move(transformed_outputs));
+
+                // Clean up any unused shm tensors that haven't been reused
+                shm_allocator.free_unused_shm_blocks();
+
+                // Empty the inputs set. This is done after sending outputs back to the main process
+                // because this takes a nontrivial amount of time
+                inputs.clear();
+            }
+            else if (msg_type == SHUTDOWN)
+            {
+                break;
+            }
+            else
+            {
+                NEUROPOD_ERROR("OPE: Unhandled message type: {}", msg_type);
             }
         }
-        else if (msg_type == REQUEST_OUTPUT)
+        catch (const std::exception &e)
         {
-            // Get the requested tensor names
-            received.get_tensor_names(requested_outputs);
+            // Send the exception info back to the main process
+            std::string msg = e.what();
+            control_channel.send_message(EXCEPTION, msg);
         }
-        else if (msg_type == INFER)
+        catch (...)
         {
-            // Run inference
-            auto outputs = neuropod->infer(inputs, requested_outputs);
-
-            // Turn these "native" tensors into shm tensors
-            for (const auto &entry : *outputs)
-            {
-                // Unfortunately, this requires a copy (done within SHMNeuropodTensor)
-                auto shm_tensor =
-                    wrap_existing_tensor<SHMNeuropodTensor>(std::dynamic_pointer_cast<NeuropodTensor>(entry.second));
-
-                // This ensures that the tensor stays around long enough for the other process to load it
-                last_outputs[entry.first] = shm_tensor;
-            }
-
-            control_channel.send_message(RETURN_OUTPUT, last_outputs);
-
-            // Let the main process know that we're done
-            control_channel.send_message(END_OUTPUT);
-
-            // Clean up any unused shm tensors that haven't been reused
-            shm_allocator.free_unused_shm_blocks();
-
-            // Clear the requested outputs
-            requested_outputs.clear();
-
-            // Empty the inputs set. This is done after sending outputs back to the main process
-            // because this takes a nontrivial amount of time
-            inputs.clear();
+            control_channel.send_message(EXCEPTION, "An unknown exception occurred during inference");
         }
-        else if (msg_type == INFER_COMPLETE)
-        {
-            // The main process loaded our output tensors
-            // We no longer need to maintain references to these tensors
-            last_outputs.clear();
-        }
-        else if (msg_type == SHUTDOWN)
-        {
-            break;
-        }
+
+        SPDLOG_TRACE("OPE: BOTTOM OF WORKER LOOP");
     }
 }
 

--- a/source/neuropod/multiprocess/serialization/ipc_serialization.hh
+++ b/source/neuropod/multiprocess/serialization/ipc_serialization.hh
@@ -122,6 +122,14 @@ inline void ipc_deserialize(std::istream &in, std::string &item)
     }
 }
 
+// Specialization for serializing char[] (for constant strings)
+template <size_t N>
+inline void ipc_serialize(std::ostream &out, const char (&item)[N])
+{
+    std::string str = item;
+    ipc_serialize(out, str);
+}
+
 // Specialization for vector
 template <typename T>
 inline void ipc_serialize(std::ostream &out, const std::vector<T> &item)

--- a/source/neuropod/tests/test_ipc_control_channel.cc
+++ b/source/neuropod/tests/test_ipc_control_channel.cc
@@ -47,9 +47,8 @@ TEST(test_ipc_control_channel, simple)
     for (int i = 0; i < 4; i++)
     {
         // Get a message
-        neuropod::ControlMessage received;
-        worker_control_channel.recv_message(received);
-        auto msg_type = received.get_type();
+        auto received = worker_control_channel.recv_message();
+        auto msg_type = received.get_payload_type();
 
         switch (i)
         {
@@ -61,7 +60,7 @@ TEST(test_ipc_control_channel, simple)
             break;
         case 2:
             EXPECT_EQ(msg_type, neuropod::ADD_INPUT);
-            received.get_valuemap(recvd_map);
+            received.get(recvd_map);
             break;
         default:
             EXPECT_EQ(msg_type, neuropod::INFER);
@@ -110,9 +109,8 @@ TEST(test_ipc_control_channel, no_tensors)
     for (int i = 0; i < 4; i++)
     {
         // Get a message
-        neuropod::ControlMessage received;
-        worker_control_channel.recv_message(received);
-        auto msg_type = received.get_type();
+        auto received = worker_control_channel.recv_message();
+        auto msg_type = received.get_payload_type();
 
         switch (i)
         {
@@ -126,7 +124,7 @@ TEST(test_ipc_control_channel, no_tensors)
             // We need a new scope here because of the `tmp` variable declaration
             EXPECT_EQ(msg_type, neuropod::ADD_INPUT);
             neuropod::NeuropodValueMap tmp;
-            received.get_valuemap(tmp);
+            received.get(tmp);
             EXPECT_EQ(tmp.size(), 0);
             break;
         }

--- a/source/neuropod/tests/test_multiprocess_allowed_transitions.cc
+++ b/source/neuropod/tests/test_multiprocess_allowed_transitions.cc
@@ -12,22 +12,8 @@ TEST(test_multiprocess_allowed_transitions, simple)
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
     verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
-    verifier.assert_transition_allowed(neuropod::ADD_INPUT);
-
-    // A heartbeat is allowed at any time
-    verifier.assert_transition_allowed(neuropod::HEARTBEAT);
-
-    verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::INFER);
     verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
-
-    // A heartbeat is allowed at any time
-    verifier.assert_transition_allowed(neuropod::HEARTBEAT);
-
-    verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::END_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::INFER_COMPLETE);
 }
 
 TEST(test_multiprocess_allowed_transitions, shutdown)
@@ -36,7 +22,6 @@ TEST(test_multiprocess_allowed_transitions, shutdown)
 
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
     verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
-    verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
 
     // Shutdown is allowed at any time
@@ -58,10 +43,9 @@ TEST(test_multiprocess_allowed_transitions, invalid)
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);
     verifier.assert_transition_allowed(neuropod::LOAD_SUCCESS);
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
-    verifier.assert_transition_allowed(neuropod::ADD_INPUT);
 
     // This is invalid
-    EXPECT_ANY_THROW(verifier.assert_transition_allowed(neuropod::INFER_COMPLETE));
+    EXPECT_ANY_THROW(verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD));
 }
 
 TEST(test_multiprocess_allowed_transitions, new_infer)
@@ -74,8 +58,6 @@ TEST(test_multiprocess_allowed_transitions, new_infer)
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::INFER);
     verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::END_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::INFER_COMPLETE);
 
     // Running inference again is valid
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
@@ -91,8 +73,6 @@ TEST(test_multiprocess_allowed_transitions, load_neuropod)
     verifier.assert_transition_allowed(neuropod::ADD_INPUT);
     verifier.assert_transition_allowed(neuropod::INFER);
     verifier.assert_transition_allowed(neuropod::RETURN_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::END_OUTPUT);
-    verifier.assert_transition_allowed(neuropod::INFER_COMPLETE);
 
     // Loading another neuropod is valid
     verifier.assert_transition_allowed(neuropod::LOAD_NEUROPOD);


### PR DESCRIPTION
This PR completes the OPE message queue refactor (see #297, #298, #299, and #304).

Since the message queue is now handling more responsibilities than it previously did (e.g. heartbeats, variable sized payloads, cross-process moves, etc.), we can also simplify the explicit messaging between the main process and the worker process.