### PR TITLE
[OPE] Use GPU UUIDs instead of indices for more stability

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -28,10 +28,10 @@ fi
 
 # Run python tests
 pushd python
-python -m unittest discover --verbose neuropod/tests
+NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod/tests
 
 # Test the native bindings
-NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests
 popd
 
 # Run native tests

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -39,16 +39,16 @@ fi
 
 # Run python tests
 pushd python
-python -m unittest discover --verbose neuropod/tests
+NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod/tests
 
 # Test the native bindings
-NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests
 
 # Run GPU only python tests
-python -m unittest discover --verbose neuropod/tests -p gpu_test*.py
+NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod/tests -p gpu_test*.py
 
 # Run GPU only python tests with native bindings
-NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests -p gpu_test*.py
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod/tests -p gpu_test*.py
 popd
 
 # Run native tests

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -34,6 +34,9 @@ void init_registrar_if_needed()
 {
     std::call_once(registrar_initialized, []() {
         registered_backends_by_type = stdx::make_unique<std::unordered_map<std::string, BackendInfo>>();
+
+        // Make sure our logging is initialized
+        init_logging();
     });
 }
 

--- a/source/neuropod/internal/cuda_device_mapping.cc
+++ b/source/neuropod/internal/cuda_device_mapping.cc
@@ -1,0 +1,228 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#include "neuropod/internal/cuda_device_mapping.hh"
+
+#include "neuropod/internal/error_utils.hh"
+#include "neuropod/internal/logging.hh"
+
+#include <unordered_map>
+
+#include <dlfcn.h>
+
+namespace neuropod
+{
+
+namespace
+{
+
+typedef int   cudaError_t;
+typedef int   nvmlReturn_t;
+typedef void *nvmlDevice_t;
+
+// __host__​__device__​cudaError_t cudaGetDeviceCount ( int* count )
+cudaError_t (*cudaGetDeviceCount)(int *);
+
+// __host__​cudaError_t cudaDeviceGetPCIBusId ( char* pciBusId, int  len, int  device )
+cudaError_t (*cudaDeviceGetPCIBusId)(char *, int, int);
+
+// __host__​__device__​cudaError_t cudaGetLastError ( void )
+cudaError_t (*cudaGetLastError)();
+
+// nvmlReturn_t nvmlInit ( void )
+nvmlReturn_t (*nvmlInit)();
+
+// nvmlReturn_t nvmlDeviceGetHandleByPciBusId ( const char* pciBusId, nvmlDevice_t* device )
+nvmlReturn_t (*nvmlDeviceGetHandleByPciBusId)(const char *, nvmlDevice_t *);
+
+// nvmlReturn_t nvmlDeviceGetUUID ( nvmlDevice_t device, char* uuid, unsigned int  length )
+nvmlReturn_t (*nvmlDeviceGetUUID)(nvmlDevice_t, char *, unsigned int);
+
+// const DECLDIR char* nvmlErrorString ( nvmlReturn_t result )
+const char *(*nvmlErrorString)(nvmlReturn_t);
+
+// Try to load CUDA
+bool load_cuda()
+{
+    void *cuda_handle = nullptr;
+
+    // CUDA suffixes in priority order
+    const auto cuda_suffixes = {"", ".10.1", ".10.0", ".9.0"};
+    for (const std::string &suffix : cuda_suffixes)
+    {
+        const auto sopath = "libcudart.so" + suffix;
+        SPDLOG_TRACE("Trying to load CUDA runtime: {}", sopath);
+        cuda_handle = dlopen(sopath.c_str(), RTLD_LAZY);
+        if (cuda_handle)
+        {
+            break;
+        }
+    }
+
+    if (!cuda_handle)
+    {
+        // Couldn't load the CUDA runtime
+        SPDLOG_DEBUG("Neuropod could not load the CUDA runtime");
+        return false;
+    }
+
+    // Load the functions we care about
+    cudaGetDeviceCount = reinterpret_cast<cudaError_t (*)(int *)>(dlsym(cuda_handle, "cudaGetDeviceCount"));
+
+    cudaDeviceGetPCIBusId =
+        reinterpret_cast<cudaError_t (*)(char *, int, int)>(dlsym(cuda_handle, "cudaDeviceGetPCIBusId"));
+
+    cudaGetLastError = reinterpret_cast<cudaError_t (*)()>(dlsym(cuda_handle, "cudaGetLastError"));
+
+    return true;
+}
+
+// Try to load NVML
+bool load_nvml()
+{
+    void *nvml_handle = nullptr;
+
+    // NVML suffixes in priority order
+    const auto nvml_suffixes = {"", ".1"};
+    for (const std::string &suffix : nvml_suffixes)
+    {
+        const auto sopath = "libnvidia-ml.so" + suffix;
+        SPDLOG_TRACE("Trying to load NVML: {}", sopath);
+        nvml_handle = dlopen(sopath.c_str(), RTLD_LAZY);
+        if (nvml_handle)
+        {
+            break;
+        }
+    }
+
+    if (!nvml_handle)
+    {
+        // Couldn't load NVML
+        SPDLOG_DEBUG("Neuropod could not load NVML");
+        return false;
+    }
+
+    // Load the functions we care about
+    nvmlInit = reinterpret_cast<nvmlReturn_t (*)()>(dlsym(nvml_handle, "nvmlInit"));
+
+    nvmlDeviceGetHandleByPciBusId = reinterpret_cast<nvmlReturn_t (*)(const char *, nvmlDevice_t *)>(
+        dlsym(nvml_handle, "nvmlDeviceGetHandleByPciBusId"));
+
+    nvmlDeviceGetUUID =
+        reinterpret_cast<nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int)>(dlsym(nvml_handle, "nvmlDeviceGetUUID"));
+
+    nvmlErrorString = reinterpret_cast<const char *(*) (nvmlReturn_t)>(dlsym(nvml_handle, "nvmlErrorString"));
+
+    auto err = nvmlInit();
+    if (err != 0 /* NVML_SUCCESS */)
+    {
+        SPDLOG_ERROR("Error when initializing NVML: {}", nvmlErrorString(err));
+        return false;
+    }
+
+    return true;
+}
+
+// Gets a mapping from a CUDA GPU index to a UUID corresponding to the GPU
+// This is a standard id that is not affected by CUDA_VISIBLE_DEVICES so we can
+// use it to have stable IDs across processes (e.g. for OPE)
+std::unordered_map<int, std::string> get_id_mapping()
+{
+    // Make sure our logging is initialized
+    init_logging();
+
+    if (!load_cuda() || !load_nvml())
+    {
+        // Couldn't load CUDA or NVML so we can't do anything else
+        return {};
+    }
+
+    // Get device count
+    // Based on https://github.com/pytorch/pytorch/blob/master/c10/cuda/CUDAFunctions.h#L19
+    int device_count;
+    int err = cudaGetDeviceCount(&device_count);
+
+    // Check if CUDA gave us an error
+    if (err != 0 /* cudaSuccess */)
+    {
+        // Clear out the error state, so we don't spuriously trigger someone else.
+        cudaGetLastError();
+        SPDLOG_DEBUG("Error when getting number of GPU devices");
+        return {};
+    }
+
+    // Check if we have a GPU
+    if (device_count <= 0)
+    {
+        SPDLOG_DEBUG("No GPUs available");
+        return {};
+    }
+
+    std::unordered_map<int, std::string> id_mapping;
+    for (int i = 0; i < device_count; i++)
+    {
+        // Get the UUID from the device ID
+
+        // At most 13 chars according to
+        // https://docs.nvidia.com/cuda/archive/9.0/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1gea264dad3d8c4898e0b82213c0253def
+        char pciBusId[13];
+        err = cudaDeviceGetPCIBusId(pciBusId, sizeof(pciBusId), i);
+        if (err != 0 /* cudaSuccess */)
+        {
+            // Clear out the error state, so we don't spuriously trigger someone else.
+            cudaGetLastError();
+            SPDLOG_ERROR("Error when getting pciBusId for GPU {}", i);
+            return {};
+        }
+
+        // Get an NVML device handle
+        nvmlDevice_t device;
+        err = nvmlDeviceGetHandleByPciBusId(pciBusId, &device);
+        if (err != 0 /* NVML_SUCCESS */)
+        {
+            SPDLOG_ERROR("NVML error when getting device from pciBusId: {}", nvmlErrorString(err));
+        }
+
+        // Get a UUID from the handle
+        // At most 80 chars according to
+        // https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g84dca2d06974131ccec1651428596191
+        char uuid[80];
+        err = nvmlDeviceGetUUID(device, uuid, sizeof(uuid));
+        if (err != 0 /* NVML_SUCCESS */)
+        {
+            SPDLOG_ERROR("NVML error when getting uuid from device: {}", nvmlErrorString(err));
+        }
+
+        SPDLOG_INFO("Found GPU {} with UUID {}", i, uuid);
+
+        id_mapping.emplace(i, uuid);
+    }
+
+    return id_mapping;
+}
+
+const auto cuda_id_to_uuid = get_id_mapping();
+
+} // namespace
+
+std::string get_gpu_uuid(int cuda_id)
+{
+    if (cuda_id_to_uuid.empty())
+    {
+        SPDLOG_DEBUG(
+            "No GPUs available, but requested CUDA ID {}. (This message is expected if the machine does not have GPUs)",
+            cuda_id);
+    }
+
+    auto it = cuda_id_to_uuid.find(cuda_id);
+    if (it != cuda_id_to_uuid.end())
+    {
+        return it->second;
+    }
+
+    SPDLOG_WARN("Didn't find a GPU corresponding to the requested CUDA ID {}. Returning empty UUID", cuda_id);
+    return "";
+}
+
+} // namespace neuropod

