### PR TITLE
[Build] Fix Travis CI Python 3.5 release builds

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -16,7 +16,7 @@ source .neuropod_venv/bin/activate
 # Install deps for the python interface
 # (the -f flag tells pip where to find the torch nightly builds)
 pushd source/python
-pip install -U pip setuptools numpy coverage requests requests[security] mkdocs==1.0.4 mkdocs-material==4.6.0
+pip install -U pip setuptools numpy coverage requests[security] mkdocs==1.0.4 mkdocs-material==4.6.0
 python setup.py egg_info
 cat neuropod.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install
 popd


### PR DESCRIPTION
#365 attempted to fix this issue by installing `requests[security]`.

Unfortunately, including both `requests` and `requests[security]` in a single `pip install` command causes the additional dependencies in `requests[security]` not to be installed.

This PR removes the plain `requests` dependency.

## Test Plan

Manually tested release uploading in the Travis CI environment for the Python 3.5 mac build
