### PR TITLE
[Python] Experimental support for specifying model dependencies

### DIFF
--- a/build/neuropod.dockerfile
+++ b/build/neuropod.dockerfile
@@ -5,6 +5,10 @@
 ARG NEUROPOD_CUDA_VERSION=10.0
 FROM nvidia/cuda:${NEUROPOD_CUDA_VERSION}-cudnn7-runtime-ubuntu16.04 as neuropod-base
 
+# Use utf8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 # We use sudo in the build scripts
 RUN apt-get update && apt-get install -y sudo
 

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -136,7 +136,7 @@ void PythonBridge::load_model_internal()
     const auto local_path = loader_->ensure_local();
 
     // Load the neuropod and save a reference to it
-    neuropod_ = stdx::make_unique<py::object>(load_neuropod(local_path));
+    neuropod_ = stdx::make_unique<py::object>(load_neuropod(local_path, true /* is_native */));
 }
 
 PythonBridge::~PythonBridge()

--- a/source/python/neuropod/backends/python/executor.py
+++ b/source/python/neuropod/backends/python/executor.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from neuropod.backends.neuropod_executor import NeuropodExecutor
 from neuropod.utils.hash_utils import sha256sum
+from neuropod.utils.pip_utils import load_deps
 
 # Workaround for https://bugs.python.org/issue32573
 if not hasattr(sys, "argv"):
@@ -59,7 +60,7 @@ class PythonNeuropodExecutor(NeuropodExecutor):
     Executes a python neuropod
     """
 
-    def __init__(self, neuropod_path, load_custom_ops=True):
+    def __init__(self, neuropod_path, is_native=False, load_custom_ops=True):
         """
         Load a python neuropod
 
@@ -76,6 +77,17 @@ class PythonNeuropodExecutor(NeuropodExecutor):
         # Load entrypoint info from config
         entrypoint_package_path = model_config["entrypoint_package"]
         entrypoint_fn_name = model_config["entrypoint"]
+
+        if is_native:
+            # This is running from the native code - set up the requirements if any
+            # Note: This is only intended to work when using OPE so this can be problematic
+            # when running multiple python models in a single process
+            # (which you should try to avoid anyway because of the GIL)
+            # For other code paths (e.g. when calling `load_neuropod` from python with `_always_use_native=False`),
+            # the user is responsible for ensuring that all dependencies are installed in the environment
+            lockfile = os.path.join(neuropod_path, "0", "requirements.lock")
+            if os.path.isfile(lockfile):
+                load_deps(lockfile)
 
         # Add the custom op paths to the beginning of the python path
         # Note: there currently isn't a good way to handle multiple custom ops with the same name.

