### PR TITLE
[Build] Start enabling additional warnings

### DIFF
--- a/source/bazel/cc.bzl
+++ b/source/bazel/cc.bzl
@@ -1,0 +1,45 @@
+# Build rules that let us pass in a set of warning flags for some targets
+# without requiring us to pass them to all targets (e.g. third party libraries)
+
+_warnings = [
+    "-Weverything",
+    "-Wno-c++98-compat",
+    "-Wno-c++98-compat-pedantic",
+    "-Wno-padded",
+
+    # This is a warning that a move would not have been applied on old compilers
+    # https://reviews.llvm.org/D43322
+    "-Wno-return-std-move-in-c++11",
+
+    # We need this for polymorphism with header only implementations
+    "-Wno-weak-vtables",
+
+    # We're okay with these for now, but should refactor to remove if we can
+    "-Wno-global-constructors",
+    "-Wno-exit-time-destructors",
+]
+
+_test_warnings = _warnings + [
+    # Test specific warnings and exceptions
+]
+
+def neuropod_cc_library(name, copts = [], **kwargs):
+    native.cc_library(
+        name = name,
+        copts = _warnings + copts,
+        **kwargs
+    )
+
+def neuropod_cc_binary(name, copts = [], **kwargs):
+    native.cc_binary(
+        name = name,
+        copts = _warnings + copts,
+        **kwargs
+    )
+
+def neuropod_cc_test(name, copts = [], **kwargs):
+    native.cc_test(
+        name = name,
+        copts = _test_warnings + copts,
+        **kwargs
+    )

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("//bazel:cc.bzl", "neuropod_cc_library")
 
