### PR TITLE
[OPE] Pass RuntimeOptions to the worker process

### DIFF
--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -190,6 +190,14 @@ public:
         load_config_.neuropod_path             = neuropod_path_;
         load_config_.default_backend_overrides = default_backend_overrides;
 
+        // Copy options into the load configuration
+        // Note: some of these options will be overridden in the worker process
+        load_config_.opts = options_;
+
+        // Since we're using CUDA_VISIBLE_DEVICES to set the appropriate device above,
+        // we'll just tell the worker to use GPU0
+        load_config_.opts.visible_device = Device::GPU0;
+
         if (options.load_model_at_construction)
         {
             load_model();

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -57,8 +57,13 @@ void multiprocess_worker_loop(const std::string &control_queue_name)
                 ope_load_config config;
                 received.get(config);
 
+                // Override some options
+                auto &opts                      = config.opts;
+                opts.load_model_at_construction = true;
+                opts.use_ope                    = false;
+
                 // Load a neuropod
-                neuropod  = stdx::make_unique<Neuropod>(config.neuropod_path, config.default_backend_overrides);
+                neuropod  = stdx::make_unique<Neuropod>(config.neuropod_path, config.default_backend_overrides, opts);
                 allocator = neuropod->get_tensor_allocator();
                 inputs.clear();
                 control_channel.send_message(LOAD_SUCCESS);

--- a/source/neuropod/multiprocess/ope_load_config.hh
+++ b/source/neuropod/multiprocess/ope_load_config.hh
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "neuropod/internal/backend_registration.hh"
 #include "neuropod/multiprocess/serialization/ipc_serialization.hh"
+#include "neuropod/options.hh"
 
 namespace neuropod
 {
@@ -29,6 +30,9 @@ struct ope_load_config
 
     // See the docs in `neuropod.hh`
     std::vector<BackendLoadSpec> default_backend_overrides;
+
+    // Options to pass to the worker process
+    RuntimeOptions opts;
 };
 
 } // namespace neuropod

--- a/source/neuropod/tests/test_ipc_serialization.cc
+++ b/source/neuropod/tests/test_ipc_serialization.cc
@@ -76,10 +76,13 @@ TEST(test_ipc_serialization, ope_load_config)
         {"torchscript", "1.12.0", "/some/path/to/neuropod_torchscrtipt_backend.so"},
     };
 
+    expected.opts.visible_device = neuropod::Device::GPU2;
+
     const auto actual = serialize_deserialize(expected);
 
     EXPECT_EQ(expected.neuropod_path, actual.neuropod_path);
     EXPECT_EQ(expected.default_backend_overrides, actual.default_backend_overrides);
+    EXPECT_EQ(expected.opts.visible_device, actual.opts.visible_device);
 }
 
 TEST(test_ipc_serialization, neuropod_value_map)


### PR DESCRIPTION
This PR passes user-specified `RuntimeOptions` to the OPE worker process when loading a model.

This enables us to easily add options without having to write special logic for OPE.

See #361 and #364 for examples.