### PR TITLE
[Torch] Include mklml in the macOS packages

### DIFF
--- a/source/deps/BUILD.libtorch
+++ b/source/deps/BUILD.libtorch
@@ -10,7 +10,7 @@ cc_library(
     name = "libtorch",
     srcs = select({
         "@bazel_tools//src/conditions:darwin": glob(["lib/libcaffe2.dylib", "lib/libc10.dylib", "lib/libtorch.dylib", "lib/libtorch.1.dylib"]),
-        "//conditions:default": glob(["lib/libcaffe2.so", "lib/libtorch.so", "lib/libc10.so"]),
+        "//conditions:default": glob(["lib/lib*.so*"]),
     }),
     deps = select({
         "@bazel_tools//src/conditions:darwin": ["@mklml_repo_darwin//:mklml"],
@@ -36,6 +36,7 @@ filegroup(
     name = "libtorch_libs",
     srcs = select({
         "@bazel_tools//src/conditions:darwin": glob([
+            "lib/libtorch.dylib",
             "lib/libtorch.1.dylib",
             "lib/libcaffe2.dylib",
             "lib/libc10.dylib",

--- a/source/deps/BUILD.mklml
+++ b/source/deps/BUILD.mklml
@@ -10,3 +10,8 @@ cc_library(
     name = "mklml",
     srcs = ["lib/libmklml.dylib"],
 )
+
+filegroup(
+    name = "mklml_libs",
+    srcs = ["lib/libmklml.dylib"],
+)

--- a/source/neuropod/backends/torchscript/BUILD
+++ b/source/neuropod/backends/torchscript/BUILD
@@ -24,7 +24,10 @@ cc_binary(
     ],
     data = [
         ":copy_libtorch",
-    ]
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": [":copy_mklml"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -55,12 +58,20 @@ copy_libs(
     libs = "@libtorch_repo//:libtorch_libs"
 )
 
+copy_libs(
+    name = "copy_mklml",
+    libs = "@mklml_repo_darwin//:mklml_libs"
+)
+
 pkg_tar(
     name = "neuropod_torchscript_backend",
     srcs = [
         ":libneuropod_torchscript_backend.so",
         "@libtorch_repo//:libtorch_libs",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": ["@mklml_repo_darwin//:mklml_libs"],
+        "//conditions:default": [],
+    }),
     tags = ["manual"],
     extension = "tar.gz",
     visibility = [


### PR DESCRIPTION
In order for the Torch Neuropod backend to be self-contained on macOS, it must include mklml in addition to the to the torch libs