### PR TITLE
[Build] Include headers under `core` in the release package

### DIFF
--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -84,6 +84,7 @@ pkg_tar(
     package_dir = "include/neuropod/",
     deps = [
         "//neuropod/backends:libneuropod_backends_hdrs",
+        "//neuropod/core:libneuropod_core_hdrs",
         "//neuropod/internal:libneuropod_internal_hdrs",
         "//neuropod/serialization:libneuropod_serialization_hdrs",
     ],

--- a/source/neuropod/core/BUILD
+++ b/source/neuropod/core/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
 cc_library(
     name = "core",
     hdrs = glob(["*.hh"]),
@@ -36,4 +38,14 @@ cc_library(
         "//neuropod/internal",
     ],
     alwayslink = True,
+)
+
+# Package all the header files
+pkg_tar(
+    name = "libneuropod_core_hdrs",
+    srcs = glob(["*.hh"]),
+    package_dir = "core/",
+    visibility = [
+        "//visibility:public",
+    ],
 )


### PR DESCRIPTION
### Summary:
Include headers under `core` in the release package

### Test Plan:
CI + local verification that the headers are included
