### PR TITLE
[Build] Split Python dependency into headers and libs

### DIFF
--- a/source/deps/BUILD.pybind11
+++ b/source/deps/BUILD.pybind11
@@ -26,6 +26,6 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@python_repo//:python",
+        "@python_repo//:python_hdrs",
     ],
 )

--- a/source/deps/BUILD.python
+++ b/source/deps/BUILD.python
@@ -17,11 +17,7 @@ package(
 )
 
 cc_library(
-    name = "python",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["lib/libpython{PYTHON_VERSION}.dylib"],
-        "//conditions:default": glob(["lib/libpython{PYTHON_VERSION}.so.1.0", "lib/libpython{PYTHON_VERSION}m.so.1.0"]),
-    }),
+    name = "python_hdrs",
     hdrs = glob([
         "include/python{PYTHON_VERSION}/**/*.h",
         "include/python{PYTHON_VERSION}m/**/*.h",
@@ -31,5 +27,15 @@ cc_library(
         "include/python{PYTHON_VERSION}m",
     ],
     defines = ["PYTHON_VERSION={PYTHON_VERSION}"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "python",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": ["lib/libpython{PYTHON_VERSION}.dylib"],
+        "//conditions:default": glob(["lib/libpython{PYTHON_VERSION}.so.1.0", "lib/libpython{PYTHON_VERSION}m.so.1.0"]),
+    }),
+    deps = [":python_hdrs"],
     visibility = ["//visibility:public"],
 )

--- a/source/neuropod/backends/python_bridge/BUILD
+++ b/source/neuropod/backends/python_bridge/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "//neuropod/bindings",
         "//neuropod/core",
         "//neuropod/internal",
+        "@python_repo//:python",
     ],
     alwayslink = True,
 )


### PR DESCRIPTION
### Summary:
This change splits the python bazel dependency into a `python_hdrs` target and a `python` target.

This lets us build the python bindings against just the headers (without linking against python) while linking the pythonbridge backend against python.

Fixes #387

### Test Plan:

CI + 

Verification that `neuropod_native.so` doesn't depend on Python, but `libneuropod_pythonbridge_backend.so` does

Linux:
```
$ ldd neuropod_native.so | grep libpython | wc -l
0

$ ldd libneuropod_pythonbridge_backend.so | grep libpython | wc -l
1
```

Mac:
```
$ otool -L neuropod_native.so | grep Python.framework | wc -l
       0

$ otool -L libneuropod_pythonbridge_backend.so | grep Python.framework | wc -l
       1
```
