### PR TITLE
[Build] Simplify the bazel build

### DIFF
--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -15,9 +15,9 @@ http_archive(
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
-# This is a manylinux2010 compatible sysroot
+# This is a manylinux2014 compatible sysroot
 http_archive(
-    name = "manylinux2010_sysroot",
+    name = "manylinux2014_sysroot",
     build_file_content = """
 filegroup(
   name = "sysroot",
@@ -25,15 +25,15 @@ filegroup(
   visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "5be526543d53eada141921dd5108e082953e7fcb0131df09dde7e9efd109eeae",
-    urls = ["https://github.com/VivekPanyam/manylinux-sysroot/releases/download/0.0.1/manylinux2010_sysroot.tar.gz"],
+    sha256 = "2c5aa261bb7a124e2363b6f42f93e6188c44f2aa8871496adef61a653ccd0575",
+    urls = ["https://github.com/VivekPanyam/manylinux-sysroot/releases/download/0.0.1/manylinux2014_sysroot.tar.gz"],
 )
 
 llvm_toolchain(
     name = "llvm_toolchain",
     llvm_version = "9.0.0",
     sysroot = {
-        "linux": "@manylinux2010_sysroot//:sysroot",
+        "linux": "@manylinux2014_sysroot//:sysroot",
     },
 )
 

--- a/source/deps/BUILD.libtorch
+++ b/source/deps/BUILD.libtorch
@@ -7,7 +7,15 @@ package(
 )
 
 cc_library(
-    name = "libtorch_hdrs",
+    name = "libtorch",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": glob(["lib/libcaffe2.dylib", "lib/libc10.dylib", "lib/libtorch.dylib", "lib/libtorch.1.dylib"]),
+        "//conditions:default": glob(["lib/libcaffe2.so", "lib/libtorch.so", "lib/libc10.so"]),
+    }),
+    deps = select({
+        "@bazel_tools//src/conditions:darwin": ["@mklml_repo_darwin//:mklml"],
+        "//conditions:default": [],
+    }),
     hdrs = glob([
         "include/ATen/**",
         "include/c10/**",
@@ -22,18 +30,6 @@ cc_library(
         "include/torch/csrc/api/include",
     ],
     defines = {TORCH_DEFINES}
-)
-
-cc_library(
-    name = "libtorch",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": glob(["lib/libcaffe2.dylib", "lib/libc10.dylib", "lib/libtorch.dylib", "lib/libtorch.1.dylib"]),
-        "//conditions:default": ["lib/libtorch.so"],
-    }),
-    deps = select({
-        "@bazel_tools//src/conditions:darwin": ["@mklml_repo_darwin//:mklml"],
-        "//conditions:default": [],
-    }),
 )
 
 filegroup(

--- a/source/deps/BUILD.tensorflow
+++ b/source/deps/BUILD.tensorflow
@@ -10,7 +10,7 @@ cc_library(
     name = "libtensorflow",
     srcs = select({
         "@bazel_tools//src/conditions:darwin": glob(["lib/libtensorflow.so", "lib/libtensorflow.1.dylib"]),
-        "//conditions:default": glob(["lib/libtensorflow.so", "lib/libtensorflow.so.1"]),
+        "//conditions:default": glob(["lib/libtensorflow.so", "lib/libtensorflow_framework.so", "lib/libtensorflow.so.1", "lib/libtensorflow_framework.so.1"]),
     }),
 )
 

--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -15,8 +15,7 @@ cc_library(
     ],
     deps = [
         "//neuropod/backends:neuropod_backend",
-        "//neuropod/internal:neuropod_config_utils",
-        "//neuropod/internal:neuropod_tensor",
+        "//neuropod/internal",
     ],
 )
 
@@ -25,6 +24,16 @@ cc_binary(
     linkshared = True,
     linkstatic = True,
     linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":neuropod_impl",
+    ]
+)
+
+cc_library(
+    name = "neuropod_impl",
     srcs = [
         "neuropod.cc",
     ],
@@ -33,13 +42,11 @@ cc_binary(
     ],
     deps = [
         ":neuropod_hdrs",
-        "//neuropod/internal:backend_registration_impl",
-        "//neuropod/internal:neuropod_loader_impl",
-        "//neuropod/internal:neuropod_tensor_raw_data_access_impl",
-        "//neuropod/internal:tensor_serialization_impl",
-        "//neuropod/multiprocess:multiprocess_impl",
-        "//neuropod/serialization:serialization_impl",
-    ]
+        "//neuropod/internal:impl",
+        "//neuropod/multiprocess:impl",
+        "//neuropod/serialization:impl",
+    ],
+    alwayslink = True,
 )
 
 pkg_tar(

--- a/source/neuropod/backends/BUILD
+++ b/source/neuropod/backends/BUILD
@@ -17,11 +17,7 @@ cc_library(
         "//visibility:public",
     ],
     deps = [
-        "//neuropod/internal:backend_registration",
-        "//neuropod/internal:deleter",
-        "//neuropod/internal:neuropod_config_utils",
-        "//neuropod/internal:neuropod_tensor",
-        "//neuropod/internal:neuropod_loader",
+        "//neuropod/internal",
     ],
 )
 

--- a/source/neuropod/backends/python_bridge/BUILD
+++ b/source/neuropod/backends/python_bridge/BUILD
@@ -7,14 +7,28 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 cc_binary(
     name = "libneuropod_pythonbridge_backend.so",
     srcs = [
-        "python_bridge.cc",
-        "python_bridge.hh",
         "//neuropod:libneuropod.so",
     ],
     linkshared = True,
     linkstatic = True,
     linkopts = [
         "-Wl,-rpath,$$ORIGIN",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        ":python_bridge",
+    ],
+)
+
+cc_library(
+    name = "python_bridge",
+    srcs = [
+        "python_bridge.cc",
+        "python_bridge.hh",
+    ],
+    linkopts = [
         "-ldl",
     ],
     visibility = [
@@ -23,9 +37,10 @@ cc_binary(
     deps = [
         "//neuropod/backends:neuropod_backend",
         "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod/bindings:bindings",
-        "//neuropod/internal:deleter",
+        "//neuropod/bindings",
+        "//neuropod/internal",
     ],
+    alwayslink = True,
 )
 
 pkg_tar(

--- a/source/neuropod/backends/tensorflow/BUILD
+++ b/source/neuropod/backends/tensorflow/BUILD
@@ -8,12 +8,6 @@ load("//bazel:copy_libs.bzl", "copy_libs")
 cc_binary(
     name = "libneuropod_tensorflow_backend.so",
     srcs = [
-        "tf_backend.cc",
-        "tf_backend.hh",
-        "tf_tensor.cc",
-        "tf_tensor.hh",
-        "type_utils.cc",
-        "type_utils.hh",
         "//neuropod:libneuropod.so",
     ],
     linkshared = True,
@@ -23,16 +17,35 @@ cc_binary(
         "//neuropod:__subpackages__",
     ],
     deps = [
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends:neuropod_backend",
-        "//neuropod/internal:deleter",
-        "//neuropod/internal:logging",
-        "@tensorflow_hdrs_repo//:tensorflow_hdrs",
-        "@tensorflow_repo//:libtensorflow",
+        ":tensorflow_backend",
     ],
     data = [
         "copy_libtensorflow",
     ]
+)
+
+cc_library(
+    name = "tensorflow_backend",
+    srcs = [
+        "tf_backend.cc",
+        "tf_backend.hh",
+        "tf_tensor.cc",
+        "tf_tensor.hh",
+        "type_utils.cc",
+        "type_utils.hh",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        "//neuropod:neuropod_hdrs",
+        "//neuropod/backends:neuropod_backend",
+        "//neuropod/internal",
+        "@tensorflow_hdrs_repo//:tensorflow_hdrs",
+        "@tensorflow_repo//:libtensorflow",
+        "@libjsoncpp_repo//:libjsoncpp",
+    ],
+    alwayslink = True,
 )
 
 copy_libs(

--- a/source/neuropod/backends/test_backend/BUILD
+++ b/source/neuropod/backends/test_backend/BUILD
@@ -13,14 +13,27 @@ cc_library(
     ],
     deps = [
         "//neuropod/backends:neuropod_backend",
-        "//neuropod/internal:deleter",
+        "//neuropod/internal",
     ],
+)
+
+cc_library(
+    name = "test_backend",
+    srcs = [
+        "test_neuropod_backend.cc",
+    ],
+    visibility = [
+        "//neuropod:__subpackages__",
+    ],
+    deps = [
+        ":test_backend_hdrs"
+    ],
+    alwayslink = True
 )
 
 cc_binary(
     name = "libneuropod_test_backend.so",
     srcs = [
-        "test_neuropod_backend.cc",
         "//neuropod:libneuropod.so",
     ],
     linkshared = True,
@@ -30,6 +43,6 @@ cc_binary(
         "//neuropod:__subpackages__",
     ],
     deps = [
-        ":test_backend_hdrs"
+        ":test_backend"
     ]
 )

--- a/source/neuropod/backends/torchscript/BUILD
+++ b/source/neuropod/backends/torchscript/BUILD
@@ -8,8 +8,6 @@ load("//bazel:copy_libs.bzl", "copy_libs")
 cc_binary(
     name = "libneuropod_torchscript_backend.so",
     srcs = [
-        "torch_backend.cc",
-        "type_utils.cc",
         "//neuropod:libneuropod.so",
     ],
     linkshared = True,
@@ -19,9 +17,7 @@ cc_binary(
         "//neuropod:__subpackages__",
     ],
     deps = [
-        ":neuropod_torchscript_backend_hdrs",
-        "//neuropod/internal:deleter",
-        "@libtorch_repo//:libtorch",
+        ":torch_backend",
     ],
     data = [
         ":copy_libtorch",
@@ -29,7 +25,11 @@ cc_binary(
 )
 
 cc_library(
-    name = "neuropod_torchscript_backend_hdrs",
+    name = "torch_backend",
+    srcs = [
+        "torch_backend.cc",
+        "type_utils.cc",
+    ],
     hdrs = [
         "torch_backend.hh",
         "torch_tensor.hh",
@@ -40,9 +40,11 @@ cc_library(
     ],
     deps = [
         "//neuropod:neuropod_hdrs",
+        "//neuropod/internal",
         "//neuropod/backends:neuropod_backend",
-        "@libtorch_repo//:libtorch_hdrs",
-    ]
+        "@libtorch_repo//:libtorch",
+    ],
+    alwayslink = True,
 )
 
 copy_libs(

--- a/source/neuropod/bindings/BUILD
+++ b/source/neuropod/bindings/BUILD
@@ -10,8 +10,8 @@ cc_binary(
     ],
     deps = [
         ":bindings",
-        "//neuropod/multiprocess:multiprocess_hdrs",
-        "//neuropod/serialization:serialization_hdrs",
+        "//neuropod/multiprocess",
+        "//neuropod/serialization",
         "//neuropod/backends/test_backend:test_backend_hdrs",
     ],
     linkshared = True,
@@ -29,8 +29,7 @@ cc_library(
         "//neuropod:__subpackages__",
     ],
     deps = [
-        "//neuropod/internal:neuropod_tensor",
-        "//neuropod/internal:neuropod_tensor_raw_data_access",
+        "//neuropod/internal",
         "//neuropod:neuropod_hdrs",
         "@pybind11_repo//:pybind11",
     ],

--- a/source/neuropod/conversions/BUILD
+++ b/source/neuropod/conversions/BUILD
@@ -9,7 +9,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//neuropod/internal:neuropod_tensor",
+        "//neuropod/internal",
         "@eigen3_repo//:eigen3",
     ],
 )

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -5,198 +5,35 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 cc_library(
-    name = "neuropod_config_utils",
-    srcs = [
-        "config_utils.cc",
-    ],
-    hdrs = [
-        "config_utils.hh",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        ":error_utils",
-        ":memory_utils",
-        ":neuropod_loader",
-        ":neuropod_tensor",
-        "@libjsoncpp_repo//:libjsoncpp",
-    ],
-)
-
-cc_library(
-    name = "memory_utils",
-    hdrs = [
-        "memory_utils.hh",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-)
-
-cc_library(
-    name = "logging",
-    hdrs = [
-        "logging.hh",
-    ],
-    srcs = [
-        "logging.cc"
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        "@spdlog_repo//:spdlog",
-    ],
-)
-
-cc_library(
-    name = "neuropod_tensor",
-    srcs = [
-        "neuropod_tensor.cc",
-        "tensor_types.cc",
-    ],
-    hdrs = [
-        "tensor_accessor.hh",
-        "neuropod_tensor.hh",
-        "tensor_types.hh",
-        "type_macros.hh",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        ":error_utils",
-        ":memory_utils",
-    ],
-)
-
-cc_library(
-    name = "tensor_serialization_impl",
-    srcs = [
-        "neuropod_tensor_serialization.cc",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        ":neuropod_tensor_raw_data_access",
-        "@boost_repo//:boost",
-        "//neuropod/backends:neuropod_backend",
-        "//neuropod/serialization:serialization_hdrs",
-    ],
-)
-
-cc_library(
-    name = "backend_registration",
-    hdrs = [
-        "backend_registration.hh",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        ":error_utils",
-        ":memory_utils",
-        ":neuropod_config_utils",
-    ],
-)
-
-cc_library(
-    name = "backend_registration_impl",
-    srcs = [
-        "backend_registration.cc",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-    deps = [
-        ":backend_registration",
-    ],
-    linkopts = ["-ldl"],
-)
-
-cc_library(
-    name = "deleter",
-    hdrs = [
-        "deleter.hh",
-    ],
-    srcs = [
-        "deleter.cc",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-)
-
-cc_library(
-    name = "error_utils",
-    hdrs = [
-        "error_utils.hh",
-        "error_utils_header_only.hh",
-    ],
-    srcs = [
-        "error_utils_header_only.cc",
-    ],
+    name = "internal",
+    hdrs = glob(["*.hh"]),
     visibility = [
         "//neuropod:__subpackages__",
     ],
     deps = [
         "@fmt_repo//:fmt",
-        ":logging",
-    ],
+        "@spdlog_repo//:spdlog",
+    ]
 )
 
 cc_library(
-    name = "neuropod_loader",
-    hdrs = [
-        "neuropod_loader.hh",
-    ],
+    name = "impl",
+    srcs = glob(["*.cc"]),
+    linkopts = ["-ldl"],
     visibility = [
         "//neuropod:__subpackages__",
     ],
-)
-
-cc_library(
-    name = "neuropod_loader_impl",
-    srcs = [
-        "neuropod_loader.cc",
-    ],
     deps = [
-        ":error_utils",
-        ":neuropod_loader",
-        ":memory_utils",
+        ":internal",
+        "//neuropod/backends:neuropod_backend",
+        "//neuropod/serialization",
+        "@boost_repo//:boost",
         "@filesystem_repo//:filesystem",
+        "@libjsoncpp_repo//:libjsoncpp",
         "@picosha2_repo//:picosha2",
         "@zipper_repo//:zipper",
     ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-)
-
-cc_library(
-    name = "neuropod_tensor_raw_data_access",
-    hdrs = [
-        "neuropod_tensor_raw_data_access.hh",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
-)
-
-cc_library(
-    name = "neuropod_tensor_raw_data_access_impl",
-    srcs = [
-        "neuropod_tensor_raw_data_access.cc",
-    ],
-    deps = [
-        ":neuropod_tensor",
-        ":neuropod_tensor_raw_data_access",
-    ],
-    visibility = [
-        "//neuropod:__subpackages__",
-    ],
+    alwayslink = True,
 )
 
 cc_library(

--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -13,7 +13,7 @@ cc_library(
     ],
     deps = [
         "//neuropod/backends:neuropod_backend",
-        "//neuropod/internal:deleter",
+        "//neuropod/internal",
         "//neuropod/multiprocess/shm",
         "//neuropod/multiprocess/serialization",
     ],
@@ -55,7 +55,7 @@ cc_library(
     deps = [
         ":ipc_control_channel",
         "//neuropod:neuropod_hdrs",
-        "//neuropod/internal:neuropod_tensor_raw_data_access",
+        "//neuropod/internal",
     ],
 )
 
@@ -76,7 +76,7 @@ cc_binary(
 )
 
 cc_library(
-    name = "multiprocess_hdrs",
+    name = "multiprocess",
     hdrs = [
         "multiprocess.hh",
     ],
@@ -92,7 +92,7 @@ cc_library(
 )
 
 cc_library(
-    name = "multiprocess_impl",
+    name = "impl",
     srcs = [
         "multiprocess.cc",
     ],
@@ -106,7 +106,7 @@ cc_library(
         ":ipc_control_channel",
         "//neuropod:neuropod_hdrs",
         "//neuropod/backends:neuropod_backend",
-        "//neuropod/internal:deleter",
+        "//neuropod/internal",
         "@boost_repo//:boost",
     ],
 )

--- a/source/neuropod/multiprocess/shm/BUILD
+++ b/source/neuropod/multiprocess/shm/BUILD
@@ -18,9 +18,7 @@ cc_library(
         "//conditions:default": ["-lrt"],
     }),
     deps = [
-        "//neuropod/internal:error_utils",
-        "//neuropod/internal:logging",
-        "//neuropod/internal:memory_utils",
+        "//neuropod/internal",
         "@boost_repo//:boost",
     ],
 )

--- a/source/neuropod/serialization/BUILD
+++ b/source/neuropod/serialization/BUILD
@@ -5,7 +5,7 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 cc_library(
-    name = "serialization_hdrs",
+    name = "serialization",
     hdrs = [
         "serialization.hh",
     ],
@@ -18,7 +18,7 @@ cc_library(
 )
 
 cc_library(
-    name = "serialization_impl",
+    name = "impl",
     srcs = [
         "serialization.cc",
     ],
@@ -26,7 +26,7 @@ cc_library(
         "//neuropod:__subpackages__",
     ],
     deps = [
-        ":serialization_hdrs",
+        ":serialization",
         "//neuropod/backends:neuropod_backend",
     ],
 )

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -6,13 +6,11 @@ cc_test(
     name = "benchmark_accessor",
     srcs = [
         "benchmark_accessor.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@benchmark//:benchmark_main",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod:neuropod_hdrs",
+        "//neuropod/backends/test_backend",
+        "//neuropod:neuropod_impl",
     ],
 )
 
@@ -20,18 +18,15 @@ cc_test(
     name = "benchmark_multiprocess",
     srcs = [
         "benchmark_multiprocess.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@benchmark//:benchmark_main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/multiprocess:multiprocess_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/multiprocess",
+        "//neuropod/backends/tensorflow:tensorflow_backend",
     ],
     data = [
         "//neuropod/tests/test_data",
-        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
-        "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
-        "//neuropod/backends/tensorflow:libneuropod_tensorflow_backend.so",
     ],
 )
 
@@ -39,14 +34,12 @@ cc_test(
     name = "benchmark_serialization",
     srcs = [
         "benchmark_serialization.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@benchmark//:benchmark_main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod/serialization:serialization_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
+        "//neuropod/serialization",
     ],
 )
 
@@ -65,14 +58,12 @@ cc_test(
     name = "test_input_output",
     srcs = [
         "test_input_output.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod/serialization:serialization_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
+        "//neuropod/serialization",
     ],
 )
 
@@ -80,14 +71,12 @@ cc_test(
     name = "test_serialization",
     srcs = [
         "test_serialization.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod/serialization:serialization_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
+        "//neuropod/serialization",
     ],
 )
 
@@ -95,11 +84,10 @@ cc_test(
     name = "test_ipc_serialization",
     srcs = [
         "test_ipc_serialization.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/serialization",
         "//neuropod/multiprocess:ipc_control_channel",
         "//neuropod/multiprocess:shm_tensor",
@@ -113,6 +101,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/mq",
     ],
 )
@@ -124,6 +113,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/mq",
     ],
 )
@@ -135,6 +125,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/mq",
     ],
 )
@@ -143,11 +134,11 @@ cc_test(
     name = "test_python_bridge",
     srcs = [
         "test_python_bridge.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
     ],
     deps = [
         ":neuropod_test_utils",
+        "//neuropod/backends/python_bridge",
+        "//neuropod:neuropod_impl",
     ],
 )
 
@@ -155,11 +146,11 @@ cc_test(
     name = "gpu_test_python_bridge",
     srcs = [
         "gpu_test_python_bridge.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
     ],
     deps = [
         ":neuropod_test_utils",
+        "//neuropod/backends/python_bridge",
+        "//neuropod:neuropod_impl",
     ],
 )
 
@@ -167,12 +158,11 @@ cc_test(
     name = "test_torchscript_backend",
     srcs = [
         "test_torchscript_backend.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
     ],
     deps = [
         ":neuropod_test_utils",
-        "//neuropod/backends/torchscript:neuropod_torchscript_backend_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/torchscript:torch_backend",
     ],
 )
 
@@ -180,11 +170,11 @@ cc_test(
     name = "test_tensorflow_backend",
     srcs = [
         "test_tensorflow_backend.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/tensorflow:libneuropod_tensorflow_backend.so",
     ],
     deps = [
         ":neuropod_test_utils",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/tensorflow:tensorflow_backend",
     ],
 )
 
@@ -192,15 +182,13 @@ cc_test(
     name = "test_default_backend",
     srcs = [
         "test_default_backend.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         ":neuropod_test_utils",
-    ],
-    data = [
-        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
-        "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
-        "//neuropod/backends/tensorflow:libneuropod_tensorflow_backend.so",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/torchscript:torch_backend",
+        "//neuropod/backends/tensorflow:tensorflow_backend",
+        "//neuropod/backends/python_bridge",
     ],
     linkstatic = True,
 )
@@ -208,13 +196,12 @@ cc_test(
 cc_library(
     name = "neuropod_test_utils",
     hdrs = ["test_utils.hh"],
-    srcs = ["//neuropod:libneuropod.so"],
     visibility = [
         "//visibility:public",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
+        "//neuropod:neuropod_impl",
     ],
     data = [
         "//neuropod/tests/test_data"
@@ -225,12 +212,11 @@ cc_test(
     name = "test_config_utils",
     srcs = [
         "test_config_utils.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/internal:neuropod_config_utils",
+        "//neuropod:neuropod_impl",
+        "//neuropod/internal",
     ],
 )
 
@@ -238,13 +224,11 @@ cc_test(
     name = "test_accessor",
     srcs = [
         "test_accessor.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod:neuropod_hdrs",
+        "//neuropod/backends/test_backend",
+        "//neuropod:neuropod_impl",
     ],
 )
 
@@ -255,6 +239,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/shm",
     ],
 )
@@ -266,6 +251,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess:shm_tensor",
     ],
 )
@@ -277,6 +263,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess:ipc_control_channel",
     ],
 )
@@ -288,6 +275,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess/mq",
         "//neuropod/multiprocess:ipc_control_channel",
     ],
@@ -297,10 +285,10 @@ cc_test(
     name = "test_multiprocess_worker",
     srcs = [
         "test_multiprocess_worker.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess:multiprocess_worker",
     ],
 )
@@ -312,6 +300,7 @@ cc_test(
     ],
     deps = [
         "@gtest//:main",
+        "//neuropod:neuropod_impl",
         "//neuropod/multiprocess:ipc_control_channel",
     ],
 )
@@ -320,16 +309,14 @@ cc_test(
     name = "test_multiprocess",
     srcs = [
         "test_multiprocess.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         ":neuropod_test_utils",
-        "//neuropod/multiprocess:multiprocess_hdrs",
-    ],
-    data = [
-        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
-        "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
-        "//neuropod/backends/tensorflow:libneuropod_tensorflow_backend.so",
+        "//neuropod:neuropod_impl",
+        "//neuropod/multiprocess",
+        "//neuropod/backends/torchscript:torch_backend",
+        "//neuropod/backends/tensorflow:tensorflow_backend",
+        "//neuropod/backends/python_bridge",
     ],
 )
 
@@ -337,13 +324,12 @@ cc_test(
     name = "test_internal_neuropod_tensor",
     srcs = [
         "test_internal_neuropod_tensor.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
-        "//neuropod/internal:neuropod_tensor",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
+        "//neuropod/internal",
     ],
 )
 
@@ -351,13 +337,11 @@ cc_test(
     name = "test_conversions_eigen",
     srcs = [
         "test_conversions_eigen.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
         "//neuropod/conversions:eigen",
         "@eigen3_repo//:eigen3",
     ],
@@ -367,13 +351,11 @@ cc_test(
     name = "test_test_backend",
     srcs = [
         "test_test_backend.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
     ],
 )
 
@@ -381,12 +363,11 @@ cc_test(
     name = "test_backend_registration",
     srcs = [
         "test_backend_registration.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/internal:backend_registration",
+        "//neuropod:neuropod_impl",
+        "//neuropod/internal",
     ],
 )
 
@@ -394,12 +375,11 @@ cc_test(
     name = "test_factories",
     srcs = [
         "test_factories.cc",
-        "//neuropod:libneuropod.so",
-        "//neuropod/backends/test_backend:libneuropod_test_backend.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod/backends/test_backend:test_backend_hdrs",
+        "//neuropod:neuropod_impl",
+        "//neuropod/backends/test_backend",
     ],
 )
 
@@ -407,12 +387,11 @@ cc_test(
     name = "test_loader",
     srcs = [
         "test_loader.cc",
-        "//neuropod:libneuropod.so",
     ],
     deps = [
         "@gtest//:main",
-        "//neuropod:neuropod_hdrs",
-        "//neuropod/internal:neuropod_loader",
+        "//neuropod:neuropod_impl",
+        "//neuropod/internal",
     ],
     data = [
         "//neuropod/tests/test_data"


### PR DESCRIPTION
This PR simplifies the bazel build as follows:
 - Splits the backends into `cc_binary` and `cc_library` targets for simpler usage in tests 
 - Combines targets within `internal`

As part of this, we also needed to upgrade to a `manylinux2014` sysroot since the TF binaries are not manylinux2010 compatible.