### PR TITLE
Move the embedded python interpreter sys.argv fix into the python backend

### DIFF
--- a/source/python/neuropod/backends/python/executor.py
+++ b/source/python/neuropod/backends/python/executor.py
@@ -27,9 +27,7 @@ from neuropod.backends.neuropod_executor import NeuropodExecutor
 from neuropod.utils.hash_utils import sha256sum
 
 # Workaround for https://bugs.python.org/issue32573
-if not hasattr(sys, "argv") and (
-    sys.version_info.major == 3 and sys.version_info.minor < 8
-):
+if not hasattr(sys, "argv"):
     sys.argv = [""]
 
 # Create the neuropod package symlink directory

--- a/source/python/neuropod/backends/python/executor.py
+++ b/source/python/neuropod/backends/python/executor.py
@@ -26,6 +26,12 @@ import numpy as np
 from neuropod.backends.neuropod_executor import NeuropodExecutor
 from neuropod.utils.hash_utils import sha256sum
 
+# Workaround for https://bugs.python.org/issue32573
+if not hasattr(sys, "argv") and (
+    sys.version_info.major == 3 and sys.version_info.minor < 8
+):
+    sys.argv = [""]
+
 # Create the neuropod package symlink directory
 SYMLINKS_DIR = tempfile.mkdtemp(suffix=".neuropod_python_symlinks")
 open(os.path.join(SYMLINKS_DIR, "__init__.py"), "a").close()

--- a/source/python/neuropod/loader.py
+++ b/source/python/neuropod/loader.py
@@ -20,12 +20,6 @@ from neuropod.utils import zip_loader
 from neuropod.registry import _REGISTERED_BACKENDS
 from neuropod.utils.dtype_utils import maybe_convert_bindings_types
 
-# Workaround for https://bugs.python.org/issue32573
-if not hasattr(sys, "argv") and (
-    sys.version_info.major == 3 and sys.version_info.minor < 8
-):
-    sys.argv = [""]
-
 # Add the script's directory to the PATH so we can find the worker binary
 os.environ["PATH"] += ":" + os.path.dirname(os.path.realpath(__file__))
 

--- a/source/python/neuropod/loader.py
+++ b/source/python/neuropod/loader.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 from neuropod.backends import config_utils
 from neuropod.utils import zip_loader
 

--- a/source/python/neuropod/tests/test_python_packaging.py
+++ b/source/python/neuropod/tests/test_python_packaging.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2020 UATC, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from testpath.tempdir import TemporaryDirectory
+
+from neuropod.packagers import create_python_neuropod
+from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+
+ADDITION_MODEL_SOURCE = """
+import sys
+
+def addition_model(x, y):
+    return {
+        "out": x + y
+    }
+
+def get_model(_):
+    # Test for https://github.com/uber/neuropod/issues/374
+    assert hasattr(sys, 'argv'), "sys.argv should exist"
+
+    return addition_model
+"""
+
+
+class TestPythonPackaging(unittest.TestCase):
+    def package_simple_addition_model(self, do_fail=False):
+        with TemporaryDirectory() as test_dir:
+            neuropod_path = os.path.join(test_dir, "test_neuropod")
+            model_code_dir = os.path.join(test_dir, "model_code")
+            os.makedirs(model_code_dir)
+
+            with open(os.path.join(model_code_dir, "addition_model.py"), "w") as f:
+                f.write(ADDITION_MODEL_SOURCE)
+
+            # `create_python_neuropod` runs inference with the test data immediately
+            # after creating the neuropod. Raises a ValueError if the model output
+            # does not match the expected output.
+            create_python_neuropod(
+                neuropod_path=neuropod_path,
+                model_name="addition_model",
+                data_paths=[],
+                code_path_spec=[
+                    {
+                        "python_root": model_code_dir,
+                        "dirs_to_package": [
+                            ""  # Package everything in the python_root
+                        ],
+                    }
+                ],
+                entrypoint_package="addition_model",
+                entrypoint="get_model",
+                # Get the input/output spec along with test data
+                **get_addition_model_spec(do_fail=do_fail)
+            )
+
+            # Run some additional checks
+            check_addition_model(neuropod_path)
+
+    def test_simple_addition_model(self):
+        # Tests a case where packaging works correctly and
+        # the model output matches the expected output
+        self.package_simple_addition_model()
+
+    def test_simple_addition_model_failure(self):
+        # Tests a case where the output does not match the expected output
+        with self.assertRaises(ValueError):
+            self.package_simple_addition_model(do_fail=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
Move the `sys.argv` fix for embedded python interpreters (originally added in #375) from `loader.py` to `executor.py` in the python backend.

This is necessary because the C++ PythonBridge uses the python executor directly and bypasses `loader.py`.

More details in #374

### Test Plan
Added a new test that confirms `sys.argv` is available from within python models.

_Note: This description was edited by @VivekPanyam to add details and improve clarity_ 