### PR TITLE
Add a `view` and `flat` method to TypedNeuropodTensor

### DIFF
--- a/source/neuropod/tests/test_accessor.cc
+++ b/source/neuropod/tests/test_accessor.cc
@@ -166,4 +166,64 @@ TEST(test_accessor, test_string_write)
         auto actual = tensor->get_data_as_vector();
         EXPECT_EQ(expected, actual);
     }
+
+    // Get a flat view
+    {
+        auto actual = tensor->flat();
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), actual.begin()));
+    }
+}
+
+TEST(test_accessor, view_read)
+{
+    auto allocator = neuropod::get_generic_tensor_allocator();
+
+    auto tensor = allocator->arange<int32_t>(15);
+
+    auto view = tensor->view(3, 5);
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                EXPECT_EQ(view[i][j], i * 5 + j);
+            }
+        }
+    }
+}
+
+TEST(test_accessor, view_write)
+{
+    auto allocator = neuropod::get_generic_tensor_allocator();
+
+    auto tensor = allocator->arange<int32_t>(15);
+
+    auto view = tensor->view(3, 5);
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                view[i][j] = i * 5 + j;
+            }
+        }
+    }
+
+    std::vector<int32_t> expected(15);
+    std::iota(expected.begin(), expected.end(), 0);
+
+    EXPECT_EQ(expected, tensor->get_data_as_vector());
+}
+
+TEST(test_accessor, view_dims)
+{
+    auto allocator = neuropod::get_generic_tensor_allocator();
+
+    auto tensor1 = allocator->allocate_tensor<float>({3, 5});
+
+    // All dims passed to view must be positive
+    EXPECT_THROW(tensor1->view(-1, -2), std::runtime_error);
+
+    // Total number of elements must match
+    EXPECT_THROW(tensor1->view(4, 2), std::runtime_error);
 }


### PR DESCRIPTION
### Summary:

This PR adds a `view` method to `TypedNeuropodTensor<T>` that allows users to view and access a tensor as if it had a different set of dimensions.

Somewhat similar to https://pytorch.org/docs/stable/tensors.html#torch.Tensor.view except we currently don't support `-1` dimensions. Our implementation is also simpler because all `NeuropodTensor`s are currently contiguous.

The `view` method returns a `TensorView` which is a thin wrapper around `TensorAccessor` to store strides and dimensions.

Changes made in the returned view modify the original tensor data.

`flat` is a simple method that returns a 1D view of the tensor (effectively `return view(get_num_elements())`). See https://www.tensorflow.org/api_docs/cc/class/tensorflow/tensor#flat for more details.

### Test Plan:

CI + added tests
