### PR TITLE
[PythonBridge] Make the PythonBridge only support python/pytorch models

### DIFF
--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -100,8 +100,8 @@ void PythonBridge::load_model_internal()
     // Acquire the GIL
     py::gil_scoped_acquire gil;
 
-    // Get the neuropod loader
-    py::object load_neuropod = py::module::import("neuropod.loader").attr("load_neuropod");
+    // Get the python neuropod loader
+    py::object load_neuropod = py::module::import("neuropod.backends.python.executor").attr("PythonNeuropodExecutor");
 
     // Converts from unicode to ascii for python 3 string arrays
     maybe_convert_bindings_types_ = stdx::make_unique<py::object>(

--- a/source/neuropod/tests/test_python_bridge.cc
+++ b/source/neuropod/tests/test_python_bridge.cc
@@ -15,27 +15,3 @@ TEST(test_models, test_pytorch_strings_model)
     // Test the PyTorch strings model using the python bridge
     test_strings_model("neuropod/tests/test_data/pytorch_strings_model/", "PythonBridge");
 }
-
-TEST(test_models, test_torchscript_addition_model)
-{
-    // Test the TorchScript addition model using the python bridge
-    test_addition_model("neuropod/tests/test_data/torchscript_addition_model/", "PythonBridge");
-}
-
-TEST(test_models, test_torchscript_strings_model)
-{
-    // Test the TorchScript strings model using the python bridge
-    test_strings_model("neuropod/tests/test_data/torchscript_strings_model/", "PythonBridge");
-}
-
-TEST(test_models, test_tensorflow_addition_model)
-{
-    // Test the TensorFlow addition model using the python bridge
-    test_addition_model("neuropod/tests/test_data/tf_addition_model/", "PythonBridge");
-}
-
-TEST(test_models, test_tensorflow_strings_model)
-{
-    // Test the TensorFlow strings model using the python bridge
-    test_strings_model("neuropod/tests/test_data/tf_strings_model/", "PythonBridge");
-}


### PR DESCRIPTION
As part of a refactor to make the python library always use the native inference implementations, this PR makes the PythonBridge only support python models.