### PR TITLE
Allow models to specify target framework versions

### DIFF
--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -173,3 +173,13 @@ http_archive(
     strip_prefix = "fmt-5.3.0",
     url = "https://github.com/fmtlib/fmt/archive/5.3.0.zip",
 )
+
+http_archive(
+    name = "semver_repo",
+    build_file = "@//deps:BUILD.semver",
+    patch_args = ["-p1"],
+    patches = ["@//bazel:semver.patch"],
+    sha256 = "3cb8b507c3389f8d8b80304360afc0ba8b3dbbe9504332d9b8f5d6793fb221e8",
+    strip_prefix = "cpp-semver-ff341259099465283bc3dc60fb5ede16776e1607",
+    url = "https://github.com/easz/cpp-semver/archive/ff341259099465283bc3dc60fb5ede16776e1607.zip",
+)

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -10,7 +10,7 @@ def _impl(repository_ctx):
     # Get the torch cuda string (e.g. cpu, cu90, cu92, cu100)
     torch_cuda_string = "cu" + CUDA_VERSION.replace(".", "") if IS_GPU else "cpu"
 
-    defines = []
+    defines = ["TORCH_VERSION=" + version]
 
     # If this is a nightly build, we want to define a variable
     # to let our code know what nightly version this is

--- a/source/bazel/semver.patch
+++ b/source/bazel/semver.patch
@@ -1,0 +1,59 @@
+# Because we use semver during library initialization, we can't assume that global variables
+# have been initialized already. This patch refactors semver to remove the 3 global variables
+# that are used
+diff --git a/include/base/util.hpp b/include/base/util.hpp
+index 921a2c2..b80bb55 100755
+--- a/include/base/util.hpp
++++ b/include/base/util.hpp
+@@ -6,13 +6,10 @@
+
+ namespace semver
+ {
+-  const std::string any_space = " \n\r\t\v\f";
+-  const std::string any_number = "0123456789";
+-  const std::string any_alphabat = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+-
+   // [    x y    z  ] -> [ x y z ]
+   inline std::string reduce_space(const std::string& str)
+   {
++    const std::string any_space = " \n\r\t\v\f";
+     std::string new_string;
+     bool pre_space = false;
+     for (const char& c : str)
+@@ -30,6 +27,7 @@ namespace semver
+   // [    x y    z  ] -> [x y    z]
+   inline std::string trim_string(const std::string& str)
+   {
++    const std::string any_space = " \n\r\t\v\f";
+     size_t start = str.find_first_not_of(any_space);
+     if (start == std::string::npos)
+       return {};
+diff --git a/include/parser/parser.hpp b/include/parser/parser.hpp
+index b1151c8..1bc0157 100755
+--- a/include/parser/parser.hpp
++++ b/include/parser/parser.hpp
+@@ -11,6 +11,7 @@ namespace semver
+ {
+   inline int parse_nr(const std::string& input)
+   {
++    const std::string any_number = "0123456789";
+     // nr ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
+
+     if (input.length() == 0)
+@@ -45,6 +46,8 @@ namespace semver
+
+   inline std::string parse_part(const std::string& input)
+   {
++    const std::string any_number = "0123456789";
++    const std::string any_alphabat = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+     // part  ::=
+
+     if (input.empty() || any_number.find(input.at(0)) != std::string::npos)
+@@ -172,6 +175,7 @@ namespace semver
+
+   inline syntax::range parse_range(const std::string& input)
+   {
++    const std::string any_space = " \n\r\t\v\f";
+     // range ::=
+     std::vector<std::string> hyphen_tokens = split(input, " - ", true);
+     if (hyphen_tokens.size() == 2)

--- a/source/deps/BUILD.semver
+++ b/source/deps/BUILD.semver
@@ -1,0 +1,18 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "semver",
+    hdrs = glob([
+        "include/**",
+    ]),
+    includes = [
+        "include"
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/source/deps/BUILD.tensorflow_hdrs
+++ b/source/deps/BUILD.tensorflow_hdrs
@@ -23,4 +23,5 @@ cc_library(
         "tensorflow-{TENSORFLOW_VERSION}.data/purelib/tensorflow/include/",
         "tensorflow_core/include/",
     ],
+    defines = ["TENSORFLOW_VERSION={TENSORFLOW_VERSION}"],
 )

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -49,8 +49,6 @@ std::unique_ptr<py::gil_scoped_release> maybe_initialize()
 #ifndef __APPLE__
 // This binary is already linked against `libpython`; the dlopen just
 // promotes it to RTLD_GLOBAL.
-#define STR_HELPER(x) #x
-#define STR(x) STR_HELPER(x)
 #define PYTHON_LIB_NAME "libpython" STR(PYTHON_VERSION) ".so"
     void *libpython = dlopen(PYTHON_LIB_NAME, RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
 
@@ -147,6 +145,6 @@ std::unique_ptr<NeuropodValueMap> PythonBridge::infer_internal(const NeuropodVal
     return stdx::make_unique<NeuropodValueMap>(std::move(outputs));
 }
 
-REGISTER_NEUROPOD_BACKEND(PythonBridge, "python", "pytorch")
+REGISTER_NEUROPOD_BACKEND(PythonBridge, "python", PY_VERSION)
 
 } // namespace neuropod

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -384,6 +384,6 @@ std::unique_ptr<NeuropodValueMap> TensorflowNeuropodBackend::infer_internal(
     return to_return;
 }
 
-REGISTER_NEUROPOD_BACKEND(TensorflowNeuropodBackend, "tensorflow")
+REGISTER_NEUROPOD_BACKEND(TensorflowNeuropodBackend, "tensorflow", STR(TENSORFLOW_VERSION))
 
 } // namespace neuropod

--- a/source/neuropod/backends/test_backend/test_neuropod_backend.cc
+++ b/source/neuropod/backends/test_backend/test_neuropod_backend.cc
@@ -27,6 +27,6 @@ std::unique_ptr<NeuropodValueMap> TestNeuropodBackend::infer_internal(const Neur
     return stdx::make_unique<NeuropodValueMap>();
 }
 
-REGISTER_NEUROPOD_BACKEND(TestNeuropodBackend, "noop")
+REGISTER_NEUROPOD_BACKEND(TestNeuropodBackend, "noop", "0.1.0")
 
 } // namespace neuropod

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -439,6 +439,6 @@ std::unique_ptr<NeuropodValueMap> TorchNeuropodBackend::infer_internal(const Neu
     return to_return;
 }
 
-REGISTER_NEUROPOD_BACKEND(TorchNeuropodBackend, "torchscript")
+REGISTER_NEUROPOD_BACKEND(TorchNeuropodBackend, "torchscript", STR(TORCH_VERSION))
 
 } // namespace neuropod

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "@filesystem_repo//:filesystem",
         "@libjsoncpp_repo//:libjsoncpp",
         "@picosha2_repo//:picosha2",
+        "@semver_repo//:semver",
         "@zipper_repo//:zipper",
     ],
     alwayslink = True,

--- a/source/neuropod/internal/backend_registration.hh
+++ b/source/neuropod/internal/backend_registration.hh
@@ -32,9 +32,10 @@ std::unique_ptr<NeuropodBackend> createNeuropodBackend(const std::string &neurop
 
 // Register a backend for a set of specific types
 // This is used in the macro below
-bool register_backend(const std::string &             name,
-                      const std::vector<std::string> &supported_types,
-                      BackendFactoryFunction          factory_fn);
+bool register_backend(const std::string &    name,
+                      const std::string &    type,
+                      const std::string &    version,
+                      BackendFactoryFunction factory_fn);
 
 // Get a backend factory function for a neuropod type (e.g. "python", "tensorflow", "torchscript")
 // `default_backend_overrides` allows users to override the default backend for a given type.
@@ -42,11 +43,17 @@ bool register_backend(const std::string &             name,
 // Note: Libraries in this map will only be loaded if a backend for the requested type hasn't already
 // been loaded
 BackendFactoryFunction get_backend_for_type(
-    const std::unordered_map<std::string, std::string> &default_backend_overrides, const std::string &type);
+    const std::unordered_map<std::string, std::string> &default_backend_overrides,
+    const std::string &                                 type,
+    const std::string &                                 target_version_range = "*");
 
 // A macro to easily define a backend
-// Example: REGISTER_NEUROPOD_BACKEND(MyPythonBackend, "pytorch", "python")
-#define REGISTER_NEUROPOD_BACKEND(CLS, ... /* supported types */) \
-    bool is_registered_##CLS = register_backend(#CLS, {__VA_ARGS__}, createNeuropodBackend<CLS>);
+// Example: REGISTER_NEUROPOD_BACKEND(SomeTensorflowBackend, "tensorflow", "1.13.1")
+#define REGISTER_NEUROPOD_BACKEND(CLS, type, version) \
+    bool is_registered_##CLS = register_backend(#CLS, type, version, createNeuropodBackend<CLS>);
+
+// Utility macros
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
 
 } // namespace neuropod

--- a/source/neuropod/internal/config_utils.hh
+++ b/source/neuropod/internal/config_utils.hh
@@ -58,6 +58,14 @@ struct ModelConfig
     const std::string name;
     const std::string platform;
 
+    // The requested versions of the platform specified as a semver range
+    // e.g. `1.13.1` or `> 1.13.1`
+    // See the following URLs for examples and more info:
+    // - https://semver.org/
+    // - https://docs.npmjs.com/misc/semver#ranges
+    // - https://docs.npmjs.com/misc/semver#advanced-range-syntax
+    const std::string platform_version_semver;
+
     const std::vector<TensorSpec> inputs;
     const std::vector<TensorSpec> outputs;
 

--- a/source/neuropod/neuropod.cc
+++ b/source/neuropod/neuropod.cc
@@ -31,9 +31,11 @@ Neuropod::Neuropod(const std::string &                                 neuropod_
     }
     else
     {
-        // Get the backend in a normal way
-        backend_ = get_backend_for_type(default_backend_overrides,
-                                        load_model_config(neuropod_path)->platform)(neuropod_path, options);
+        // Get the backend from the registered backends
+        const auto model_config = load_model_config(neuropod_path);
+        backend_                = get_backend_for_type(default_backend_overrides,
+                                        model_config->platform,
+                                        model_config->platform_version_semver)(neuropod_path, options);
     }
 }
 

--- a/source/neuropod/python/backends/config_utils.py
+++ b/source/neuropod/python/backends/config_utils.py
@@ -163,6 +163,7 @@ def write_neuropod_config(
     platform,
     input_spec,
     output_spec,
+    platform_version_semver="*",
     custom_ops=None,
     input_tensor_device=None,
     default_input_tensor_device="GPU",
@@ -174,6 +175,12 @@ def write_neuropod_config(
     :param  neuropod_path:  The path to a neuropod package
     :param  model_name:     The name of the model (e.g. "my_addition_model")
     :param  platform:       The model type (e.g. "python", "pytorch", "tensorflow", etc.)
+
+    :param  platform_version_semver: The required platform version specified as semver range
+                                     See https://semver.org/, https://docs.npmjs.com/misc/semver#ranges
+                                     or https://docs.npmjs.com/misc/semver#advanced-range-syntax for
+                                     examples and more info. Default is `*` (any version is okay)
+                                     Ex: `1.13.1` or `> 1.13.1`
 
     :param  input_spec:     A list of dicts specifying the input to the model.
                             Ex: [{"name": "x", "dtype": "float32", "shape": (None, )}]
@@ -227,6 +234,7 @@ def write_neuropod_config(
         config = {
             "name": model_name,
             "platform": platform,
+            "platform_version_semver": platform_version_semver,
             "input_spec": input_spec,
             "output_spec": output_spec,
             "custom_ops": custom_ops,


### PR DESCRIPTION
This PR allows models to specify target framework versions.

For example, if a model is only compatible with TensorFlow 1.15 (e.g. because of custom ops built against 1.15 headers), that can be specified at export time.

Target version ranges are specified as semver ranges (see https://semver.org/, https://docs.npmjs.com/misc/semver#ranges, https://docs.npmjs.com/misc/semver#advanced-range-syntax). This provides a very flexible way of defining the required framework. 

When we load the model, we attempt to find a backend that satisfies the specified range.

Future PRs will extend the default backend list to include version numbers. This (combined with OPE) will enable environments to provide many supported versions of each framework and have models choose which one to use.