### PR TITLE
[Docs] Minor updates to docs in preparation for open-sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-docs/index.md
+# Neuropod
+
+## What is Neuropod?
+
+[Neuropod](https://github.com/uber/neuropod) is a library that provides a uniform interface to run deep learning models from multiple frameworks in C++ and Python. Neuropod makes it easy for researchers to build models in a framework of their choosing while also simplifying productionization of these models.
+
+It currently supports TensorFlow, PyTorch, TorchScript, and Keras.
+
+## Why use Neuropod?
+
+#### Run models from any supported framework using one API
+
+Running a TensorFlow model looks exactly like running a PyTorch model.
+
+```py
+x = np.array([1, 2, 3, 4])
+y = np.array([5, 6, 7, 8])
+
+for model_path in [TF_ADDITION_MODEL_PATH, PYTORCH_ADDITION_MODEL_PATH]:
+    # Load the model
+    neuropod = load_neuropod(model_path)
+
+    # Run inference
+    results = neuropod.infer({"x": x, "y": y})
+
+    # array([6, 8, 10, 12])
+    print results["out"]
+```
+
+See the [tutorial](https://neuropod.ai/tutorial/), [Python guide](https://neuropod.ai/pyguide/), or [C++ guide](https://neuropod.ai/cppguide/) for more examples.
+
+Some benefits of this include:
+
+- All of your inference code is framework agnostic.
+- You can easily switch between deep learning frameworks if necessary without changing runtime code.
+- Avoid the learning curve of using the C++ libtorch API and the C/C++ TF API
+
+Any Neuropod model can be run from both C++ and Python (even PyTorch models that have not been converted to TorchScript).
+
+#### Define a Problem API
+
+This lets you focus more on the problem you're solving rather than the framework you're using to solve it.
+
+For example, if you define a problem API for 2d object detection, any model that implements it can reuse all the existing inference code and infrastructure for that problem.
+
+```py
+INPUT_SPEC = [
+    # BGR image
+    {"name": "image", "dtype": "uint8", "shape": (1200, 1920, 3)},
+]
+
+OUTPUT_SPEC = [
+    # shape: (num_detections, 4): (xmin, ymin, xmax, ymax)
+    # These values are in units of pixels. The origin is the top left corner
+    # with positive X to the right and positive Y towards the bottom of the image
+    {"name": "boxes", "dtype": "float32", "shape": ("num_detections", 4)},
+
+    # The list of classes that the network can output
+    # This must be some subset of ['vehicle', 'person', 'motorcycle', 'bicycle']
+    {"name": "supported_object_classes", "dtype": "string", "shape": ("num_classes",)},
+
+    # The probability of each class for each detection
+    # These should all be floats between 0 and 1
+    {"name": "object_class_probability", "dtype": "float32", "shape": ("num_detections", "num_classes")},
+]
+```
+
+This lets you
+
+- Build a single metrics pipeline for a problem
+- Easily compare models solving the same problem (even if they're in different frameworks)
+- Build optimized inference code that can run any model that solves a particular problem
+- Swap out models that solve the same problem at runtime with no code change (even if the models are from different frameworks)
+- Run fast experiments
+
+See the [tutorial](https://neuropod.ai/tutorial/) for more details.
+
+#### Build generic tools and pipelines
+
+If you have several models that take in a similar set of inputs, you can build and optimize one framework-agnostic input generation pipeline and share it across models.
+
+#### Other benefits
+
+- Fully self-contained models (including custom ops)
+- [Efficient zero-copy operations](https://neuropod.ai/advanced/efficient_tensor_creation/)
+- [Tested on](https://neuropod.ai/developing/#build-matrix) platforms including
+    - Mac, Linux, Linux (GPU)
+    - Four or five versions of each supported framework
+    - Five versions of Python
+
+- Model isolation with [out-of-process execution](https://neuropod.ai/advanced/ope/)
+    - Use multiple different versions of frameworks in the same application
+        - Ex: Experimental models using Torch nightly along with models using Torch 1.1.0
+- Switch from running in-process to running out-of-process with [one line of code](https://neuropod.ai/advanced/ope/)
+
+## Getting started
+
+See the [basic introduction tutorial](https://neuropod.ai/tutorial/) for an overview of how to get started with Neuropod.
+
+The [Python guide](https://neuropod.ai/pyguide/) and [C++ guide](https://neuropod.ai/cppguide/) go into more detail on running Neuropod models.

--- a/docs/cppguide.md
+++ b/docs/cppguide.md
@@ -10,6 +10,8 @@ This guide walks through the Neuropod C++ API in detail and goes over many diffe
 The simplest way to load a neuropod is as follows:
 
 ```cpp
+#include "neuropod/neuropod.hh"
+
 Neuropod neuropod(PATH_TO_MY_MODEL);
 ```
 
@@ -96,6 +98,14 @@ Neuropod neuropod(PATH_TO_MY_MODEL);
 auto allocator = neuropod.get_tensor_allocator();
 ```
 
+For scenarios where a model isn't loaded (e.g. unit tests), you can use a generic tensor allocator:
+
+```cpp
+#include "neuropod/core/generic_tensor.hh"
+
+auto allocator = neuropod::get_generic_tensor_allocator();
+```
+
 ### Allocate new memory
 
 For this, we just need the dimensions and type of the tensor we want to allocate.
@@ -168,7 +178,8 @@ auto tensor = allocator->tensor_from_memory<uint8_t>(
     );
     ```
 
-TODO(vip): Add a utility function for wrapping a cv::Mat
+!!! note
+    Utilities for wrapping types from common libraries will be added in a future release.
 
 #### Eigen
 
@@ -182,6 +193,9 @@ auto eigen_map = neuropod::as_eigen(*tensor);
 ```
 
 See [the Eigen docs](https://eigen.tuxfamily.org/dox/group__TutorialMapClass.html) for more details.
+
+!!! note
+    If you're not using the features of Eigen and just need simple element access, use [accessors](#directly-setget-data) instead.
 
 ### Factory functions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## What is Neuropod?
 
-Neuropod is a library that provides a uniform interface to run deep learning models from multiple frameworks in C++ and Python.
+[Neuropod](https://github.com/uber/neuropod) is a library that provides a uniform interface to run deep learning models from multiple frameworks in C++ and Python. Neuropod makes it easy for researchers to build models in a framework of their choosing while also simplifying productionization of these models.
 
 It currently supports TensorFlow, PyTorch, TorchScript, and Keras.
 
@@ -27,9 +27,9 @@ for model_path in [TF_ADDITION_MODEL_PATH, PYTORCH_ADDITION_MODEL_PATH]:
     print results["out"]
 ```
 
-See the [tutorial](tutorial.md) or [Python guide](pyguide.md) for more examples.
+See the [tutorial](tutorial.md), [Python guide](pyguide.md), or [C++ guide](cppguide.md) for more examples.
 
-There are many benefits to this:
+Some benefits of this include:
 
 - All of your inference code is framework agnostic.
 - You can easily switch between deep learning frameworks if necessary without changing runtime code.
@@ -85,8 +85,8 @@ If you have several models that take in a similar set of inputs, you can build a
 - [Efficient zero-copy operations](advanced/efficient_tensor_creation.md)
 - [Tested on](developing.md#build-matrix) platforms including
     - Mac, Linux, Linux (GPU)
-    - Four versions of each supported frameworks
-    - Four versions of Python
+    - Four or five versions of each supported framework
+    - Five versions of Python
 
 - Model isolation with [out-of-process execution](advanced/ope.md)
     - Use multiple different versions of frameworks in the same application

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,11 @@
 site_name: Neuropod
 theme:
   name: 'material'
+
+google_analytics:
+  - UA-7627242-14
+  - auto
+
 markdown_extensions:
   - toc:
       permalink: true


### PR DESCRIPTION
### Summary:
Previously, `README.md` was a symlink to `docs/index.md`. Unfortunately, this broke all the relative links in the file.

This PR splits `README.md` into a separate file that contains absolute links to the documentation website.

It also makes some other minor updates throughout the docs in preparation for open-sourcing

### Test Plan:
Local testing of the website + CI
