### PR TITLE
[Bindings] Fix a type issue for string tensors of zero elements

### DIFF
--- a/source/neuropod/bindings/python_bindings.cc
+++ b/source/neuropod/bindings/python_bindings.cc
@@ -142,6 +142,13 @@ py::array tensor_to_numpy(std::shared_ptr<NeuropodTensor> value)
 
     if (tensor->get_tensor_type() == STRING_TENSOR)
     {
+        // Special case for empty string tensors because the pybind functions below don't correctly set the
+        // type of the resulting array in this case
+        if (tensor->get_num_elements() == 0)
+        {
+            return py::array_t<std::array<char, 1>>(tensor->get_dims());
+        }
+
         // This makes a copy
         auto arr = py::array(py::cast(tensor->as_typed_tensor<std::string>()->get_data_as_vector()));
         arr.resize(tensor->get_dims());

--- a/source/neuropod/tests/test_serialization.cc
+++ b/source/neuropod/tests/test_serialization.cc
@@ -36,18 +36,25 @@ TEST(test_allocate_tensor, serialize_string_tensor)
 
     auto allocator = neuropod::get_generic_tensor_allocator();
 
-    // Allocate tensors
+    // 1D Tensor
     const auto tensor_1D = allocator->allocate_tensor({4}, neuropod::STRING_TENSOR);
     tensor_1D->as_typed_tensor<std::string>()->copy_from(expected_data);
 
     const auto actual_1D = serialize_deserialize(*allocator, *tensor_1D);
     EXPECT_EQ(*tensor_1D, *actual_1D);
 
+    // 2D Tensor
     const auto tensor_2D = allocator->allocate_tensor({2, 2}, neuropod::STRING_TENSOR);
     tensor_2D->as_typed_tensor<std::string>()->copy_from(expected_data);
 
     const auto actual_2D = serialize_deserialize(*allocator, *tensor_2D);
     EXPECT_EQ(*tensor_2D, *actual_2D);
+
+    // Empty 1D Tensor
+    const auto tensor_empty_1D = allocator->allocate_tensor({0}, neuropod::STRING_TENSOR);
+
+    const auto actual_empty_1D = serialize_deserialize(*allocator, *tensor_empty_1D);
+    EXPECT_EQ(*tensor_empty_1D, *actual_empty_1D);
 }
 
 TEST(test_allocate_tensor, serialize_scalar_tensor)

--- a/source/python/neuropod/tests/test_serialization.py
+++ b/source/python/neuropod/tests/test_serialization.py
@@ -37,7 +37,7 @@ class TestSerialization(unittest.TestCase):
             np.uint64,
             np.string_,
         ]
-        _TESTED_SHAPES = [(1,), (3,), (2, 3), (2, 3, 4)]
+        _TESTED_SHAPES = [(0,), (1,), (3,), (2, 3), (2, 3, 4)]
 
         # Used for testing NeuropodValueMap serialization
         counter = 0


### PR DESCRIPTION
### Summary:
Previously, the python bindings did not correctly set the numpy array type for string tensors with zero elements.

This PR adds a fix along with additional tests.

### Test Plan:
Added some new cases to the existing serialization tests:
1. A C++ test for string tensors with zero elements
2. A Python test for string tensors with zero elements

Before the fix in this PR, the C++ test passed, but the python one failed (implying an issue in the python bindings). With the fix, both tests pass.