--- a/source/neuropod/internal/cuda_device_mapping.hh
+++ b/source/neuropod/internal/cuda_device_mapping.hh
@@ -1,0 +1,17 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include <string>
+
+namespace neuropod
+{
+
+// This returns a UUID string from a cuda ID that's valid in the current process
+// Note: The returned string includes the "GPU-" prefix returned by NVML
+// Returns an empty string if a GPU corresponding to the requested ID is not available
+std::string get_gpu_uuid(int cuda_id);
+
+} // namespace neuropod

--- a/source/neuropod/internal/logging.cc
+++ b/source/neuropod/internal/logging.cc
@@ -51,15 +51,29 @@ spdlog::level::level_enum get_default_log_level()
     return spdlog::level::info;
 }
 
-bool set_initial_log_level()
-{
-    spdlog::set_level(get_default_log_level());
-    spdlog::set_pattern("%D %T.%f: %L %@] [thread %t, process %P] %v");
+std::once_flag logging_initialized;
 
+} // namespace
+
+void init_logging()
+{
+    std::call_once(logging_initialized, []() {
+        spdlog::set_level(get_default_log_level());
+        spdlog::set_pattern("%D %T.%f: %L %@] [thread %t, process %P] %v");
+    });
+}
+
+namespace
+{
+
+bool static_init_logging()
+{
+    init_logging();
     return true;
 }
 
-bool current_log_level = set_initial_log_level();
+// Initialize logging if nothing else did
+bool current_log_level = static_init_logging();
 
 } // namespace
 

