### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/build/wheel/build_wheel.py
+++ b/build/wheel/build_wheel.py
@@ -66,7 +66,7 @@ def package(package_name, tar_path, platform, platform_version):
         content = content.format(
             PACKAGE_NAME=package_name,
             # TODO(vip): Update this to get a version from a central location
-            NEUROPOD_VERSION="0.2.0rc2",
+            NEUROPOD_VERSION="0.2.0",
             SHARED_LIBRARY_NAME=shared_library_name,
             LIBS=str(members),
             PLATFORM=platform,

--- a/source/neuropod/version.hh
+++ b/source/neuropod/version.hh
@@ -31,14 +31,14 @@ namespace neuropod
 #define NEUROPOD_PATCH_VERSION 0
 
 // These are allowed to be 4 bits each
-#define NEUROPOD_RELEASE_LEVEL NEUROPOD_RELEASE_LEVEL_RELEASE_CANDIDATE
-#define NEUROPOD_RELEASE_SERIAL 2
+#define NEUROPOD_RELEASE_LEVEL NEUROPOD_RELEASE_LEVEL_FINAL_RELEASE
+#define NEUROPOD_RELEASE_SERIAL 0
 
 static_assert(NEUROPOD_RELEASE_LEVEL < 16, "NEUROPOD_RELEASE_LEVEL must be in the range 0 to 15 (4 bits)");
 static_assert(NEUROPOD_RELEASE_SERIAL < 16, "NEUROPOD_RELEASE_SERIAL must be in the range 0 to 15 (4 bits)");
 
 // The version as a string
-#define NEUROPOD_VERSION "0.2.0rc2"
+#define NEUROPOD_VERSION "0.2.0"
 
 // Version as a single 4-byte hex number, e.g. 0x010502B2 == 1.5.2b2.
 // Use this for numeric comparisons

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -10,7 +10,7 @@ class BinaryDistribution(Distribution):
 
 setup(
     name="neuropod",
-    version="0.2.0rc2",
+    version="0.2.0",
     install_requires=REQUIRED_PACKAGES,
     packages=find_packages(),
     package_data={'': ["neuropod_native.so", "libneuropod.so", "neuropod_multiprocess_worker"]},


### PR DESCRIPTION
### Summary:
Update the Neuropod version to `0.2.0`

### Test Plan:
CI