### PR TITLE
[Python Bindings] Use a consistent string type regardless of Python version

### DIFF
--- a/source/neuropod/tests/test_data/pytorch_strings_model/0/code/strings_model.py
+++ b/source/neuropod/tests/test_data/pytorch_strings_model/0/code/strings_model.py
@@ -5,7 +5,19 @@ import torch.nn as nn
 
 class StringsModel(nn.Module):
     def forward(self, x, y):
-        return {"out": np.array([f + " " + s for f, s in zip(x, y)])}
+        # Python 3 uses unicode for strings. Neuropod doesn't automatically convert
+        # string tensors to unicode because it's possible that these tensors contain
+        # aribtrary byte sequences instead of valid unicode.
+
+        # Since we know x and y contain valid strings, we can convert to np.str_ here.
+        # This decodes the data as unicode in python3 and doesn't have an effect in
+        # python2.
+        x = x.astype(np.str_)
+        y = y.astype(np.str_)
+
+        return {
+            "out": np.array([f + " " + s for f, s in zip(x, y)])
+        }
 
 
 def get_model(_):

--- a/source/python/neuropod/backends/neuropod_executor.py
+++ b/source/python/neuropod/backends/neuropod_executor.py
@@ -175,7 +175,7 @@ class NeuropodExecutor(object):
         # Convert unicode to string
         for k, v in inputs.items():
             if v.dtype.type == np.unicode_:
-                inputs[k] = v.astype("str")
+                inputs[k] = v.astype(np.string_)
 
         # Validate inputs
         validate_tensors_against_specs(inputs, self.neuropod_config["input_spec"])
@@ -189,7 +189,7 @@ class NeuropodExecutor(object):
         # Convert unicode to string
         for k, v in out.items():
             if v.dtype.type == np.unicode_:
-                out[k] = v.astype("str")
+                out[k] = v.astype(np.string_)
 
         # Validate outputs
         validate_tensors_against_specs(out, self.neuropod_config["output_spec"])

--- a/source/python/neuropod/backends/tensorflow/executor.py
+++ b/source/python/neuropod/backends/tensorflow/executor.py
@@ -138,7 +138,7 @@ class TensorflowNeuropodExecutor(NeuropodExecutor):
             name = spec["name"]
             dtype = get_dtype(spec["dtype"])
             if (
-                dtype.type == np.str_
+                dtype.type == np.string_
                 and outputs[name].dtype == "object"
                 and type(outputs[name].item(0)) == six.binary_type
             ):

--- a/source/python/neuropod/backends/torchscript/executor.py
+++ b/source/python/neuropod/backends/torchscript/executor.py
@@ -133,7 +133,7 @@ class TorchScriptNeuropodExecutor(NeuropodExecutor):
             # Get the target device for this tensor
             target_device = self._get_torch_device(self.input_device_mapping[k])
 
-            if v.dtype.type == np.str_:
+            if v.dtype.type == np.string_:
                 converted_inputs[k] = v.tolist()
 
                 # We don't handle devices for string "tensors" because lists cannot
@@ -210,7 +210,7 @@ class TorchScriptNeuropodExecutor(NeuropodExecutor):
         elif isinstance(value, list) and (
             dtype == "string" or isinstance(value[0], string_types)
         ):
