### PR TITLE
[Seal] Basic implementation of `to` operation

### DIFF
--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -14,9 +14,18 @@ cc_library(
         "//visibility:public",
     ],
     deps = [
+        ":options",
         "//neuropod/backends:neuropod_backend",
         "//neuropod/core",
         "//neuropod/internal",
+    ],
+)
+
+cc_library(
+    name = "options",
+    hdrs = ["options.hh"],
+    visibility = [
+        "//visibility:public",
     ],
 )
 
@@ -60,6 +69,7 @@ pkg_tar(
         # Headers
         ":neuropod.hh",
         ":version.hh",
+        ":options.hh",
     ],
     package_dir = "include/neuropod/",
     deps = [

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -97,7 +97,7 @@ static auto gil_release = maybe_initialize();
 PythonBridge::PythonBridge(const std::string &             neuropod_path,
                            const RuntimeOptions &          options,
                            const std::vector<std::string> &python_path_additions)
-    : NeuropodBackendWithDefaultAllocator<GenericNeuropodTensor>(neuropod_path)
+    : NeuropodBackendWithDefaultAllocator<GenericNeuropodTensor>(neuropod_path, options)
 {
     // Modify PYTHONPATH
     set_python_path(python_path_additions);

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -132,9 +132,8 @@ std::string get_handle_cache_key(const std::map<std::string, tensorflow::Tensor>
 } // namespace
 
 TensorflowNeuropodBackend::TensorflowNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
-    : NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>(neuropod_path),
-      session_(tensorflow::NewSession(get_tf_opts(options))),
-      options_(options)
+    : NeuropodBackendWithDefaultAllocator<TensorflowNeuropodTensor>(neuropod_path, options),
+      session_(tensorflow::NewSession(get_tf_opts(options)))
 {
     if (options.load_model_at_construction)
     {

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -31,9 +31,6 @@ class TensorflowNeuropodBackend : public NeuropodBackendWithDefaultAllocator<Ten
 private:
     std::unique_ptr<tensorflow::Session> session_;
 
-    // The options this model was loaded with
-    RuntimeOptions options_;
-
     // Cached access to callable handles
     std::unordered_map<std::string, int64_t> callable_handle_cache_;
 

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -215,8 +215,7 @@ std::mutex                      loaded_op_mutex;
 } // namespace
 
 TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
-    : NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>(neuropod_path),
-      options_(options),
+    : NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>(neuropod_path, options),
       input_device_mapping_(model_config_->input_tensor_device)
 {
     if (options.load_model_at_construction)

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -29,9 +29,6 @@ private:
     // The model output specification from ModelConfig
     std::vector<TensorSpec> output_specs_;
 
-    // The options this model was loaded with
-    RuntimeOptions options_;
-
     // The device mapping for the input tensors
     std::unordered_map<std::string, NeuropodDeviceType> input_device_mapping_;
 

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "//neuropod:__subpackages__",
     ],
     deps = [
+        "//neuropod:options",
         "@fmt_repo//:fmt",
         "@spdlog_repo//:spdlog",
     ],

--- a/source/neuropod/internal/neuropod_tensor.cc
+++ b/source/neuropod/internal/neuropod_tensor.cc
@@ -58,12 +58,13 @@ void throw_error_hh(
 
 } // namespace detail
 
-NeuropodTensor::NeuropodTensor(TensorType tensor_type, const std::vector<int64_t> dims)
+NeuropodTensor::NeuropodTensor(TensorType tensor_type, const std::vector<int64_t> dims, NeuropodDevice device)
     : NeuropodValue(true),
       tensor_type_(tensor_type),
       dims_(dims),
       strides_(compute_strides(dims)),
-      num_elements_(compute_num_elements(dims))
+      num_elements_(compute_num_elements(dims)),
+      device_(device)
 {
 }
 
@@ -128,6 +129,15 @@ bool NeuropodTensor::operator==(const NeuropodTensor &other) const
     }
 
     return memcmp(first, second, num_bytes) == 0;
+}
+
+void NeuropodTensor::assure_device_cpu() const
+{
+    if (device_ != Device::CPU)
+    {
+        NEUROPOD_ERROR("Tried to perform an operation on a tensor that expected the tensor to be on CPU. Tensor: {}",
+                       *this);
+    }
 }
 
 NeuropodTensor *NeuropodValue::as_tensor()

--- a/source/neuropod/internal/neuropod_tensor_raw_data_access.hh
+++ b/source/neuropod/internal/neuropod_tensor_raw_data_access.hh
@@ -5,11 +5,16 @@
 #pragma once
 
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 namespace neuropod
 {
 
 class NeuropodTensor;
+
+template <typename T>
+class TypedNeuropodTensor;
 
 namespace internal
 {

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -127,7 +127,7 @@ public:
     MultiprocessNeuropodBackend(const std::string &neuropod_path,
                                 const std::string &control_queue_name,
                                 bool               free_memory_every_cycle)
-        : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path),
+        : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path, {}),
           control_queue_name_(control_queue_name),
           free_memory_every_cycle_(free_memory_every_cycle),
           control_channel_(control_queue_name, MAIN_PROCESS)
@@ -144,7 +144,7 @@ public:
                                 const RuntimeOptions &              options,
                                 bool                                free_memory_every_cycle,
                                 const std::vector<BackendLoadSpec> &default_backend_overrides)
