### PR TITLE
[Build] Pin Black to v19.10b0

### DIFF
--- a/build/ci/install_lint_deps.sh
+++ b/build/ci/install_lint_deps.sh
@@ -21,7 +21,7 @@ wget https://raw.githubusercontent.com/Sarcasm/run-clang-format/de6e8ca07d171a7f
 # Install pip, black, and flake8
 wget https://bootstrap.pypa.io/get-pip.py
 python3.6 get-pip.py
-python3.6 -m pip install black flake8
+python3.6 -m pip install black==19.10b0 flake8
 
 # Get buildifier (for linting bazel files)
 wget https://github.com/bazelbuild/buildtools/releases/download/2.2.1/buildifier -O /tmp/buildifier


### PR DESCRIPTION
### Summary:

There was a new [major](https://github.com/psf/black/releases/tag/20.8b0) [release](https://github.com/psf/black/releases/tag/20.8b1) of Black this morning that changed some formatting behavior. 

This pins to a previous release until a non-beta v20 release of black is published

### Test Plan:

CI
