### PR TITLE
Fix a bug with string tensors and OPE

### DIFF
--- a/source/neuropod/multiprocess/shm_tensor.hh
+++ b/source/neuropod/multiprocess/shm_tensor.hh
@@ -192,9 +192,10 @@ public:
                       const SHMBlockID &          block_id)
         : TypedNeuropodTensor<std::string>(copy_and_strip_last_dim(dims)), write_buffer_(this->get_num_elements())
     {
-        auto base_ptr =
-            stdx::make_unique<SHMNeuropodTensor<uint8_t>>(dims, std::move(block), data, block_id)->get_raw_data_ptr();
-        auto max_len = dims[dims.size() - 1];
+        auto byte_block = stdx::make_unique<SHMNeuropodTensor<uint8_t>>(dims, std::move(block), data, block_id);
+
+        auto base_ptr = byte_block->get_raw_data_ptr();
+        auto max_len  = dims[dims.size() - 1];
 
         // Copy into our local buffer
         auto numel = get_num_elements();

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -365,6 +365,25 @@ cc_test(
 )
 
 cc_test(
+    name = "test_ope_multiple_instances",
+    srcs = [
+        "test_ope_multiple_instances.cc",
+    ],
+    data = [
+        "//neuropod/backends/python_bridge:libneuropod_pythonbridge_backend.so",
+    ],
+    tags = [
+        "no_trace_logging",
+        "requires_path",
+    ],
+    deps = [
+        ":neuropod_test_utils",
+        "//neuropod:neuropod_impl",
+        "//neuropod/multiprocess",
+    ],
+)
+
+cc_test(
     name = "test_internal_neuropod_tensor",
     srcs = [
         "test_internal_neuropod_tensor.cc",

--- a/source/neuropod/tests/test_ope_multiple_instances.cc
+++ b/source/neuropod/tests/test_ope_multiple_instances.cc
@@ -1,0 +1,79 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "neuropod/neuropod.hh"
+#include "neuropod/tests/ope_overrides.hh"
+
+#include <thread>
+
+TEST(test_ope_multiple_instances, multithreaded)
+{
+    constexpr auto NUM_INSTANCES = 4;
+    constexpr auto NUM_REQUESTS  = 2048;
+
+    // Create models (on the main thread)
+    std::vector<neuropod::Neuropod> models;
+    for (size_t i = 0; i < NUM_INSTANCES; i++)
+    {
+        neuropod::RuntimeOptions opts;
+        opts.use_ope = true;
+        models.emplace_back(
+            "neuropod/tests/test_data/pytorch_strings_model/", detail::ope_backend_location_overrides, opts);
+    }
+
+    // Start worker threads to run inference
+    std::vector<std::thread> workers;
+    for (size_t idx = 0; idx < models.size(); idx++)
+    {
+        workers.emplace_back([idx, &models]() {
+            // Every thread uses a dedicated instance
+            auto &model = models.at(idx);
+
+            // Shape and target information to validate output
+            const std::vector<int64_t>     shape  = {3};
+            const std::vector<std::string> target = {"apple sauce", "banana pudding", "carrot cake"};
+
+            for (size_t i = 0; i < NUM_REQUESTS; ++i)
+            {
+                auto x_ten = model.allocate_tensor<std::string>(shape);
+                auto y_ten = model.allocate_tensor<std::string>(shape);
+
+                x_ten->copy_from({"apple", "banana", "carrot"});
+                y_ten->copy_from({"sauce", "pudding", "cake"});
+
+                // Run inference
+                const auto output_data = model.infer({{"x", x_ten}, {"y", y_ten}});
+
+                // Check that the output data matches expected
+                const auto out_tensor = output_data->at("out")->as_typed_tensor<std::string>();
+
+                const auto out_vector = out_tensor->get_data_as_vector();
+                const auto out_shape  = out_tensor->get_dims();
+
+                // Check that the output data matches
+                EXPECT_EQ(out_vector.size(), 3);
+                EXPECT_TRUE(out_vector == target);
+
+                // Check that the shape matches
+                EXPECT_TRUE(out_shape == shape);
+            }
+        });
+    }
+
+    // Join threads
+    std::for_each(workers.begin(), workers.end(), [](std::thread &t) { t.join(); });
+}


### PR DESCRIPTION
### Summary:

#397 describes a segfault that happens in certain cases when creating several string tensors and using OPE with multiple models across threads.

This PR implements a test that can reproduce the segfault a very high percentage of the time along with a fix for the root cause of the issue.

This line was the root cause of the issue:

https://github.com/uber/neuropod/blob/14a7e67edfe61930e123582be26075b9efcbe8f7/source/neuropod/multiprocess/shm_tensor.hh#L195-L196

We were not storing the unique_ptr created by `make_unique` so the destructor was immediately called. The reason this didn't cause visible issues in all cases has to do with how caching of shared memory blocks is implemented.

When `block` is destroyed in the code above, the underlying shared memory block is returned to an in-process cache as it's likely that the block will be loaded again. As such, the SHM block is not actually unmapped so the address returned by `get_raw_data_ptr()` still points to a valid location.

In #397, it was observed that the issue only happens when running inference in parallel across multiple threads and using the default setting of `free_memory_every_cycle = true;`. This is because such a configuration significantly increases the likelihood of clearing a shared memory cache (and unmapping the blocks in the cache) while another thread is accessing data in one of those shared memory blocks.

Fixes #397.

### Test Plan:

Added a test that consistently failed before the fix, but passes on every run after the fix.