--- a/source/neuropod/internal/logging.hh
+++ b/source/neuropod/internal/logging.hh
@@ -9,3 +9,14 @@
 
 #include "spdlog/fmt/ostr.h"
 #include "spdlog/spdlog.h"
+
+namespace neuropod
+{
+
+// Initialize Neuropod logging and set the initial log level (if not already initialized)
+// This is used by code that logs as soon as the process is loaded. Object construction order
+// across translation units is not defined so if you attempt to log before the process has
+// fully started, the messages may not show up. Calling `init_logging` fixes this
+void init_logging();
+
+} // namespace neuropod

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -5,6 +5,7 @@
 #include "neuropod/multiprocess/multiprocess.hh"
 
 #include "neuropod/backends/neuropod_backend.hh"
+#include "neuropod/internal/cuda_device_mapping.hh"
 #include "neuropod/internal/logging.hh"
 #include "neuropod/multiprocess/control_messages.hh"
 #include "neuropod/multiprocess/ipc_control_channel.hh"
@@ -158,7 +159,9 @@ public:
         }
         else
         {
-            env["CUDA_VISIBLE_DEVICES"] = std::to_string(options.visible_device);
+            // The GPU UUID is a standard id that is not affected by CUDA_VISIBLE_DEVICES so we can
+            // use it to have stable IDs across processes (e.g. for OPE)
+            env["CUDA_VISIBLE_DEVICES"] = get_gpu_uuid(options.visible_device);
         }
 
         // Convert to a vector


### PR DESCRIPTION
When launching a worker process for OPE, we don't want to just pass through a device index because `CUDA_VISIBLE_DEVICES` may be applied to the main process, causing an index mismatch between the worker and the main process.

For example:

If the real CUDA GPU ordering is:
```
0 -> GPU A
1 -> GPU B
2 -> GPU C
3 -> GPU D
```

and the main process is launched with CUDA_VISIBLE_DEVICES=2, it might see the following:
```
0 -> GPU C
```

If that process tries to run a model using OPE (with `visible_device` in `RuntimeOptions` set to `0`), we expect it to use `GPU C` (as that is GPU 0 in the main process).

However, if it launches a worker process setting CUDA_VISIBLE_DEVICES=opts. visible_device (as it currently does), the worker will see
```
0 -> GPU A
```

because `opts.visible_device` index is 0.

To fix this, we use GPU UUIDs instead of indices when launching an OPE worker process.