### PR TITLE
Ensure consistent output hashes when packaging the same model

### DIFF
--- a/source/python/neuropod/tests/custom_ops/pytorch/test_pytorch_custom_ops.py
+++ b/source/python/neuropod/tests/custom_ops/pytorch/test_pytorch_custom_ops.py
@@ -22,6 +22,7 @@ from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_pytorch_neuropod
 from neuropod.tests.utils import get_addition_model_spec
+from neuropod.utils.hash_utils import sha256sum
 
 ADDITION_MODEL_SOURCE = """
 import torch
@@ -105,6 +106,20 @@ class TestPytorchPackaging(unittest.TestCase):
                 self.package_simple_addition_model(
                     test_dir, do_fail=True, custom_ops=[self.custom_op_path]
                 )
+
+    def test_consistent_hash(self):
+        # Packages the same model twice and ensures it has the same hash
+        shas = []
+        for i in range(2):
+            with TemporaryDirectory() as test_dir:
+                self.package_simple_addition_model(
+                    test_dir, custom_ops=[self.custom_op_path, self.second_custom_op]
+                )
+
+                neuropod_path = os.path.join(test_dir, "test_neuropod")
+                shas.append(sha256sum(neuropod_path))
+
+        self.assertEqual(shas[0], shas[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary:

Previously, when packaging a model multiple times, the hash of the output package could change even if the input did not (e.g. all the files contained in the package had the same hashes).

This was mostly because the output Neuropod package (which is a zipfile) stored timestamps of all the included files. It was also possible that we'd add files to the zip in different orders (because `os.walk` doesn't guarantee an order).

This PR sets the timestamp of all included files to a constant and also ensures that we always add the files in the same order.

### Test Plan:

Added a test to package a model twice and compare the `sha256` of the output. Also confirmed consistent hashes on a model internally.
