### PR TITLE
Run all C++ tests with the TRACE log level

### DIFF
--- a/build/run_cpp_tests.py
+++ b/build/run_cpp_tests.py
@@ -38,6 +38,9 @@ def make_test(test_target, tags):
             PATH += ":" + os.path.join(os.getcwd(), "bazel-bin/neuropod/multiprocess/")
             env["PATH"] = PATH
 
+        if "no_trace_logging" not in tags:
+            env["NEUROPOD_LOG_LEVEL"] = "TRACE"
+
         subprocess.check_call(test_path, cwd=runfiles_path, env=env)
     return test
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -76,8 +76,9 @@ The Python tests run against both the Python and C++ libraries by using python b
 
 C++ tests can have the following tags:
 
- - `gpu`: Only run when running GPU tests
- - `requires_ld_library_path`: `LD_LIBRARY_PATH` and `PATH` variables will be set so the backends and multiprocess worker are available. This is useful for tests that run a model using OPE
+ - `gpu`: Only run this test when running GPU tests
+ - `requires_ld_library_path`: Set the `LD_LIBRARY_PATH` and `PATH` environment variables so the backends and multiprocess worker are available. This is useful for tests that run a model using OPE.
+ - `no_trace_logging`: Don't set the log level to `TRACE` when running this test. This is useful to avoid lots of output when running benchmarks.
 
 ## CI
 

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -22,7 +22,11 @@ cc_test(
     data = [
         "//neuropod/tests/test_data",
     ],
-    tags = ["requires_ld_library_path"],
+    tags = [
+        "requires_ld_library_path",
+        # Don't do trace logging in CI for this benchmark
+        "no_trace_logging",
+    ],
     deps = [
         "//neuropod:neuropod_impl",
         "//neuropod/backends/tensorflow:tensorflow_backend",


### PR DESCRIPTION
Default to the `TRACE` log level when running C++ tests 