### PR TITLE
Allow models to specify target framework versions [Part 2]

### DIFF
--- a/build/ci/buildkite_lint.sh
+++ b/build/ci/buildkite_lint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Make sure we can build the docs
-./build/ci/docs.sh
-
 # Used for bazel caching to s3 in CI
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
@@ -19,6 +16,9 @@ bazels3cache --bucket=neuropod-build-cache
 
 # Install lint deps
 ./build/ci/install_lint_deps.sh
+
+# Make sure we can build the docs
+./build/ci/docs.sh
 
 # Run lint
 ./build/ci/lint.sh

--- a/build/wheel/build_wheel.py
+++ b/build/wheel/build_wheel.py
@@ -14,7 +14,7 @@ from testpath.tempdir import TemporaryDirectory
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "template")
 IS_MAC = platform.system() == "Darwin"
 
-def package(package_name, tar_path, platforms):
+def package(package_name, tar_path, platform, platform_version):
     # Remove all `.` characters from the name
     package_name = package_name.replace(".", "-")
 
@@ -69,7 +69,8 @@ def package(package_name, tar_path, platforms):
             NEUROPOD_VERSION="0.1.0",
             SHARED_LIBRARY_NAME=shared_library_name,
             LIBS=str(members),
-            PLATFORM=str(platforms),
+            PLATFORM=platform,
+            PLATFORM_VERSION=platform_version,
         )
 
         # Write it out
@@ -123,8 +124,9 @@ if __name__ == '__main__':
     gpustring = "gpu-cuda-{}".format(CUDA_VERSION) if IS_GPU else "cpu"
 
     # Build wheels for the backends
-    package("neuropod-backend-tensorflow-{}-{}".format(REQUESTED_TF_VERSION, gpustring), "bazel-bin/neuropod/backends/tensorflow/neuropod_tensorflow_backend.tar.gz", ["tensorflow"])
-    package("neuropod-backend-torchscript-{}-{}".format(REQUESTED_TORCH_VERSION, gpustring), "bazel-bin/neuropod/backends/torchscript/neuropod_torchscript_backend.tar.gz", ["torchscript"])
+    package("neuropod-backend-tensorflow-{}-{}".format(REQUESTED_TF_VERSION, gpustring), "bazel-bin/neuropod/backends/tensorflow/neuropod_tensorflow_backend.tar.gz", "tensorflow", REQUESTED_TF_VERSION)
+    package("neuropod-backend-torchscript-{}-{}".format(REQUESTED_TORCH_VERSION, gpustring), "bazel-bin/neuropod/backends/torchscript/neuropod_torchscript_backend.tar.gz", "torchscript", REQUESTED_TORCH_VERSION)
 
     # The python backend isn't different depending on CPU/GPU so we don't include that in the name
-    package("neuropod-backend-python-{}".format(PYTHON_VERSION), "bazel-bin/neuropod/backends/python_bridge/neuropod_pythonbridge_backend.tar.gz", ["python", "pytorch"])
+    # TODO(vip): It isn't necessarily true that the current python version is the version we're packaging
+    package("neuropod-backend-python-{}".format(PYTHON_VERSION), "bazel-bin/neuropod/backends/python_bridge/neuropod_pythonbridge_backend.tar.gz", "python", platform.python_version())