--- a/source/python/neuropod/tests/test_python_deps.py
+++ b/source/python/neuropod/tests/test_python_deps.py
@@ -1,0 +1,92 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+import numpy as np
+import os
+import sys
+import unittest
+from testpath.tempdir import TemporaryDirectory
+
+from neuropod.loader import load_neuropod
+from neuropod.packagers import create_python_neuropod
+from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
+
+# From the example at https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html
+SKLEARN_MODEL_SOURCE = """
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
+# y = 1 * x_0 + 2 * x_1 + 3
+y = np.dot(X, np.array([1, 2])) + 3
+
+reg = LinearRegression().fit(X, y)
+
+def model(x):
+    return {
+        "out": reg.predict(x)
+    }
+
+def get_model(_):
+    return model
+"""
+
+
+@unittest.skipIf(
+    not RUN_NATIVE_TESTS,
+    "Specifying python deps are only supported by the native bindings",
+)
+class TestPythonDeps(unittest.TestCase):
+    def package_sklearn_model(self, test_dir):
+        neuropod_path = os.path.join(test_dir, "test_neuropod")
+        model_code_dir = os.path.join(test_dir, "model_code")
+        os.makedirs(model_code_dir)
+
+        with open(os.path.join(model_code_dir, "sklearn_model.py"), "w") as f:
+            f.write(SKLEARN_MODEL_SOURCE)
+
+        create_python_neuropod(
+            neuropod_path=neuropod_path,
+            model_name="sklearn_model",
+            data_paths=[],
+            code_path_spec=[
+                {
+                    "python_root": model_code_dir,
+                    "dirs_to_package": [""],  # Package everything in the python_root
+                }
+            ],
+            entrypoint_package="sklearn_model",
+            entrypoint="get_model",
+            input_spec=[{"name": "x", "dtype": "float64", "shape": ("batch_size", 2)}],
+            output_spec=[{"name": "out", "dtype": "float64", "shape": ("batch_size",)}],
+            test_input_data={"x": np.array([[3, 5]], dtype=np.float64)},
+            test_expected_out={"out": np.array([16], dtype=np.float64)},
+            # We define requirements this way because this test runs on python 2.7 - 3.8
+            # but there isn't a single version of scikit-learn that works on all of them
+            requirements="""
+            # Requirements for this model
+            scikit-learn=={}
+            """.format(
+                "0.20.0" if sys.version_info.major == 2 else "0.22.0"
+            ),
+        )
+
+        return neuropod_path
+
+    def test_python_deps(self):
+        # Test that we can correctly load two different models with the same dependencies
+        with TemporaryDirectory() as test_dir1:
+            with TemporaryDirectory() as test_dir2:
+                path1 = self.package_sklearn_model(test_dir1)
+                path2 = self.package_sklearn_model(test_dir2)
+
+                with load_neuropod(path1) as n1:
+                    with load_neuropod(path2) as n2:
+                        input_data = {"x": np.array([[4, 5]], dtype=np.float64)}
+                        self.assertAlmostEqual(n1.infer(input_data)["out"][0], 17)
+                        self.assertAlmostEqual(n2.infer(input_data)["out"][0], 17)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/python/neuropod/utils/pip_utils.py
+++ b/source/python/neuropod/utils/pip_utils.py
@@ -1,0 +1,131 @@
+#
+# Uber, Inc. (c) 2020
+#
+
+import errno
+import os
+import glob
+import subprocess
+import sys
+
+PACKAGE_BASE_DIR = os.path.abspath(
+    os.path.expanduser(
+        "~/.neuropod/pythonpackages/py{}{}/".format(
+            sys.version_info.major, sys.version_info.minor
+        )
+    )
+)
+
+
+def create_if_not_exists(path):
+    # Messy because this needs to be python2 + 3 compatible
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+
+def compile_requirements(requirements, lockfile):
+    """
+    Run piptools compile over a requirement file to generate an output lockfile.
+    We use `--allow-unsafe` as we want to include wheel, pip, and setuptools in our output.
+    """
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "piptools",
+            "compile",
+            "--no-header",
+            "--allow-unsafe",
+            "-q",
+            "-o",
+            lockfile,
+            requirements,
+        ],
+    )
+
+
+def install_package(specifier, prefix):
+    """
+    Install a pip package (without dependencies) into the prefix directory.
+    """
+
+    # TODO(vip): If this command is run as a different user, we can prevent models
+    # from modifying the installed packages (can also do things like read-only mounts, etc.)
+    from pip._internal.cli.main import main as pip_entry_point
+
+    exit_code = pip_entry_point(
+        [
+            "-q",
+            "install",
+            "--compile",
+            "--no-deps",
+            "--disable-pip-version-check",
+            "--no-warn-script-location",
+            "--prefix={}".format(prefix),
+            "--ignore-installed",
+            specifier,
+        ]
+    )
+
+    if exit_code != 0:
+        raise RuntimeError("Error installing python dependency: {}".format(specifier))
+
+
+def load_deps(lockfile):
+    """
+    For each dependency in the lockfile, install it to the cachedir if necessary
+    and add it to sys.path
+
+    Note: the lockfile contains all transitive deps so we don't need to do any
+    recursive scanning
+
+    This is intented to be used by the native code when running with OPE (i.e. one
+    model per process).
+    """
+
+    requirements = []
+    with open(lockfile, "r") as f:
+        for line in f:
+            # Remove comments
+            pos = line.find("#")
+            if pos != -1:
+                line = line[:pos]
+
+            # Remove surrounding whitespace
+            line = line.strip()
+            if not line:
+                continue
+
+            # Anything else must be of the form name==version or we error
+            parts = line.split("==")
+            if len(parts) != 2:
+                raise ValueError(
+                    "Expected requirements of the form name==version but got {}".format(
+                        line
+                    )
+                )
+
+            # Add it to our list of requirements
+            requirements.append(line.lower())
+
+    # Create our package base dir if necessary
+    create_if_not_exists(PACKAGE_BASE_DIR)
+
+    for requirement in requirements:
+        req_path = os.path.abspath(os.path.join(PACKAGE_BASE_DIR, requirement))
+
+        # Sanity check to guard against bad input
+        if not req_path.startswith(PACKAGE_BASE_DIR):
+            raise ValueError("Invalid dependency: {}".format(requirement))
+
+        # Install this package if we need to
+        if not os.path.isdir(req_path):
+            install_package(requirement, req_path)
+
+        # Add this package to the pythonpath
+        sys.path.insert(
+            0, glob.glob("{}/lib/python*/site-packages".format(req_path))[0]
+        )

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution
 
-REQUIRED_PACKAGES = ["numpy", "testpath", "future", "six"]
+REQUIRED_PACKAGES = ["numpy", "testpath", "future", "six", "pip-tools"]
 
 if sys.version_info[:2] in ((2, 7), (3, 4)):
     # typing is built in to cpython for >= 3.5


### PR DESCRIPTION
### Summary:

This PR allows python/pytorch models to specify their python dependencies at packaging time. These dependencies are used to generate a `requirements.lock` file that is stored within the model.

When loading a python model, if a requirements.lock file is found, the dependencies are automatically installed into `~/.neuropod/pythonpackages/py{MAJOR_VERSION}{MINOR_VERSION}/` (if they don't already exist).

These python packages are installed in a way where we can independently load each python package we want.

### Test Plan:

Added a test that packages, loads, and runs inference with a python model that requires `scikit-learn`.