### PR TITLE
Added logs for situations where the backend could not be loaded

### DIFF
--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -159,7 +159,7 @@ BackendFactoryFunction find_registered_backend(const std::string &type, const st
         SPDLOG_TRACE("Unable to find backend for type '{}' in backend registry which contains '{}' elements address {:p}",
                      type,
                      registered_backends_by_type->size(),
-                     const_cast<string*>(registered_backends_by_type.get()));
+                     static_cast<void*>(registered_backends_by_type.get()));
     }
 
     return nullptr;
@@ -213,7 +213,7 @@ bool register_backend(const std::string &    name,
                  type,
                  version,
                  registered_backends_by_type->size(),
-                 const_cast<string*>(registered_backends_by_type.get()));
+                 static_cast<void*>(registered_backends_by_type.get()));
 
     return true;
 }

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -146,6 +146,20 @@ BackendFactoryFunction find_registered_backend(const std::string &type, const st
         {
             return it->second.factory;
         }
+        else
+        {
+            SPDLOG_TRACE("Version '{}' for backend '{}' does not satisfy the requested version range '{}'",
+                         it->second.version,
+                         type,
+                         target_version_range);
+        }
+    }
+    else
+    {
+        SPDLOG_TRACE("Unable to find backend for type '{}' in backend registry which contains '{}' elements address {:p}",
+                     type,
+                     registered_backends_by_type->size(),
+                     (void*)registered_backends_by_type.get());
     }
 
     return nullptr;
@@ -193,6 +207,13 @@ bool register_backend(const std::string &    name,
     }
 
     registered_backends_by_type->insert(std::make_pair(type, info));
+
+    SPDLOG_DEBUG("Finished registering backend {} with type {} and version {} registered backend size {} at address {:p}",
+                 name,
+                 type,
+                 version,
+                 registered_backends_by_type->size(),
+                 (void*)registered_backends_by_type.get());
 
     return true;
 }

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -159,7 +159,7 @@ BackendFactoryFunction find_registered_backend(const std::string &type, const st
         SPDLOG_TRACE("Unable to find backend for type '{}' in backend registry which contains '{}' elements address {:p}",
                      type,
                      registered_backends_by_type->size(),
-                     (void*)registered_backends_by_type.get());
+                     const_cast<string*>(registered_backends_by_type.get()));
     }
 
     return nullptr;
@@ -213,7 +213,7 @@ bool register_backend(const std::string &    name,
                  type,
                  version,
                  registered_backends_by_type->size(),
-                 (void*)registered_backends_by_type.get());
+                 const_cast<string*>(registered_backends_by_type.get()));
 
     return true;
 }

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -156,10 +156,9 @@ BackendFactoryFunction find_registered_backend(const std::string &type, const st
     }
     else
     {
-        SPDLOG_TRACE("Unable to find backend for type '{}' in backend registry which contains '{}' elements address {:p}",
+        SPDLOG_TRACE("Unable to find backend for type '{}' in backend registry which contains '{}' elements.",
                      type,
-                     registered_backends_by_type->size(),
-                     static_cast<void*>(registered_backends_by_type.get()));
+                     registered_backends_by_type->size());
     }
 
     return nullptr;
@@ -200,20 +199,12 @@ bool register_backend(const std::string &    name,
     // Using OPE overcomes this problem
     if (registered_backends_by_type->find(type) != registered_backends_by_type->end())
     {
-        NEUROPOD_ERROR(
-            "Attempted to register a backend for type '{}', but one was already loaded. If you are trying "
-            "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
-            type);
+        NEUROPOD_ERROR("Attempted to register a backend for type '{}', but one was already loaded. If you are trying "
+                       "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
+                       type);
     }
 
     registered_backends_by_type->insert(std::make_pair(type, info));
-
-    SPDLOG_DEBUG("Finished registering backend {} with type {} and version {} registered backend size {} at address {:p}",
-                 name,
-                 type,
-                 version,
-                 registered_backends_by_type->size(),
-                 static_cast<void*>(registered_backends_by_type.get()));
 
     return true;
 }

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -199,9 +199,10 @@ bool register_backend(const std::string &    name,
     // Using OPE overcomes this problem
     if (registered_backends_by_type->find(type) != registered_backends_by_type->end())
     {
-        NEUROPOD_ERROR("Attempted to register a backend for type '{}', but one was already loaded. If you are trying "
-                       "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
-                       type);
+        NEUROPOD_ERROR(
+            "Attempted to register a backend for type '{}', but one was already loaded. If you are trying "
+            "to use multiple versions of the same framework, you must use OPE. See the docs at https://neuropod.ai",
+            type);
     }
 
     registered_backends_by_type->insert(std::make_pair(type, info));


### PR DESCRIPTION
### Summary:
It's not clear when the find_registered_backend method returns a null pointer, the specific reason for doing so. This change attempts to make it clear by documenting the reason why the backend isn't found.

### Test Plan:
Create a neuropod locally with required backend where we know the backend cannot be loaded. See log getting printed.
