### PR TITLE
Add read/write string tensor accessors

### DIFF
--- a/source/neuropod/backends/tensorflow/tf_tensor.hh
+++ b/source/neuropod/backends/tensorflow/tf_tensor.hh
@@ -126,7 +126,7 @@ public:
 
     ~TensorflowNeuropodTensor() = default;
 
-    void set(const std::vector<std::string> &data)
+    void copy_from(const std::vector<std::string> &data)
     {
         auto flat = tensor_.flat<std::string>();
         if (data.size() != flat.size())
@@ -143,7 +143,13 @@ public:
     tensorflow::Tensor &get_native_data() { return tensor_; }
 
 protected:
-    const std::string operator[](size_t index) const { return tensor_.flat<std::string>()(index); }
+    std::string get(size_t index) const { return tensor_.flat<std::string>()(index); }
+
+    void set(size_t index, const std::string &value)
+    {
+        auto flat   = tensor_.flat<std::string>();
+        flat(index) = value;
+    }
 };
 
 } // namespace neuropod

--- a/source/neuropod/backends/torchscript/torch_tensor.hh
+++ b/source/neuropod/backends/torchscript/torch_tensor.hh
@@ -164,7 +164,7 @@ public:
 
     ~TorchNeuropodTensor() = default;
 
-    void set(const std::vector<std::string> &data)
+    void copy_from(const std::vector<std::string> &data)
     {
         if (data.size() != get_num_elements())
         {
@@ -195,10 +195,16 @@ public:
 #endif
 
 protected:
-    const std::string operator[](size_t index) const
+    std::string get(size_t index) const
     {
         auto &tensor_data = ELEMENTS(list);
         return GET_STRING_FROM_LIST(tensor_data[index]);
+    }
+
+    void set(size_t index, const std::string &value)
+    {
+        auto &tensor_data  = ELEMENTS(list);
+        tensor_data[index] = value;
     }
 };
 

--- a/source/neuropod/bindings/python_bindings.cc
+++ b/source/neuropod/bindings/python_bindings.cc
@@ -81,7 +81,7 @@ std::shared_ptr<NeuropodTensor> tensor_from_string_numpy(NeuropodTensorAllocator
     }
 
     // This potentially does another copy (depending on the backend)
-    tensor->set(out);
+    tensor->copy_from(out);
 
     return tensor;
 }

--- a/source/neuropod/core/generic_tensor.hh
+++ b/source/neuropod/core/generic_tensor.hh
@@ -58,14 +58,19 @@ private:
     std::vector<std::string> data_;
 
 public:
-    GenericNeuropodTensor(const std::vector<int64_t> &dims) : TypedNeuropodTensor<std::string>(dims) {}
+    GenericNeuropodTensor(const std::vector<int64_t> &dims)
+        : TypedNeuropodTensor<std::string>(dims), data_(this->get_num_elements())
+    {
+    }
 
     ~GenericNeuropodTensor() = default;
 
-    void set(const std::vector<std::string> &data) { data_ = data; }
+    void copy_from(const std::vector<std::string> &data) { data_ = data; }
 
 protected:
-    const std::string operator[](size_t index) const { return data_[index]; }
+    std::string get(size_t index) const { return data_[index]; }
+
+    void set(size_t index, const std::string &value) { data_[index] = value; }
 };
 
 // Get a `NeuropodTensorAllocator` that creates `GenericNeuropodTensor`s

--- a/source/neuropod/internal/neuropod_tensor.hh
+++ b/source/neuropod/internal/neuropod_tensor.hh
@@ -414,6 +414,38 @@ protected:
     size_t get_bytes_per_element() const { return sizeof(T); }
 };
 
+// A class that lets us implement read/write accessors for strings
+// It can be implicitly converted to std::string and std::strings can be assigned to it
+// It proxies assignments/conversions to T::set and T::get respectively.
+// This is necessary because there isn't a standard string tensor format used by all frameworks
+// Accessors for string tensors return a StringProxy instead of an std::string directly
+template <typename T>
+class StringProxy
+{
+private:
+    T &    tensor_;
+    size_t index_;
+
+public:
+    StringProxy(T &tensor, size_t index) : tensor_(tensor), index_(index) {}
+
+    void operator=(const std::string &value) { tensor_.set(index_, value); }
+
+    // Allow implicit conversions to string
+    operator std::string() const { return tensor_.get(index_); }
+
+    // Foward all the below operators to std::string::compare
+    static int cmp(const std::string &lhs, const std::string &rhs) { return lhs.compare(rhs); }
+
+    // Based on https://en.cppreference.com/w/cpp/language/operators
+    friend bool operator==(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) == 0; }
+    friend bool operator!=(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) != 0; }
+    friend bool operator<(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) < 0; }
+    friend bool operator>(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) > 0; }
+    friend bool operator<=(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) <= 0; }
+    friend bool operator>=(const StringProxy &lhs, const std::string &rhs) { return cmp(lhs, rhs) >= 0; }
+};
+
 // A specialization for strings
 template <>
 class TypedNeuropodTensor<std::string> : public NeuropodTensor