-        : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path),
+        : NeuropodBackendWithDefaultAllocator<SHMNeuropodTensor>(neuropod_path, options),
           control_queue_name_(boost::uuids::to_string(boost::uuids::random_generator()())),
           free_memory_every_cycle_(free_memory_every_cycle),
           control_channel_(control_queue_name_, MAIN_PROCESS)

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -6,6 +6,7 @@
 
 #include "neuropod/backends/neuropod_backend.hh"
 #include "neuropod/internal/config_utils.hh"
+#include "neuropod/options.hh"
 #include "neuropod/version.hh"
 
 #include <memory>
@@ -15,60 +16,6 @@
 
 namespace neuropod
 {
-
-typedef int NeuropodDevice;
-namespace Device
-{
-constexpr int CPU  = -1;
-constexpr int GPU0 = 0;
-constexpr int GPU1 = 1;
-constexpr int GPU2 = 2;
-constexpr int GPU3 = 3;
-constexpr int GPU4 = 4;
-constexpr int GPU5 = 5;
-constexpr int GPU6 = 6;
-constexpr int GPU7 = 7;
-} // namespace Device
-
-struct RuntimeOptions
-{
-    // Whether or not to use out-of-process execution
-    // (using shared memory to communicate between the processes)
-    bool use_ope = false;
-
-    // These options are only used if use_ope is set to true
-    struct OPEOptions
-    {
-        // Internally, OPE uses a shared memory allocator that reuses blocks of memory if possible.
-        // Therefore memory isn't necessarily allocated during each inference cycle as blocks may
-        // be reused.
-        //
-        // If free_memory_every_cycle is set, then unused shared memory will be freed every cycle
-        // This is useful for simple inference, but for code that is pipelined
-        // (e.g. generating inputs for cycle t + 1 during the inference of cycle t), this may not
-        // be desirable.
-        //
-        // If free_memory_every_cycle is false, the user is responsible for periodically calling
-        // neuropod::free_unused_shm_blocks()
-        bool free_memory_every_cycle = true;
-
-        // This option can be used to run the neuropod in an existing worker process
-        // If this string is empty, a new worker will be started.
-        std::string control_queue_name;
-    } ope_options;
-
-    // The device to run this Neuropod on.
-    // Some devices are defined in the namespace above. For machines with more
-    // than 8 GPUs, passing in an index will also work (e.g. `9` for `GPU9`).
-    //
-    // To attempt to run the model on CPU, set this to `Device::CPU`
-    NeuropodDevice visible_device = Device::GPU0;
-
-    // Sometimes, it's important to be able to instantiate a Neuropod without
-    // immediately loading the model. If this is set to `false`, the model will
-    // not be loaded until the `load_model` method is called on the Neuropod.
-    bool load_model_at_construction = true;
-};
 
 class Neuropod
 {

--- a/source/neuropod/options.hh
+++ b/source/neuropod/options.hh
@@ -1,0 +1,66 @@
+//
+// Uber, Inc. (c) 2020
+//
+
+#pragma once
+
+#include <string>
+
+namespace neuropod
+{
+
+typedef int NeuropodDevice;
+namespace Device
+{
+constexpr int CPU  = -1;
+constexpr int GPU0 = 0;
+constexpr int GPU1 = 1;
+constexpr int GPU2 = 2;
+constexpr int GPU3 = 3;
+constexpr int GPU4 = 4;
+constexpr int GPU5 = 5;
+constexpr int GPU6 = 6;
+constexpr int GPU7 = 7;
+} // namespace Device
+
+struct RuntimeOptions
+{
+    // Whether or not to use out-of-process execution
+    // (using shared memory to communicate between the processes)
+    bool use_ope = false;
+
+    // These options are only used if use_ope is set to true
+    struct OPEOptions
+    {
+        // Internally, OPE uses a shared memory allocator that reuses blocks of memory if possible.
+        // Therefore memory isn't necessarily allocated during each inference cycle as blocks may
+        // be reused.
+        //
+        // If free_memory_every_cycle is set, then unused shared memory will be freed every cycle
+        // This is useful for simple inference, but for code that is pipelined
+        // (e.g. generating inputs for cycle t + 1 during the inference of cycle t), this may not
+        // be desirable.
+        //
+        // If free_memory_every_cycle is false, the user is responsible for periodically calling
+        // neuropod::free_unused_shm_blocks()
+        bool free_memory_every_cycle = true;
+
+        // This option can be used to run the neuropod in an existing worker process
+        // If this string is empty, a new worker will be started.
+        std::string control_queue_name;
+    } ope_options;
+
+    // The device to run this Neuropod on.
+    // Some devices are defined in the namespace above. For machines with more
+    // than 8 GPUs, passing in an index will also work (e.g. `9` for `GPU9`).
+    //
+    // To attempt to run the model on CPU, set this to `Device::CPU`
+    NeuropodDevice visible_device = Device::GPU0;
+
+    // Sometimes, it's important to be able to instantiate a Neuropod without
+    // immediately loading the model. If this is set to `false`, the model will
+    // not be loaded until the `load_model` method is called on the Neuropod.
+    bool load_model_at_construction = true;
+};
+
+} // namespace neuropod


### PR DESCRIPTION
This PR sets up some basic infrastructure for `seal`. It introduces a `to` method on `NeuropodTensor` that can move tensors to a specified device (GPU, worker process, remote server, etc.) before `infer` is called.

This lets us do a better job of parallelizing data transfer with compute.

For tensors that are not on CPU, all the publicly visible data access methods will throw an error.

In this PR, `to` is a noop, but future PRs will introduce implementations for each backend.

Serialization of tensors on other devices will also be more concretely specified in future PRs.