### PR TITLE
[Build] Update rpaths to be macOS compatible

### DIFF
--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -23,7 +23,10 @@ cc_binary(
     name = "libneuropod.so",
     linkshared = True,
     linkstatic = True,
-    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     visibility = [
         "//visibility:public",
     ],

--- a/source/neuropod/backends/python_bridge/BUILD
+++ b/source/neuropod/backends/python_bridge/BUILD
@@ -11,9 +11,10 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
-    linkopts = [
-        "-Wl,-rpath,$$ORIGIN",
-    ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     visibility = [
         "//neuropod:__subpackages__",
     ],

--- a/source/neuropod/backends/tensorflow/BUILD
+++ b/source/neuropod/backends/tensorflow/BUILD
@@ -12,7 +12,10 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
-    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     visibility = [
         "//neuropod:__subpackages__",
     ],

--- a/source/neuropod/backends/torchscript/BUILD
+++ b/source/neuropod/backends/torchscript/BUILD
@@ -12,7 +12,10 @@ cc_binary(
     ],
     linkshared = True,
     linkstatic = True,
-    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     visibility = [
         "//neuropod:__subpackages__",
     ],

--- a/source/neuropod/bindings/BUILD
+++ b/source/neuropod/bindings/BUILD
@@ -8,6 +8,10 @@ cc_binary(
         "neuropod_native.cc",
         "//neuropod:libneuropod.so",
     ],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     deps = [
         ":bindings",
         "//neuropod/multiprocess",

--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -66,7 +66,10 @@ cc_binary(
         "//neuropod:libneuropod.so",
     ],
     linkstatic = True,
-    linkopts = ["-Wl,-rpath,$$ORIGIN"],
+    linkopts = select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
+        "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
+    }),
     visibility = [
         "//neuropod:__subpackages__",
     ],


### PR DESCRIPTION
In preparation for removing `LD_LIBRARY_PATH` from our test scripts, we need to set rpaths correctly on all platforms