@@ -428,7 +460,7 @@ public:
     // virtual std::string *get_raw_data_ptr() = 0;
 
     // Set the data in the string tensor
-    virtual void set(const std::vector<std::string> &data) = 0;
+    virtual void copy_from(const std::vector<std::string> &data) = 0;
 
     // Get the data in the string tensor
     std::vector<std::string> get_data_as_vector() const
@@ -442,10 +474,19 @@ public:
         // Copy the data in
         for (int i = 0; i < numel; i++)
         {
-            out[i] = (*this)[i];
+            out[i] = get(i);
         }
 
         return out;
+    }
+
+    template <size_t N>
+    TensorAccessor<TypedNeuropodTensor<std::string> &, N> accessor()
+    {
+        static_assert(N > 0, "`accessor()` is used for indexing tensors, for scalars use `as_scalar()`");
+        this->assure_device_cpu();
+        this->assure_rank(N);
+        return TensorAccessor<TypedNeuropodTensor<std::string> &, N>(*this, get_dims().data(), get_strides().data());
     }
 
     template <size_t N>
@@ -464,8 +505,22 @@ protected:
     friend class NeuropodTensor;
 
     // Get a particular element
-    // TODO(vip): Can we use absl::string_view instead?
-    virtual const std::string operator[](size_t index) const = 0;
+    template <typename T>
+    friend class StringProxy;
+    const StringProxy<const TypedNeuropodTensor<std::string>> operator[](size_t index) const
+    {
+        return StringProxy<const TypedNeuropodTensor<std::string>>(*this, index);
+    }
+
+    StringProxy<TypedNeuropodTensor<std::string>> operator[](size_t index)
+    {
+        return StringProxy<TypedNeuropodTensor<std::string>>(*this, index);
+    }
+
+    // This might be slow (virtual calls in tight loops + maybe backends redoing work)
+    // TODO(vip): Profile and maybe add a write-through cache
+    virtual std::string get(size_t index) const                     = 0;
+    virtual void        set(size_t index, const std::string &value) = 0;
 
     // We can't get a raw pointer from a string tensor
     void *get_untyped_data_ptr() { NEUROPOD_ERROR_HH("`get_untyped_data_ptr` is not supported for string tensors"); };

--- a/source/neuropod/internal/neuropod_tensor_serialization.cc
+++ b/source/neuropod/internal/neuropod_tensor_serialization.cc
@@ -48,7 +48,7 @@ std::shared_ptr<NeuropodTensor> deserialize_tensor(boost::archive::binary_iarchi
     {
         std::vector<std::string> data;
         ar >> data;
-        out->as_typed_tensor<std::string>()->set(data);
+        out->as_typed_tensor<std::string>()->copy_from(data);
     }
     else
     {

--- a/source/neuropod/multiprocess/tensor_utils.hh
+++ b/source/neuropod/multiprocess/tensor_utils.hh
@@ -34,7 +34,7 @@ std::shared_ptr<NeuropodTensor> wrap_existing_tensor(NeuropodTensorAllocator &  
         // We need to make a copy because it's not possible to generically wrap string tensors
         // (each backend has its own in-memory representation)
         // TODO(vip): optimize
-        out->set(tensor->as_typed_tensor<std::string>()->get_data_as_vector());
+        out->copy_from(tensor->as_typed_tensor<std::string>()->get_data_as_vector());
 
         return out;
     }
@@ -72,7 +72,8 @@ std::shared_ptr<NeuropodTensor> wrap_existing_tensor(std::shared_ptr<NeuropodTen
         // We need to make a copy because it's not possible to generically wrap string tensors
         // (each backend has its own in-memory representation)
         // TODO(vip): optimize
-        out->template as_typed_tensor<std::string>()->set(tensor->as_typed_tensor<std::string>()->get_data_as_vector());
+        out->template as_typed_tensor<std::string>()->copy_from(
+            tensor->as_typed_tensor<std::string>()->get_data_as_vector());
 
         return out;
     }

--- a/source/neuropod/tests/test_accessor.cc
+++ b/source/neuropod/tests/test_accessor.cc
@@ -113,8 +113,8 @@ TEST(test_accessor, test_string_read)
             }
         }
 
-        tensor->set(to_set);
-    };
+        tensor->copy_from(to_set);
+    }
 
     // Read with an accessor
     const auto accessor = tensor->accessor<2>();
@@ -126,5 +126,33 @@ TEST(test_accessor, test_string_read)
                 EXPECT_EQ(accessor[i][j], std::to_string(i * 5 + j));
             }
         }
