### PR TITLE
[Seal] Implementation of `to` for the Torch backend

### DIFF
--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -197,17 +197,6 @@ void process_dict(NeuropodValueMap &output, const c10::IValue &item)
     }
 }
 
-torch::jit::IValue maybe_set_device(const torch::jit::IValue &item, const torch::Device &device)
-{
-    if (item.isTensor())
-    {
-        // .to(device) is a no-op if the tensor is already transferred
-        return item.toTensor().to(device);
-    }
-
-    return item;
-}
-
 // Used to avoid loading the same custom op multiple times
 std::unordered_set<std::string> loaded_op_hashes;
 std::mutex                      loaded_op_mutex;
@@ -215,8 +204,7 @@ std::mutex                      loaded_op_mutex;
 } // namespace
 
 TorchNeuropodBackend::TorchNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options)
-    : NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>(neuropod_path, options),
-      input_device_mapping_(model_config_->input_tensor_device)
+    : NeuropodBackendWithDefaultAllocator<TorchNeuropodTensor>(neuropod_path, options)
 {
     if (options.load_model_at_construction)
     {
@@ -328,13 +316,11 @@ std::unique_ptr<NeuropodValueMap> TorchNeuropodBackend::infer_internal(const Neu
 
         for (const auto &entry : inputs)
         {
-            const auto  device = get_torch_device(input_device_mapping_.at(entry.first));
-            const auto &value  = get_ivalue_from_torch_tensor(entry.second);
+            const auto &value = get_ivalue_from_torch_tensor(entry.second);
 
             if (value.isTensor())
             {
-                // .to(device) is a no-op if the tensor is already transferred
-                DICT_INSERT(tensor_input_dict, entry.first, value.toTensor().to(device));
+                DICT_INSERT(tensor_input_dict, entry.first, value.toTensor());
             }
             else
             {
@@ -376,9 +362,7 @@ std::unique_ptr<NeuropodValueMap> TorchNeuropodBackend::infer_internal(const Neu
                     schema);
             }
 
-            const auto device = get_torch_device(input_device_mapping_.at(input_name));
-
-            torch_inputs.at(arg_index.value() - (has_class_type ? 1 : 0)) = maybe_set_device(input_data, device);
+            torch_inputs.at(arg_index.value() - (has_class_type ? 1 : 0)) = input_data;
         }
     }
 

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -29,9 +29,6 @@ private:
     // The model output specification from ModelConfig
     std::vector<TensorSpec> output_specs_;
 
-    // The device mapping for the input tensors
-    std::unordered_map<std::string, NeuropodDeviceType> input_device_mapping_;
-
     // Get a torch device given a target neuropod device
     // (this also depends on the visible device in the options above)
     torch::Device get_torch_device(NeuropodDeviceType target_device);

--- a/source/neuropod/internal/neuropod_tensor.hh
+++ b/source/neuropod/internal/neuropod_tensor.hh
@@ -258,10 +258,21 @@ protected:
     // This is used to implement things like early GPU copy
     friend class Sealer;
 
-    // TODO(vip): make this pure virtual once we have implementations for all backends
     // Copy a tensor to a particular device and return it
     // If this tensor is already on the target device, this is a noop
-    virtual std::shared_ptr<NeuropodValue> to(NeuropodDevice device) { return this->shared_from_this(); }
+    std::shared_ptr<NeuropodValue> to(NeuropodDevice device)
+    {
+        if (device == device_)
+        {
+            // Already on the target device
+            return this->shared_from_this();
+        }
+
+        return to_internal(device);
+    }
+
+    // TODO(vip): make this pure virtual once we have implementations for all backends
+    virtual std::shared_ptr<NeuropodValue> to_internal(NeuropodDevice device) { return this->shared_from_this(); }
 
     // Get the strides of the tensor
     const std::vector<int64_t> &get_strides() const { return strides_; }


### PR DESCRIPTION
This PR adds an implementation of `to` to `TorchNeuropodTensor`