-cc_library(
+neuropod_cc_library(
     name = "internal",
     hdrs = glob(["*.hh"]),
     visibility = [
@@ -27,7 +28,7 @@ cc_library(
     ],
 )
 
-cc_library(
+neuropod_cc_library(
     name = "impl",
     srcs = glob(["*.cc"]),
     linkopts = ["-ldl"],
@@ -48,7 +49,7 @@ cc_library(
     alwayslink = True,
 )
 
-cc_library(
+neuropod_cc_library(
     name = "blocking_spsc_queue",
     hdrs = [
         "blocking_spsc_queue.hh",

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -203,11 +203,13 @@ BackendFactoryFunction get_backend_for_type(const std::vector<BackendLoadSpec> &
 {
     init_registrar_if_needed();
 
-    // Attempt to find a registered backend that matches
-    auto retval = find_registered_backend(type, target_version_range);
-    if (retval != nullptr)
     {
-        return retval;
+        // Attempt to find a registered backend that matches
+        auto retval = find_registered_backend(type, target_version_range);
+        if (retval != nullptr)
+        {
+            return retval;
+        }
     }
 
     // Check to see if we've already loaded a backend for `type`

--- a/source/neuropod/internal/config_utils.cc
+++ b/source/neuropod/internal/config_utils.cc
@@ -118,9 +118,8 @@ std::vector<Dimension> get_dims_from_json(const Json::Value &json_shape)
 
 } // namespace
 
-Dimension::Dimension(int64_t value) : value(value) {}
-Dimension::Dimension(std::string symbol) : value(-2), symbol(std::move(symbol)) {}
-Dimension::~Dimension() = default;
+Dimension::Dimension(int64_t v) : value(v) {}
+Dimension::Dimension(std::string s) : value(-2), symbol(std::move(s)) {}
 
 bool Dimension::operator==(const Dimension &other) const
 {
@@ -133,12 +132,10 @@ bool Dimension::operator==(const Dimension &other) const
     return false;
 }
 
-TensorSpec::TensorSpec(std::string name, std::vector<Dimension> dims, const TensorType type)
-    : name(std::move(name)), dims(std::move(dims)), type(type)
+TensorSpec::TensorSpec(std::string n, std::vector<Dimension> d, const TensorType t)
+    : name(std::move(n)), dims(std::move(d)), type(t)
 {
 }
-
-TensorSpec::~TensorSpec() = default;
 
 std::unique_ptr<ModelConfig> load_model_config(const std::string &neuropod_path)
 {
@@ -239,16 +236,16 @@ std::unique_ptr<ModelConfig> load_model_config(std::istream &input_stream)
     {
         const Json::Value &device_mapping = obj["input_tensor_device"];
         const auto         names          = device_mapping.getMemberNames();
-        for (const auto &name : names)
+        for (const auto &tensor_name : names)
         {
-            const auto type = device_mapping[name].asString();
+            const auto type = device_mapping[tensor_name].asString();
             if (type == "GPU")
             {
-                input_tensor_device[name] = DeviceType::GPU;
+                input_tensor_device[tensor_name] = DeviceType::GPU;
             }
             else if (type == "CPU")
             {
-                input_tensor_device[name] = DeviceType::CPU;
+                input_tensor_device[tensor_name] = DeviceType::CPU;
             }
             else
             {

--- a/source/neuropod/internal/config_utils.hh
+++ b/source/neuropod/internal/config_utils.hh
@@ -39,7 +39,6 @@ struct Dimension
 {
     Dimension(int64_t value);
     Dimension(std::string symbol);
-    ~Dimension();
 
     bool operator==(const Dimension &other) const;
 
@@ -56,7 +55,6 @@ struct Dimension
 struct TensorSpec
 {
     TensorSpec(std::string name, std::vector<Dimension> dims, const TensorType type);
-    ~TensorSpec();
 
     const std::string            name;
     const std::vector<Dimension> dims;

--- a/source/neuropod/internal/error_utils.hh
+++ b/source/neuropod/internal/error_utils.hh
@@ -42,6 +42,6 @@ template <typename... Params>
 // A helper macro that lets us do things like
 // NEUROPOD_ERROR("Expected value {}, but got {}", a, b);
 // This will log the error message and then throw an exception
-#define NEUROPOD_ERROR(...) neuropod::detail::throw_error(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__);
+#define NEUROPOD_ERROR(...) neuropod::detail::throw_error(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__)
 
 } // namespace neuropod

--- a/source/neuropod/internal/error_utils_header_only.hh
+++ b/source/neuropod/internal/error_utils_header_only.hh
@@ -32,7 +32,7 @@ namespace detail
 // An error macro for use in user-facing header files. This is done to avoid
 // having the release packages depend on fmt and spdlog being in the user's environment
 // See error_utils.hh for more
-#define NEUROPOD_ERROR_HH(...) neuropod::detail::throw_error_hh(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__);
+#define NEUROPOD_ERROR_HH(...) neuropod::detail::throw_error_hh(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__)
 
 } // namespace detail
 

--- a/source/neuropod/internal/neuropod_tensor.cc
+++ b/source/neuropod/internal/neuropod_tensor.cc
@@ -33,13 +33,13 @@ std::vector<int64_t> compute_strides(const std::vector<int64_t> &dims)
     std::vector<int64_t> out(dims.size());
 
     int64_t running_product = 1;
-    for (int i = out.size() - 1; i >= 0; i--)
+    for (size_t i = out.size(); i > 0; i--)
     {
         // Set the stride
-        out[i] = running_product;
+        out[i - 1] = running_product;
 
         // Update the running product
-        running_product *= dims[i];
+        running_product *= dims[i - 1];
     }
 
     return out;
@@ -48,7 +48,7 @@ std::vector<int64_t> compute_strides(const std::vector<int64_t> &dims)
 size_t compute_num_elements(const std::vector<int64_t> &dims)
 {
     // Get the number of elements in the tensor by multiplying all the dims together
-    return std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>());
+    return static_cast<size_t>(std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>()));
 }
 
 } // namespace
@@ -116,7 +116,7 @@ bool NeuropodTensor::operator==(const NeuropodTensor &other) const
         const auto numel = get_num_elements();
         const auto t1    = as_typed_tensor<std::string>();
         const auto t2    = other.as_typed_tensor<std::string>();
-        for (int i = 0; i < numel; i++)
+        for (size_t i = 0; i < numel; i++)
         {
             if ((*t1)[i] != (*t2)[i])
             {

--- a/source/neuropod/internal/neuropod_tensor.hh
+++ b/source/neuropod/internal/neuropod_tensor.hh
@@ -155,7 +155,7 @@ public:
 
     NeuropodTensor(const NeuropodTensor &) = delete;
 
-    virtual ~NeuropodTensor() {}
+    virtual ~NeuropodTensor() override {}
 
     friend std::ostream &operator<<(std::ostream &out, const NeuropodTensor &tensor)
     {
@@ -283,7 +283,7 @@ protected:
     }
 
     // TODO(vip): make this pure virtual once we have implementations for all backends
-    virtual std::shared_ptr<NeuropodValue> to_internal(NeuropodDevice device) { return this->shared_from_this(); }
+    virtual std::shared_ptr<NeuropodValue> to_internal(NeuropodDevice /*unused*/) { return this->shared_from_this(); }
 
     // Get the strides of the tensor
     const std::vector<int64_t> &get_strides() const { return strides_; }
@@ -494,7 +494,7 @@ public:
         std::vector<std::string> out(numel);
 
         // Copy the data in
-        for (int i = 0; i < numel; i++)
+        for (size_t i = 0; i < numel; i++)
         {
             out[i] = get(i);
         }
@@ -545,17 +545,17 @@ protected:
     virtual void        set(size_t index, const std::string &value) = 0;
 
     // We can't get a raw pointer from a string tensor
-    void *get_untyped_data_ptr() { NEUROPOD_ERROR_HH("`get_untyped_data_ptr` is not supported for string tensors"); };
+    void *get_untyped_data_ptr() { NEUROPOD_ERROR_HH("`get_untyped_data_ptr` is not supported for string tensors"); }
 
     const void *get_untyped_data_ptr() const
     {
         NEUROPOD_ERROR_HH("`get_untyped_data_ptr` is not supported for string tensors");
-    };
+    }
 
     size_t get_bytes_per_element() const
     {
         NEUROPOD_ERROR_HH("`get_bytes_per_element` is not supported for string tensors");
-    };
+    }
 };
 
 // Utility to make a tensor of a specific type
@@ -571,8 +571,6 @@ std::unique_ptr<NeuropodTensor> make_tensor(TensorType tensor_type, Params &&...
     switch (tensor_type)
     {
         FOR_EACH_TYPE_MAPPING_INCLUDING_STRING(MAKE_TENSOR)
-    default:
-        NEUROPOD_ERROR_HH("Unsupported tensor type: {}", tensor_type);
     }
 }
 
@@ -583,8 +581,8 @@ std::unique_ptr<NeuropodTensor> make_tensor_no_string(TensorType tensor_type, Pa
     switch (tensor_type)
     {
         FOR_EACH_TYPE_MAPPING_EXCEPT_STRING(MAKE_TENSOR)
-    default:
-        NEUROPOD_ERROR_HH("Unsupported tensor type: {}", tensor_type);
+    case STRING_TENSOR:
+        NEUROPOD_ERROR_HH("`make_tensor_no_string` does not support type STRING_TENSOR");
     }
 }
 

--- a/source/neuropod/internal/neuropod_tensor_serialization.cc
+++ b/source/neuropod/internal/neuropod_tensor_serialization.cc
@@ -71,8 +71,8 @@ std::shared_ptr<NeuropodTensor> deserialize_tensor(boost::archive::binary_iarchi
     return out;
 }
 
-} // namespace
-
 MAKE_SERIALIZABLE(NeuropodTensor, serialize_tensor, deserialize_tensor);
+
+} // namespace
 
 } // namespace neuropod

--- a/source/neuropod/internal/tensor_types.cc
+++ b/source/neuropod/internal/tensor_types.cc
@@ -25,7 +25,7 @@ std::ostream &operator<<(std::ostream &out, const TensorType value)
 #define GENERATE_CASE(item) \
     case (item):            \
         s = #item;          \
-        break;
+        break
     switch (value)
     {
         GENERATE_CASE(FLOAT_TENSOR);


### PR DESCRIPTION
### Summary:
This PR introduces a `neuropod_cc_library` rule that builds targets with `-Weverything` (+ some exceptions).

All uses of `cc_library` within `source/internal` are modified to use `neuropod_cc_library` in this PR.

Once this PR lands, we can incrementally refactor the codebase to transition all first-party `cc_*` targets to use `neuropod_cc_*` rules. At that point we can build with `-Werror` in CI to ensure that newly introduced code doesn't add warnings to the build.

### Test Plan:

Local testing + CI