### PR TITLE
[Build] Update the test runner to use bazel tags

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -74,6 +74,11 @@ Neuropod has a set of tests implemented in C++ and a set of tests implemented in
 
 The Python tests run against both the Python and C++ libraries by using python bindings. This means that many tests only need to be written in Python.
 
+C++ tests can have the following tags:
+
+ - `gpu`: Only run when running GPU tests
+ - `requires_ld_library_path`: `LD_LIBRARY_PATH` and `PATH` variables will be set so the backends and multiprocess worker are available. This is useful for tests that run a model using OPE
+
 ## CI
 
 ### Build Matrix

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -28,6 +28,7 @@ cc_test(
     data = [
         "//neuropod/tests/test_data",
     ],
+    tags = ["requires_ld_library_path"],
 )
 
 cc_test(
@@ -152,6 +153,7 @@ cc_test(
         "//neuropod/backends/python_bridge",
         "//neuropod:neuropod_impl",
     ],
+    tags = ["gpu"],
 )
 
 cc_test(
@@ -318,6 +320,7 @@ cc_test(
         "//neuropod/backends/tensorflow:tensorflow_backend",
         "//neuropod/backends/python_bridge",
     ],
+    tags = ["requires_ld_library_path"],
 )
 
 cc_test(


### PR DESCRIPTION
Updates `run_cpp_tests.py` to use bazel tags to decide which tests to run and what env variables to set.