### PR TITLE
Improve error messages when a backend is not found

### DIFF
--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -117,13 +117,15 @@ bool load_default_backend(const std::vector<BackendLoadSpec> &backends,
             const auto err = dlerror();
             if (err == nullptr)
             {
-                NEUROPOD_ERROR("Loading the default backend for type '{}' failed, but no error message was avaliable",
-                               type);
+                SPDLOG_TRACE("Loading the default backend for type '{}' failed, but no error message was avaliable",
+                             type);
             }
             else
             {
-                NEUROPOD_ERROR("Loading the default backend for type '{}' failed. Error from dlopen: {}", type, err);
+                SPDLOG_TRACE("Loading the default backend for type '{}' failed. Error from dlopen: {}", type, err);
             }
+
+            return false;
         }
         else
         {


### PR DESCRIPTION
### Summary:
Our intended error message when a backend is not found is pretty clear:

https://github.com/uber/neuropod/blob/4f5764af8f29d1ca241f9576cf4ea5bae5c025dd/source/neuropod/internal/backend_registration.cc#L248-L253

but unfortunately, we hit another error first (`Loading the default backend for type '{}' failed. Error from dlopen: {}`)

This has come up in several issues: https://github.com/uber/neuropod/issues/383, https://github.com/uber/neuropod/issues/387#issuecomment-645681546, https://github.com/uber/neuropod/issues/403#issuecomment-667234221

This PR changes some of these intermediate error messages to TRACE output instead.

### Test Plan:

CI