-            neuropod_out[key] = np.array(value, dtype=np.str_)
+            neuropod_out[key] = np.array(value, dtype=np.string_)
         else:
             raise RuntimeError(
                 "All outputs must be torch tensors or list of strings! Output `{}` was of type `{}`".format(

--- a/source/python/neuropod/tests/test_pytorch_strings.py
+++ b/source/python/neuropod/tests/test_pytorch_strings.py
@@ -26,6 +26,16 @@ import torch.nn as nn
 
 class StringsModel(nn.Module):
     def forward(self, x, y):
+        # Python 3 uses unicode for strings. Neuropod doesn't automatically convert
+        # string tensors to unicode because it's possible that these tensors contain
+        # aribtrary byte sequences instead of valid unicode.
+
+        # Since we know x and y contain valid strings, we can convert to np.str_ here.
+        # This decodes the data as unicode in python3 and doesn't have an effect in
+        # python2.
+        x = x.astype(np.str_)
+        y = y.astype(np.str_)
+
         return {
             "out": np.array([f + " " + s for f, s in zip(x, y)])
         }

--- a/source/python/neuropod/tests/test_serialization.py
+++ b/source/python/neuropod/tests/test_serialization.py
@@ -48,12 +48,6 @@ class TestSerialization(unittest.TestCase):
                 expected = np.random.random(size=shape).astype(dtype=dtype)
                 buffer = neuropod_native.serialize(expected)
                 actual = neuropod_native.deserialize(buffer)
-
-                # Unicode vs ascii for python 3
-                # TODO(vip): Add unicode support to the native bindings and fix this
-                if actual.dtype.type == np.unicode_:
-                    actual = actual.astype(np.string_)
-
                 np.testing.assert_array_equal(expected, actual)
 
                 # Add it to our dict to test NeuropodValueMap serialization
@@ -70,12 +64,6 @@ class TestSerialization(unittest.TestCase):
         # Compare elements
         for key, expected in expected_valuemap.items():
             actual = actual_valuemap[key]
-
-            # Unicode vs ascii for python 3
-            # TODO(vip): Add unicode support to the native bindings and fix this
-            if actual.dtype.type == np.unicode_:
-                actual = actual.astype(np.string_)
-
             np.testing.assert_array_equal(expected, actual)
 
     def test_invalid_stream_deserialization(self):

--- a/source/python/neuropod/tests/test_tensor_validation.py
+++ b/source/python/neuropod/tests/test_tensor_validation.py
@@ -141,7 +141,7 @@ class TestSpecValidation(unittest.TestCase):
 
     def test_string_tensors(self):
         test_input = {
-            "x": np.array([["some", "string", "tensor"]], dtype=np.str_),
+            "x": np.array([["some", "string", "tensor"]], dtype=np.string_),
         }
 
         SPEC = [

--- a/source/python/neuropod/utils/dtype_utils.py
+++ b/source/python/neuropod/utils/dtype_utils.py
@@ -21,14 +21,14 @@ def get_dtype(arg):
     Get numpy dtypes from strings in a python 2 and 3 compatible way
     """
     if arg == "string":
-        arg = "str"
+        arg = "S"
 
     return np.dtype(arg)
 
 
 def get_dtype_name(arg):
     name = get_dtype(arg).name
-    if name == "str":
+    if name == "bytes":
         return "string"
 
     return name

--- a/source/python/neuropod/utils/eval_utils.py
+++ b/source/python/neuropod/utils/eval_utils.py
@@ -29,9 +29,9 @@ logger = logging.getLogger(__name__)
 
 def check_output_matches_expected(out, expected_out):
     for key, value in expected_out.items():
-        if value.dtype.type == np.str_:
+        if value.dtype.type == np.string_ or value.dtype.type == np.str_:
             # All strings are equal
-            success_condition = (value == out[key]).all()
+            success_condition = (value.astype(np.string_) == out[key]).all()
         else:
             # All the values are close
             success_condition = np.allclose(value, out[key])


### PR DESCRIPTION
### Summary:
The previous logic for string tensors in the python bindings would return unicode arrays for Python 3 and string arrays for Python 2. This involved an implicit decode step which we don't want (in case the string data isn't a valid UTF8 string).

We always want to return arrays of dtype `np.string_` regardless of version.

The previous implementation used `py::array` and `py::cast` to do the conversion in one line, but this doesn't let us explicitly specify the type of the resulting array. The new implementation explicitly creates a string array and copies the tensor data in. This should have the same efficiency as the previous implementation, but just makes the copies explicit.

**Note: this is a breaking change for python3 models that take string tensors as inputs. The data type of the inputs will change from `np.unicode_` to `np.bytes_`**

### Test Plan:

CI + modified tests