--- a/build/wheel/template/__init__.py.in
+++ b/build/wheel/template/__init__.py.in
@@ -11,5 +11,6 @@ NATIVE_PATH = osp.join(osp.dirname(osp.abspath(__file__)), "{SHARED_LIBRARY_NAME
 
 from neuropod.registry import register_backend
 
-# {{PLATFORM}} below will be a list of platform names (e.g. `['tensorflow']`)
-register_backend({PLATFORM}, NATIVE_PATH)
+# {{PLATFORM}} below will be a platform name (e.g. `tensorflow`)
+# {{PLATFORM_VERSION}} below will be a version (e.g. `1.12.0`)
+register_backend("{PLATFORM}", "{PLATFORM_VERSION}", NATIVE_PATH)

--- a/source/neuropod/bindings/neuropod_native.cc
+++ b/source/neuropod/bindings/neuropod_native.cc
@@ -124,10 +124,13 @@ PYBIND11_MODULE(neuropod_native, m)
 {
     py::class_<Neuropod>(m, "Neuropod")
         .def(py::init([](const std::string &path, py::kwargs kwargs) { return make_neuropod(kwargs, path); }))
-        .def(py::init([](const std::string &                                 path,
-                         const std::unordered_map<std::string, std::string> &default_backend_overrides,
+        .def(py::init([](const std::string &                 path,
+                         const std::vector<BackendLoadSpec> &default_backend_overrides,
                          py::kwargs kwargs) { return make_neuropod(kwargs, path, default_backend_overrides); }))
         .def("infer", &infer);
+
+    py::class_<BackendLoadSpec>(m, "BackendLoadSpec")
+        .def(py::init<const std::string &, const std::string &, const std::string &>());
 
     m.def("serialize", &serialize_tensor_binding, "Convert a numpy array to a NeuropodTensor and serialize it");
     m.def("deserialize",

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -27,53 +27,113 @@ struct BackendInfo
     BackendFactoryFunction factory;
 };
 
-std::once_flag                                                     registrar_initialized;
-std::unique_ptr<std::unordered_multimap<std::string, BackendInfo>> registered_backends_by_type;
+std::once_flag                                                registrar_initialized;
+std::unique_ptr<std::unordered_map<std::string, BackendInfo>> registered_backends_by_type;
 
 void init_registrar_if_needed()
 {
     std::call_once(registrar_initialized, []() {
-        registered_backends_by_type = stdx::make_unique<std::unordered_multimap<std::string, BackendInfo>>();
+        registered_backends_by_type = stdx::make_unique<std::unordered_map<std::string, BackendInfo>>();
     });
 }
 
-// A map from a backend type (e.g. tensorflow, python, torchscript, etc.) to the name
-// of a shared library that supports that type. These will only be loaded if a backend
-// for the requested type hasn't already been loaded
-const std::unordered_map<std::string, std::string> default_backend_for_type = {
-    {"tensorflow", "libneuropod_tensorflow_backend.so"},
-    {"python", "libneuropod_pythonbridge_backend.so"},
-    {"pytorch", "libneuropod_pythonbridge_backend.so"},
-    {"torchscript", "libneuropod_torchscript_backend.so"},
+// A map from a backend type (e.g. tensorflow, python, torchscript, etc.) and version to
+// the name of a shared library that supports that type. These will only be loaded if a backend
+// for the requested type hasn't already been loaded.
+// Note: these are listed in reverse priority order
+// The ordering below means we'd prefer to load a newer, GPU capable version of a framework if one is available
+// TODO(vip): Actually name the backend `so` files differently depending on version
+const std::vector<BackendLoadSpec> default_backend_for_type = {
+    // Torch CPU
+    {"torchscript", "1.1.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.2.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.3.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.4.0", "libneuropod_torchscript_backend.so"},
+
+    // Torch GPU
+    {"torchscript", "1.1.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.2.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.3.0", "libneuropod_torchscript_backend.so"},
+    {"torchscript", "1.4.0", "libneuropod_torchscript_backend.so"},
+
+    // TF CPU
+    {"tensorflow", "1.12.0", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.13.1", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.14.0", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.15.0", "libneuropod_tensorflow_backend.so"},
+
+    // TF GPU
+    {"tensorflow", "1.12.0", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.13.1", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.14.0", "libneuropod_tensorflow_backend.so"},
+    {"tensorflow", "1.15.0", "libneuropod_tensorflow_backend.so"},
+
+    // Python
+    {"python", "27", "libneuropod_pythonbridge_backend.so"},
+    {"python", "35", "libneuropod_pythonbridge_backend.so"},
+    {"python", "36", "libneuropod_pythonbridge_backend.so"},
+    {"python", "37", "libneuropod_pythonbridge_backend.so"},
+    {"python", "38", "libneuropod_pythonbridge_backend.so"},
 };
 
-void load_default_backend(const std::unordered_map<std::string, std::string> &default_backend_overrides,
-                          const std::string &                                 type)
+bool load_default_backend(const std::vector<BackendLoadSpec> &backends,
+                          const std::string &                 type,
+                          const std::string &                 target_version_range)
 {
-    auto backend_it = default_backend_overrides.find(type);
-    if (backend_it == default_backend_overrides.end())
+    // Reverse priority order
+    for (auto it = backends.rbegin(); it != backends.rend(); it++)
     {
-        // This type is not in the overrides so check the default mapping
-        backend_it = default_backend_for_type.find(type);
-    }
-
-    if (backend_it == default_backend_for_type.end())
-    {
-        NEUROPOD_ERROR("Default Neuropod backend not found for type '{}'! "
-                       "Make sure that you load a Neuropod backend that can support '{}'",
-                       type,
-                       type);
-    }
-    else
-    {
-        if (dlopen(backend_it->second.c_str(), RTLD_NOW | RTLD_GLOBAL) == nullptr)
+        const auto &backend = *it;
+        if (backend.type != type)
         {
-            NEUROPOD_ERROR("Loading the default backend for type '{}' failed. Error from dlopen: {}", type, dlerror());
+            // Type doesn't match
+            continue;
+        }
+
+        if (!semver::satisfies(backend.version, target_version_range))
+        {
+            // Target version range isn't satisifed
+            continue;
+        }
+
+        // Try to dlopen it
+        const auto &sopath = backend.path;
+        if (dlopen(sopath.c_str(), RTLD_NOW | RTLD_GLOBAL) == nullptr)
+        {
+            SPDLOG_TRACE("Loading the default backend '{}' failed. Error from dlopen: {}", sopath, dlerror());
+        }
+        else
+        {
+            // Successfully loaded the backend
+            SPDLOG_TRACE("Successfully loaded default backend '{}'", sopath);
+            return true;
         }
     }
+
+    return false;
+}
+
+BackendFactoryFunction find_registered_backend(const std::string &type, const std::string &target_version_range)
+{
+    auto it = registered_backends_by_type->find(type);
+    if (it != registered_backends_by_type->end())
+    {
+        // Check if it matches the version range
+        if (semver::satisfies(it->second.version, target_version_range))
+        {
+            return it->second.factory;
+        }
+    }
+
+    return nullptr;
 }
 
 } // namespace
+
+bool BackendLoadSpec::operator==(const BackendLoadSpec &other) const
+{
+    return type == other.type && version == other.version && path == other.path;
+}
 
 bool register_backend(const std::string &    name,
                       const std::string &    type,
@@ -97,40 +157,76 @@ bool register_backend(const std::string &    name,
                        version);
     }
 
+    // Check to see if we've already loaded a backend for `type`
+    // We can only load one backend version per type into the same process
+    // (i.e. if we load TF 1.12.0, we can't load another version of TF into this process)
+    // Using OPE overcomes this problem
+    if (registered_backends_by_type->find(type) != registered_backends_by_type->end())
+    {
+        NEUROPOD_ERROR(
+            "Attempted to register a backend for type '{}', but one was already loaded. If you are trying "
+            "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
+            type);
+    }
+
     registered_backends_by_type->insert(std::make_pair(type, info));
 
     return true;
 }
 
-BackendFactoryFunction get_backend_for_type(
-    const std::unordered_map<std::string, std::string> &default_backend_overrides,
-    const std::string &                                 type,
-    const std::string &                                 target_version_range)
+BackendFactoryFunction get_backend_for_type(const std::vector<BackendLoadSpec> &default_backend_overrides,
+                                            const std::string &                 type,
+                                            const std::string &                 target_version_range)
 {
     init_registrar_if_needed();
 
-    if (registered_backends_by_type->find(type) == registered_backends_by_type->end())
+    // Attempt to find a registered backend that matches
+    auto retval = find_registered_backend(type, target_version_range);
+    if (retval != nullptr)
     {
-        // We don't have a backend loaded for the requested type
-        // Try loading the default one
-        load_default_backend(default_backend_overrides, type);
+        return retval;
     }
 
-    auto range = registered_backends_by_type->equal_range(type);
-    for (auto it = range.first; it != range.second; it++)
+    // Check to see if we've already loaded a backend for `type`
+    // We can only load one backend version per type into the same process
+    // (i.e. if we load TF 1.12.0, we can't load another version of TF into this process)
+    // Using OPE overcomes this problem
+    auto it = registered_backends_by_type->find(type);
+    if (it != registered_backends_by_type->end())
     {
-        // Check if it matches the version range
-        if (semver::satisfies(it->second.version, target_version_range))
+        NEUROPOD_ERROR(
+            "Tried to get a backend for type '{}' and version range '{}' but failed. A backend for type "
+            "'{}' was already registered, but it supports version '{}'. If you are trying "
+            "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
+            type,
+            target_version_range,
+            type,
+            it->second.version);
+    }
+
+    // Try loading using the user provided overrides
+    bool load_success = load_default_backend(default_backend_overrides, type, target_version_range);
+    if (!load_success)
+    {
+        // If that didn't work, try loading using the default map
+        load_success = load_default_backend(default_backend_for_type, type, target_version_range);
+    }
+
+    if (load_success)
+    {
+        // We loaded a library so we can check the registered backends again
+        auto retval = find_registered_backend(type, target_version_range);
+        if (retval != nullptr)
         {
-            return it->second.factory;
+            return retval;
         }
     }
 
-    // If we get here, that means that we don't have any matching backends
-    NEUROPOD_ERROR(
-        "Neuropod backend not found for type '{}' and version range '{}'! Default backend did not match either.",
-        type,
-        target_version_range);
+    // Don't have anything that matches
+    NEUROPOD_ERROR("Neuropod backend not found for type '{}' and version range '{}'! Was not able to load default "
+                   "backends either. Retry with log level TRACE for more information.",
+                   type,
+                   target_version_range);
 }
 
 } // namespace neuropod

--- a/source/neuropod/internal/backend_registration.hh
+++ b/source/neuropod/internal/backend_registration.hh
@@ -37,15 +37,29 @@ bool register_backend(const std::string &    name,
                       const std::string &    version,
                       BackendFactoryFunction factory_fn);
 
+struct BackendLoadSpec
+{
+    // A neuropod platform (e.g. "python", "tensorflow", "torchscript")
+    std::string type;
+
+    // The version of the platform (e.g. "1.12.0")
+    std::string version;
+
+    // The name or path of a shared library that supports the above platform and version
+    // (e.g. "libneuropod_tensorflow_backend.so")
+    std::string path;
+
+    bool operator==(const BackendLoadSpec &other) const;
+};
+
 // Get a backend factory function for a neuropod type (e.g. "python", "tensorflow", "torchscript")
 // `default_backend_overrides` allows users to override the default backend for a given type.
 // This is a mapping from a neuropod type to the name of a shared library that supports that type.
 // Note: Libraries in this map will only be loaded if a backend for the requested type hasn't already
 // been loaded
-BackendFactoryFunction get_backend_for_type(
-    const std::unordered_map<std::string, std::string> &default_backend_overrides,
-    const std::string &                                 type,
-    const std::string &                                 target_version_range = "*");
+BackendFactoryFunction get_backend_for_type(const std::vector<BackendLoadSpec> &default_backend_overrides,
+                                            const std::string &                 type,
+                                            const std::string &                 target_version_range = "*");
 
 // A macro to easily define a backend
 // Example: REGISTER_NEUROPOD_BACKEND(SomeTensorflowBackend, "tensorflow", "1.13.1")

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -140,10 +140,10 @@ public:
     }
 
     // Generate a control queue name and start a worker
-    MultiprocessNeuropodBackend(const std::string &                                 neuropod_path,
-                                const RuntimeOptions &                              options,
-                                bool                                                free_memory_every_cycle,
-                                const std::unordered_map<std::string, std::string> &default_backend_overrides)
+    MultiprocessNeuropodBackend(const std::string &                 neuropod_path,
+                                const RuntimeOptions &              options,
+                                bool                                free_memory_every_cycle,
+                                const std::vector<BackendLoadSpec> &default_backend_overrides)
         : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path),
           control_queue_name_(boost::uuids::to_string(boost::uuids::random_generator()())),
           free_memory_every_cycle_(free_memory_every_cycle),
@@ -273,10 +273,9 @@ protected:
 
 } // namespace
 
-std::unique_ptr<NeuropodBackend> load_neuropod_ope(
-    const std::string &                                 neuropod_path,
-    const RuntimeOptions &                              options,
-    const std::unordered_map<std::string, std::string> &default_backend_overrides)
+std::unique_ptr<NeuropodBackend> load_neuropod_ope(const std::string &                 neuropod_path,
+                                                   const RuntimeOptions &              options,
+                                                   const std::vector<BackendLoadSpec> &default_backend_overrides)
 {
     if (!options.use_ope)
     {

--- a/source/neuropod/multiprocess/multiprocess.hh
+++ b/source/neuropod/multiprocess/multiprocess.hh
@@ -18,9 +18,8 @@ namespace neuropod
 // Note: Libraries in this map will only be loaded if a backend for the requested type hasn't
 // already been loaded
 // See the comments in `neuropod.hh` for more details
-std::unique_ptr<NeuropodBackend> load_neuropod_ope(
-    const std::string &                                 neuropod_path,
-    const RuntimeOptions &                              options,
-    const std::unordered_map<std::string, std::string> &default_backend_overrides);
+std::unique_ptr<NeuropodBackend> load_neuropod_ope(const std::string &                 neuropod_path,
+                                                   const RuntimeOptions &              options,
+                                                   const std::vector<BackendLoadSpec> &default_backend_overrides);
 
 } // namespace neuropod

--- a/source/neuropod/multiprocess/ope_load_config.cc
+++ b/source/neuropod/multiprocess/ope_load_config.cc
@@ -7,6 +7,23 @@
 namespace neuropod
 {
 
+// Specialization for BackendLoadSpec
+template <>
+inline void ipc_serialize(std::ostream &out, const BackendLoadSpec &data)
+{
+    ipc_serialize(out, data.type);
+    ipc_serialize(out, data.version);
+    ipc_serialize(out, data.path);
+}
+
+template <>
+inline void ipc_deserialize(std::istream &in, BackendLoadSpec &data)
+{
+    ipc_deserialize(in, data.type);
+    ipc_deserialize(in, data.version);
+    ipc_deserialize(in, data.path);
+}
+
 template <>
 void ipc_serialize(std::ostream &out, const ope_load_config &data)
 {

--- a/source/neuropod/multiprocess/ope_load_config.hh
+++ b/source/neuropod/multiprocess/ope_load_config.hh
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "neuropod/internal/backend_registration.hh"
 #include "neuropod/multiprocess/serialization/ipc_serialization.hh"
 
 namespace neuropod
@@ -16,7 +17,7 @@ struct ope_load_config
     std::string neuropod_path;
 
     // See the docs in `neuropod.hh`
-    std::unordered_map<std::string, std::string> default_backend_overrides;
+    std::vector<BackendLoadSpec> default_backend_overrides;
 };
 
 // Serialization specializations for ope_load_config

--- a/source/neuropod/neuropod.cc
+++ b/source/neuropod/neuropod.cc
@@ -15,14 +15,14 @@ namespace neuropod
 {
 
 Neuropod::Neuropod(const std::string &neuropod_path, const RuntimeOptions &options)
-    : Neuropod(neuropod_path, std::unordered_map<std::string, std::string>(), options)
+    : Neuropod(neuropod_path, {}, options)
 {
 }
 
 // Find the right backend to use and load the neuropod
-Neuropod::Neuropod(const std::string &                                 neuropod_path,
-                   const std::unordered_map<std::string, std::string> &default_backend_overrides,
-                   const RuntimeOptions &                              options)
+Neuropod::Neuropod(const std::string &                 neuropod_path,
+                   const std::vector<BackendLoadSpec> &default_backend_overrides,
+                   const RuntimeOptions &              options)
 {
     if (options.use_ope)
     {

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -86,9 +86,9 @@ public:
     // name of a shared library that supports that type.
     // Note: Libraries in this map will only be loaded if a backend for the requested type hasn't
     // already been loaded
-    Neuropod(const std::string &                                 neuropod_path,
-             const std::unordered_map<std::string, std::string> &default_backend_overrides,
-             const RuntimeOptions &                              options = {});
+    Neuropod(const std::string &                 neuropod_path,
+             const std::vector<BackendLoadSpec> &default_backend_overrides,
+             const RuntimeOptions &              options = {});
 
     // Allows an already-initialized backend to be passed in. This enables backends that need
     // non-standard arguments. For example, this can be used to build a proxy that runs a

--- a/source/neuropod/python/loader.py
+++ b/source/neuropod/python/loader.py
@@ -19,6 +19,8 @@ def load_installed_backends():
     Get all the installed backends
     """
     # TODO(vip): Make sure these are all whitelisted packages published by us
+    # Note: these are listed in reverse priority order
+    # The ordering below means we'd prefer to load a newer, GPU capable version of a framework if one is available
     PACKAGES = [
         # Torch CPU
         "neuropod-backend-torchscript-1-1-0-cpu",

--- a/source/neuropod/python/registry.py
+++ b/source/neuropod/python/registry.py
@@ -2,11 +2,11 @@
 # Uber, Inc. (c) 2020
 #
 
-# A backend registry
+from neuropod.neuropod_native import BackendLoadSpec
 
-_REGISTERED_BACKENDS = {}
+# A list of backends that are available for the native code to load
+_REGISTERED_BACKENDS = []
 
 
-def register_backend(platforms, so_path):
-    for platform in platforms:
-        _REGISTERED_BACKENDS[platform] = so_path
+def register_backend(platform, version, so_path):
+    _REGISTERED_BACKENDS.append(BackendLoadSpec(platform, version, so_path))

--- a/source/neuropod/tests/test_ipc_serialization.cc
+++ b/source/neuropod/tests/test_ipc_serialization.cc
@@ -61,8 +61,8 @@ TEST(test_ipc_serialization, ope_load_config)
     neuropod::ope_load_config expected;
     expected.neuropod_path             = "/some/path";
     expected.default_backend_overrides = {
-        {"tensorflow", "/some/path/to/neuropod_tensorflow_backend.so"},
-        {"torchscript", "/some/path/to/neuropod_torchscrtipt_backend.so"},
+        {"tensorflow", "1.1.0", "/some/path/to/neuropod_tensorflow_backend.so"},
+        {"torchscript", "1.12.0", "/some/path/to/neuropod_torchscrtipt_backend.so"},
     };
 
     const auto actual = serialize_deserialize(expected);


### PR DESCRIPTION
Enable the native code to load different default shared objects depending on the requested framework version.

A future PR will actually rename the `so` files depending on the version of the framework they're built against (e.g. `libneuropod_torchscript_1_4_0_cpu_backend.so`)