-    };
+    }
+}
+
+TEST(test_accessor, test_string_write)
+{
+    auto allocator = neuropod::get_generic_tensor_allocator();
+
+    auto tensor = allocator->allocate_tensor<std::string>({3, 5});
+
+    // Write with an accessor
+    const auto               accessor = tensor->accessor<2>();
+    std::vector<std::string> expected;
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                auto item      = std::to_string(i * 5 + j);
+                accessor[i][j] = item;
+                expected.emplace_back(item);
+            }
+        }
+    }
+
+    // Read as a vector
+    {
+        auto actual = tensor->get_data_as_vector();
+        EXPECT_EQ(expected, actual);
+    }
 }

--- a/source/neuropod/tests/test_ipc_serialization.cc
+++ b/source/neuropod/tests/test_ipc_serialization.cc
@@ -83,7 +83,7 @@ TEST(test_ipc_serialization, neuropod_value_map)
 
     const std::shared_ptr<neuropod::NeuropodValue> string_tensor_2D =
         allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
-    string_tensor_2D->as_typed_tensor<std::string>()->set({"A", "B", "C", "D"});
+    string_tensor_2D->as_typed_tensor<std::string>()->copy_from({"A", "B", "C", "D"});
 
     const std::shared_ptr<neuropod::NeuropodValue> int_tensor_2D =
         allocator->allocate_tensor({2, 3}, neuropod::INT32_TENSOR);

--- a/source/neuropod/tests/test_serialization.cc
+++ b/source/neuropod/tests/test_serialization.cc
@@ -27,13 +27,13 @@ TEST(test_allocate_tensor, serialize_string_tensor)
 
     // Allocate tensors
     const auto tensor_1D = allocator->allocate_tensor({4}, neuropod::STRING_TENSOR);
-    tensor_1D->as_typed_tensor<std::string>()->set(expected_data);
+    tensor_1D->as_typed_tensor<std::string>()->copy_from(expected_data);
 
     const auto actual_1D = serialize_deserialize(*allocator, *tensor_1D);
     EXPECT_EQ(*tensor_1D, *actual_1D);
 
     const auto tensor_2D = allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
-    tensor_2D->as_typed_tensor<std::string>()->set(expected_data);
+    tensor_2D->as_typed_tensor<std::string>()->copy_from(expected_data);
 
     const auto actual_2D = serialize_deserialize(*allocator, *tensor_2D);
     EXPECT_EQ(*tensor_2D, *actual_2D);
@@ -70,7 +70,7 @@ TEST(test_allocate_tensor, multiple_tensors_in_a_stream)
     float_tensor_1D->as_typed_tensor<float>()->copy_from({0.0, 0.1, 0.2});
 
     const auto string_tensor_2D = allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
-    string_tensor_2D->as_typed_tensor<std::string>()->set({"A", "B", "C", "D"});
+    string_tensor_2D->as_typed_tensor<std::string>()->copy_from({"A", "B", "C", "D"});
 
     const auto int_tensor_2D = allocator->allocate_tensor({2, 3}, neuropod::INT32_TENSOR);
     int_tensor_2D->as_typed_tensor<int32_t>()->copy_from({0, 1, 2, 3, 4, 5});
@@ -99,7 +99,7 @@ TEST(test_allocate_tensor, neuropod_value_map)
 
     const std::shared_ptr<neuropod::NeuropodValue> string_tensor_2D =
         allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
-    string_tensor_2D->as_typed_tensor<std::string>()->set({"A", "B", "C", "D"});
+    string_tensor_2D->as_typed_tensor<std::string>()->copy_from({"A", "B", "C", "D"});
 
     const std::shared_ptr<neuropod::NeuropodValue> int_tensor_2D =
         allocator->allocate_tensor({2, 3}, neuropod::INT32_TENSOR);

--- a/source/neuropod/tests/test_utils.hh
+++ b/source/neuropod/tests/test_utils.hh
@@ -148,8 +148,14 @@ void test_strings_model(neuropod::Neuropod &neuropod)
     auto y_ten = neuropod.allocate_tensor<std::string>(shape);
 
     // Set the data
-    x_ten->set(x_data);
-    y_ten->set(y_data);
+    x_ten->copy_from(x_data);
+
+    // Test another code path
+    auto y_accessor = y_ten->accessor<1>();
+    for (int i = 0; i < y_data.size(); i++)
+    {
+        y_accessor[i] = y_data.at(i);
+    }
 
     // Run inference
     // Requesting the "out" tensor here isn't strictly necessary, but is used to test functionality


### PR DESCRIPTION
Previously accessors on string tensors were read-only.

This PR enables them to be read/write. Unfortunately, this likely isn't optimal for performance (especially for OPE), but the tradeoff makes sense given this is much more usable.

This PR also renames `set` to `copy_from` to be more clear and make string tensors match numeric tensors.