### PR TITLE
[Build] Update Python dependencies to fix the 3.5 build on Mac

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -16,7 +16,7 @@ source .neuropod_venv/bin/activate
 # Install deps for the python interface
 # (the -f flag tells pip where to find the torch nightly builds)
 pushd source/python
-pip install -U pip setuptools numpy coverage requests mkdocs==1.0.4 mkdocs-material==4.6.0
+pip install -U pip setuptools numpy coverage requests requests[security] mkdocs==1.0.4 mkdocs-material==4.6.0
 python setup.py egg_info
 cat neuropod.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install
 popd

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution
 
-REQUIRED_PACKAGES = ["numpy<1.17.0", "testpath", "typing", "future", "six"]
+REQUIRED_PACKAGES = ["numpy", "testpath", "typing", "future", "six"]
 
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""


### PR DESCRIPTION
The macOS Python 3.5 build in CI fails when attempting to upload a release to github. This is because of SSL validation errors. Installing the `requests[security]` package fixes this issue.

This PR also replaces the `numpy<1.17.0` requirement with `numpy`