### PR TITLE
[Build] Remove typing dependency for python >=3.5

### DIFF
--- a/build/ci/lint.sh
+++ b/build/ci/lint.sh
@@ -24,11 +24,11 @@ pushd python
 
 # Run black
 python ../../build/ci/set_status.py --context "lint/black" --description "Black Python Formatting Checks" \
-    black --check -t py27 -t py35 -t py36 --diff neuropod
+    black --check -t py27 -t py35 -t py36 --diff .
 
 # Run flake8
 python ../../build/ci/set_status.py --context "lint/flake8" --description "flake8 Python Style Checks" \
-    flake8 neuropod
+    flake8 .
 
 popd
 

--- a/source/python/setup.py
+++ b/source/python/setup.py
@@ -1,18 +1,29 @@
+import sys
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution
 
-REQUIRED_PACKAGES = ["numpy", "testpath", "typing", "future", "six"]
+REQUIRED_PACKAGES = ["numpy", "testpath", "future", "six"]
+
+if sys.version_info[:2] in ((2, 7), (3, 4)):
+    # typing is built in to cpython for >= 3.5
+    # TODO(vip): This is only used in tests so split into a separate dependency
+    REQUIRED_PACKAGES.append("typing")
+
 
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
+
     def has_ext_modules(foo):
         return True
+
 
 setup(
     name="neuropod",
     version="0.2.0",
     install_requires=REQUIRED_PACKAGES,
     packages=find_packages(),
-    package_data={'': ["neuropod_native.so", "libneuropod.so", "neuropod_multiprocess_worker"]},
+    package_data={
+        "": ["neuropod_native.so", "libneuropod.so", "neuropod_multiprocess_worker"]
+    },
     distclass=BinaryDistribution,
 )

--- a/tools/autofix.sh
+++ b/tools/autofix.sh
@@ -19,10 +19,10 @@ find . -name "*.hh" -o -name "*.cc" | xargs -L1 clang-format -style=file -i
 pushd python
 
 # Run black
-black -t py27 -t py35 -t py36 neuropod
+black -t py27 -t py35 -t py36 .
 
 # Run autopep8 to fix errors for flake8
-autopep8 -r --in-place neuropod
+autopep8 -r --in-place .
 
 popd
 popd

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -34,10 +34,10 @@ python /tmp/run-clang-format.py -r .
 pushd python
 
 # Run black in check mode
-black --check -t py27 -t py35 -t py36 --diff neuropod
+black --check -t py27 -t py35 -t py36 --diff .
 
 # Run flake8
-flake8 neuropod
+flake8 .
 
 popd
 popd


### PR DESCRIPTION
### Summary:

The `typing` module is available within CPython >= 3.5 so we don't need to depend on the pip package.

See https://github.com/python/typing/issues/739 for more details

Note: This PR also modifies some lint scripts to ensure that `setup.py` is covered by the linter.

### Test Plan:
CI
