### PR TITLE
[Java API] Neuropod Java API Interface Proposal

### DIFF
--- a/source/neuropod/bindings/java/README.md
+++ b/source/neuropod/bindings/java/README.md
@@ -1,0 +1,35 @@
+# The java api interface:
+1. To load a model:
+```
+Neuropod model = new Neuropod(modelPath);
+```
+2. To prepare the input feature:
+```
+Map<String, NeuropodTensor> inputs = new HashMap<>();
+NeuropodTensorAllocator allocator = model.getTensorAllocator();
+NeuropodTensor tensor1 = allocator.create(new float[]{1.0f, 3.0f}, Arrays.asList(2L, 1L), model);
+inputs.put("request_location_latitude",tensor1);
+tensor1.close();
+NeuropodTensor tensor2 = allocator.create(new float[]{2.0f, 5.0f}, Arrays.asList(2L, 1L), model);
+inputs.put("request_location_longitude",tensor2);
+tensor2.close();
+...
+```
+3. To do the inference job:
+```
+Map<String, NeuropodTensor> valueMap = neuropod.infer(inputs);
+```
+
+4. To retrieve the results:
+```
+NeuropodTensor output = valueMap.get(key);
+FloatBuffer res = output.toFloatBuffer();
+```
+
+5. Don't forget to clean up the memory:
+```
+allocator.close();
+output.close();
+valueMap.close();
+model.close();
+```

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Dimension.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Dimension.java
@@ -1,0 +1,53 @@
+package com.uber.neuropod;
+
+/**
+ * The type Dimension.
+ */
+public class Dimension {
+    /**
+     * The Value. -1 means None/null, any value is OK
+     * -2 means this is a symbol (see below)
+     */
+    long value;
+    /**
+     * The name of this symbol (if it is a symbol).
+     */
+    String symbol;
+
+    /**
+     * Instantiates a new Dimension by given value
+     *
+     * @param value the value
+     */
+    public Dimension(long value) {
+        this.value = value;
+    }
+
+    /**
+     * Instantiates a new Dimension by given symbol
+     *
+     * @param symbol the symbol
+     */
+    public Dimension(String symbol) {
+        this.symbol = symbol;
+        this.value = -2;
+    }
+
+    /**
+     * Gets the value.
+     *
+     * @return the value
+     */
+    public long getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the symbol.
+     *
+     * @return the symbol
+     */
+    public String getSymbol() {
+        return symbol;
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/LibraryLoader.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/LibraryLoader.java
@@ -1,0 +1,19 @@
+package com.uber.neuropod;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class is responsible for loading jni library
+ */
+class LibraryLoader {
+    /**
+     * Load jni library.
+     */
+    public static void load() {
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NativeClass.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NativeClass.java
@@ -1,0 +1,21 @@
+package com.uber.neuropod;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This is a base class for all class with a binding to native class.
+ * Need to call close() method after usage to free memory in C++ side.
+ */
+abstract class NativeClass implements AutoCloseable {
+    // Load native library
+    static {
+        LibraryLoader.load();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // Wrap the nativeDelete to close method so that we can do some common post-process here if needed.
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
@@ -1,0 +1,104 @@
+package com.uber.neuropod;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class holds the information of a Neuropod model. It has its underlying C++ Neuropod
+ * object, should call close() function to free the C++ side object when finish using the Neuopod object
+ */
+public class Neuropod extends NativeClass {
+
+    /**
+     * Load a model from the file path and use default options
+     *
+     * @param neuropodPath the neuropod model path
+     */
+    public Neuropod(String neuropodPath) {}
+
+    /**
+     * Load a model from the file path and use provided runtime options
+     *
+     * @param neuropodPath the neuropod model path
+     * @param options      the runtime options
+     */
+    public Neuropod(String neuropodPath, RuntimeOptions options) { }
+
+    /**
+     * Gets the model name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return null;
+    }
+
+    /**
+     * Gets the platform name.
+     *
+     * @return the platform
+     */
+    public String getPlatform() {
+        return null;
+    }
+
+
+    /**
+     * Perform the inference calculation on the given input data
+     *
+     * @param inputs the inputs
+     * @return the inference result
+     */
+    public Map<String, NeuropodTensor> infer(Map<String,NeuropodTensor> inputs) {
+        return null;
+    }
+
+    /**
+     * Perform the inference calculation on the given input data, only get output tensor
+     * with the keys specified by requestOutputs.
+     *
+     * @param inputs         the inputs
+     * @param requestedOutputs only tensor with these keys will be output
+     * @return the inference result
+     */
+    public Map<String, NeuropodTensor> infer(Map<String, NeuropodTensor> inputs, List<String> requestedOutputs) {
+        return null;
+    }
+
+    /**
+     * Gets input tensor specs
+     *
+     * @return the input specs
+     */
+    public List<TensorSpec> getInputs() {
+        return null;
+    }
+
+    /**
+     * Gets output tensor specs
+     *
+     * @return the output specs
+     */
+    public List<TensorSpec> getOutputs() {
+        return null;
+    }
+
+    /**
+     * Load model. Used when setLoadModelAtConstruction is set to false in RuntimeOptions
+     */
+    public void loadModel() {}
+
+    /**
+     * Gets a tensor allocator based on the backend of the model.
+     *
+     * @return the tensor allocator
+     */
+    public NeuropodTensorAllocator getTensorAllocator() {return null;}
+
+    /**
+     * Gets a generic tensor allocator.
+     *
+     * @return the generic tensor allocator
+     */
+    public static NeuropodTensorAllocator getGenericTensorAllocator() {return null;}
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodDevice.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodDevice.java
@@ -1,0 +1,20 @@
+package com.uber.neuropod;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Which device the model uses. Use const int instead of enum to
+ * support number greater than 7, or namely GPU8 or more GPUs
+ */
+public class NeuropodDevice {
+    public static final int CPU = -1;
+    public static final int GPU0 = 0;
+    public static final int GPU1 = 1;
+    public static final int GPU2 = 2;
+    public static final int GPU3 = 3;
+    public static final int GPU4 = 4;
+    public static final int GPU5 = 5;
+    public static final int GPU6 = 6;
+    public static final int GPU7 = 7;
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodJNIException.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodJNIException.java
@@ -1,0 +1,15 @@
+package com.uber.neuropod;
+
+/**
+ * All exceptions triggered in the C++ side of Neuropod
+ */
+public class NeuropodJNIException extends RuntimeException {
+    /**
+     * Instantiates a new Neuropod jni exception.
+     *
+     * @param message the message
+     */
+    public NeuropodJNIException(String message) {
+        super(message);
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
@@ -1,0 +1,146 @@
+package com.uber.neuropod;
+
+import java.io.Serializable;
+import java.nio.*;
+import java.util.List;
+
+/**
+ * This class is used for holding tensor data. It has its underlying C++ NeuropodTensor
+ * object, should call close() function to free C++ side object when finish using the
+ * NeuropodTensor object.
+ * This object can be created by the Java side or by the C++ side(as an inference result).
+ */
+public class NeuropodTensor extends NativeClass implements Serializable {
+     /**
+      * Get the dims array which represnents the shape of a tensor.
+      *
+      * @return the shape array
+      */
+     public long[] getDims() {return null;}
+
+     /**
+      * Gets the number of elements of a tensor.
+      *
+      * @return the number of elements
+      */
+     public long getNumberOfElements() {return 0;}
+
+     /**
+      * Gets the type of a tensor
+      *
+      * @return the tensor type
+      */
+     public TensorType getTensorType() {return null;}
+
+     /**
+      * Flatten the tensor data and convert it to a long buffer.
+      * <p>
+      * Can only be used when the tensor is INT64_TENSOR. Will trigger
+      * a copy.
+      *
+      * @return the LongBuffer
+      */
+     public LongBuffer toLongBuffer() {return null;}
+
+     /**
+      * Flatten the tensor data and convert it to a int buffer.
+      * <p>
+      * Can only be used when the tensor is INT32_TENSOR. Will trigger
+      * a copy.
+      *
+      * @return the IntBuffer
+      */
+     public IntBuffer toIntBuffer() {return null;}
+
+     /**
+      * Flatten the tensor data and convert it to a float buffer.
+      * <p>
+      * Can only be used when the tensor is FLOAT_TENSOR. Will trigger
+      * a copy.
+      *
+      * @return the FloatBuffer
+      */
+     public FloatBuffer toFloatBuffer() {return null;}
+
+     /**
+      * Flatten the tensor data and convert it to a double buffer.
+      * <p>
+      * Can only be used when the tensor is DOUBLE_TENSOR. Will trigger
+      * a copy.
+      *
+      * @return the DoubleBuffer
+      */
+     public DoubleBuffer toDoubleBuffer() {return null;}
+
+     /**
+      * Flatten the tensor data and convert it to a string list.
+      * <p>
+      * Can only be used when the tensor is STRING_TENSOR. Will trigger
+      * a copy.
+      *
+      * @return the List
+      */
+     List<String> toStringList() {return null;}
+
+     /**
+      * Gets an int element at the given index.
+      * <p>
+      * Can only be used when the tensor is INT32_TENSOR.
+      * For example, to get an int element from a 3rd-order tensor,
+      * the user should call getInt(x, y, z)
+      *
+      * @param index the index array
+      * @return the int element
+      */
+     int getInt(long... index) {return 0;}
+
+     /**
+      * Gets a long element at the given index.
+      * <p>
+      * Can only be used when the tensor is INT64_TENSOR.
+      * For example, to get an long element from a 3rd-order tensor,
+      * the user should call getLong(x, y, z)
+      *
+      * @param index the index array
+      * @return the long element
+      */
+     long getLong(long... index) {return 0;}
+
+     /**
+      * Gets a double element at the given index.
+      * <p>
+      * Can only be used when the tensor is DOUBLE_TENSOR.
+      * For example, to get a double element from a 3rd-order tensor,
+      * the user should call getDouble(x, y, z)
+      *
+      * @param index the index array
+      * @return the double element
+      */
+     double getDouble(long... index) {return 0.0;}
+
+     /**
+      * Gets a float element at the given index.
+      * <p>
+      * Can only be used when the tensor is FLOAT_TENSOR.
+      * For example, to get a float element from a 3rd-order tensor,
+      * the user should call getFloat(x, y, z)
+      *
+      * @param index the index array
+      * @return the float element
+      */
+     float getFloat(long... index) {return 0.0f;}
+
+     /**
+      * Gets a string element at the given index.
+      * <p>
+      * Can only be used when the tensor is STRING_TENSOR.
+      * For example, to get a string element from a 3rd-order tensor,
+      * the user should call getString(x, y, z)
+      *
+      * @param index the index array
+      * @return the string element
+      */
+     String getString(long... index) {return "";}
+
+}
+

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensorAllocator.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensorAllocator.java
@@ -1,0 +1,100 @@
+package com.uber.neuropod;
+
+import java.nio.*;
+import java.util.List;
+
+/**
+ * The factory type for NeuropodTensor, can be obtained from a neuropod model or as a generic allocator.
+ * Should call close method when finish using it.
+ */
+public class NeuropodTensorAllocator extends NativeClass {
+    /**
+     * Create a NeuropodTensor based on given ByteBuffer, dims array and tensorType. The created tensor
+     * will have the input tensorType
+     * <p>
+     * Will not trigger a copy if the buffer is a direct bytebuffer in native order and the backend of
+     * the allocator does not have alignment requirement. Otherwise it will trigger a copy.
+     *
+     * @param byteBuffer the buffer that contains tensor data
+     * @param dims       the shape of the tensor
+     * @param tensorType the tensor type
+     * @return the created NeuropodTensor
+     */
+    NeuropodTensor create(ByteBuffer byteBuffer, long[] dims, TensorType tensorType) {
+        return null;
+    }
+
+    /**
+     * Create a NeuropodTensor based on given LongBuffer, dims array. The created tensor
+     * will have tensor type INT64_TENSOR.
+     * <p>
+     * Will not trigger a copy if the buffer is a direct buffer in native order and the backend of
+     * the allocator does not have alignment requirement. Otherwise it will trigger a copy.
+     *
+     * @param longBuffer the buffer that contains tensor data
+     * @param dims       the shape of the tensor
+     * @return the created NeuropodTensor
+     */
+    NeuropodTensor create(LongBuffer longBuffer, long[] dims) {
+        return null;
+    }
+
+    /**
+     * Create a NeuropodTensor based on given IntBuffer, dims array. The created tensor
+     * will have type INT32_TENSOR.
+     * <p>
+     * Will not trigger a copy if the buffer is a direct buffer in native order and the backend of
+     * the allocator does not have alignment requirement. Otherwise it will trigger a copy.
+     *
+     * @param intBuffer the buffer that contains tensor data
+     * @param dims      the shape of the tensor
+     * @return the created NeuropodTensor
+     */
+    NeuropodTensor create(IntBuffer intBuffer, long[] dims) {
+        return null;
+    }
+
+    /**
+     * Create a NeuropodTensor based on given DoubleBuffer, dims array. The created tensor
+     * will have type DOUBLE_TENSOR.
+     * <p>
+     * Will not trigger a copy if the buffer is a direct buffer in native order and the backend of
+     * the allocator does not have alignment requirement. Otherwise it will trigger a copy.
+     *
+     * @param doubleBuffer the buffer that contains tensor data
+     * @param dims         the shape of the tensor
+     * @return the created NeuropodTensor
+     */
+    NeuropodTensor create(DoubleBuffer doubleBuffer, long[] dims) {
+        return null;
+    }
+
+    /**
+     * Create a NeuropodTensor based on given FloatBuffer, dims array. The created tensor
+     * will have type FLOAT_TENSOR.
+     * <p>
+     * Will not trigger a copy if the buffer is a direct buffer in native order and the backend of
+     * the allocator does not have alignment requirement. Otherwise it will trigger a copy.
+     *
+     * @param floatBuffer the buffer that contains tensor data
+     * @param dims        the shape of the tensor
+     * @return the neuropod NeuropodTensor
+     */
+    NeuropodTensor create(FloatBuffer floatBuffer, long[] dims) {
+        return null;
+    }
+
+    /**
+     * Create a NeuropodTensor based on given string list, dims array. The created tensor
+     * will have type STRING_TENSOR.
+     * <p>
+     * Will trigger a copy.
+     *
+     * @param stringList the string list
+     * @param dims       the dims
+     * @return the created NeuropodTensor
+     */
+    NeuropodTensor create(List<String> stringList, long[] dims) {
+        return null;
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/RuntimeOptions.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/RuntimeOptions.java
@@ -1,0 +1,71 @@
+package com.uber.neuropod;
+
+/**
+ * An One to One mapping to RuntimeOptions native class.
+ */
+public class RuntimeOptions {
+
+    /**
+     * Is use ope.
+     *
+     * Whether or not to use out-of-process execution
+     * (using shared memory to communicate between the processes)
+     */
+    public boolean useOpe = false;
+
+    /**
+     * Is free memory every cycle.
+     *
+     * Internally, OPE(out-of-process execution) uses a shared memory allocator that reuses
+     * blocks of memory if possible. Therefore memory isn't necessarily allocated during each
+     * inference cycle as blocks may be reused.
+     * If freeMemoryEveryCycle is set, then unused shared memory will be freed every cycle
+     * This is useful for simple inference, but for code that is pipelined
+     * (e.g. generating inputs for cycle t + 1 during the inference of cycle t), this may not
+     * be desirable.
+     * If freeMemoryEveryCycle is false, the user is responsible for periodically calling
+     * Neuropod.freeUnusedShmBlocks()
+     */
+    public boolean freeMemoryEveryCycle = true;
+
+
+    /**
+     * The control queue name.
+     *
+     * This option can be used to run the neuropod in an existing worker process
+     * If this string is empty, a new worker will be started.
+     */
+    public String controlQueueName = "";
+
+    /**
+     * The visible device.
+     *
+     * Some devices are defined in the NeuropodDevice class. For machines with more
+     * than 8 GPUs, passing in an index will also work (e.g. `9` for `GPU9`).
+     * To attempt to run the model on CPU, set this to `NeuropodDevice.CPU`
+     */
+    public int visibleDevice = NeuropodDevice.GPU0;
+
+    /**
+     * Is load model at construction time.
+     *
+     * Sometimes, it's important to be able to instantiate a Neuropod without
+     * immediately loading the model. If this is set to `false`, the model will
+     * not be loaded until the `loadModel` method is called on the Neuropod.
+     */
+    public boolean loadModelAtConstruction = true;
+
+    /**
+     * Is disable shape and type checking.
+     *
+     * disableShapeAndTypeCheckingBoolean means whether or not to disable shape
+     * and type checking when running inference.
+     */
+    public boolean disableShapeAndTypeChecking = false;
+
+    /**
+     * Instantiates a new Runtime options.
+     */
+    public RuntimeOptions() {}
+
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorSpec.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorSpec.java
@@ -1,0 +1,52 @@
+package com.uber.neuropod;
+
+import java.util.List;
+
+/**
+ * The type Tensor spec.
+ */
+public class TensorSpec {
+    private String name;
+    private TensorType type;
+    private List<Dimension> dims;
+
+    /**
+     * Instantiates a new Tensor spec.
+     *
+     * @param name the name
+     * @param type the type
+     * @param dims the dims
+     */
+    public TensorSpec(String name, TensorType type, List<Dimension> dims) {
+        this.name = name;
+        this.type = type;
+        this.dims = dims;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets type.
+     *
+     * @return the type
+     */
+    public TensorType getType() {
+        return type;
+    }
+
+    /**
+     * Gets dims.
+     *
+     * @return the dims
+     */
+    public List<Dimension> getDims() {
+        return dims;
+    }
+}

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorType.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorType.java
@@ -1,0 +1,80 @@
+package com.uber.neuropod;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is an one to one mapping to cpp TensorType enum
+ */
+public enum TensorType {
+
+    // Supported Types
+    /**
+     * The Float tensor.
+     */
+    FLOAT_TENSOR(0),
+    /**
+     * Double tensor data type.
+     */
+    DOUBLE_TENSOR(1),
+    /**
+     * Int 32 tensor data type.
+     */
+    INT32_TENSOR(2),
+    /**
+     * Int 64 tensor data type.
+     */
+    INT64_TENSOR(3),
+    /**
+     * String tensor data type.
+     */
+    STRING_TENSOR(4),
+
+    // Unsupported Types, the types below are not supported by the java api
+    /**
+     * The Int 8 tensor.
+     */
+    INT8_TENSOR(5),
+    /**
+     * Int 16 tensor data type.
+     */
+    INT16_TENSOR(6),
+    /**
+     * Uint 8 tensor data type.
+     */
+    UINT8_TENSOR(7),
+    /**
+     * Uint 16 tensor data type.
+     */
+    UINT16_TENSOR(8),
+    /**
+     * Uint 32 tensor data type.
+     */
+    UINT32_TENSOR(9),
+    /**
+     * Uint 64 tensor data type.
+     */
+    UINT64_TENSOR(10);
+
+    // These helper functions below are for supporting int to enum and enum to int conversion
+    private int value;
+    private static Map map = new HashMap<>();
+
+    private TensorType(int value) {
+        this.value = value;
+    }
+
+    static {
+        for (TensorType tensorType : TensorType.values()) {
+            map.put(tensorType.value, tensorType);
+        }
+    }
+
+    protected static TensorType valueOf(int dataType) {
+        return (TensorType) map.get(dataType);
+    }
+
+    protected int getValue() {
+        return value;
+    }
+}

--- a/source/neuropod/bindings/java/src/main/resources/META-INF/MANIFEST.MF
+++ b/source/neuropod/bindings/java/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: .
+Created-By: 1.8.0_252 (AdoptOpenJDK)


### PR DESCRIPTION
### Summary:
The Java API Interface for Neuropod Java API.

The NeuropodNativeTensor class will be implemented as the following: It can be created by both C++ side(as inference result) and Java side. It has a private field buffer. For the objects created by C++ side, the buffer is wrapped from the raw memory pointer from the C++ side tensor. For the objects created by Java side, the buffer is a direct native bytebuffer from the Java side. The C++ tensor is created from the Java bytebuffer's memory. User won't tell the difference between these two types of NeuropodNativeTensor, unless they try to convert it to a pure Java tensor NeuropodJavaTensor. NeuropodNativeTensor created by the C++ side will have to trigger a copy to make the memory section is allocated by the Java side.