### PR TITLE
[TF] Add runtime support for TF 2.3.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -190,23 +190,23 @@ steps:
     retry:
       automatic: true
 
-  - label: ":docker: CPU Tests (test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8)"
+  - label: ":docker: CPU Tests (test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8)"
     timeout_in_minutes: 60
     agents:
       queue: private-default
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.1.0:
-          build: test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          build: test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
           image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          cache-from: test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           push-retries: 5
       - docker-compose#v3.1.0:
-          push: test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          push: test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
       - docker-compose#v3.1.0:
-          run: test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          run: test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY
@@ -375,23 +375,23 @@ steps:
     retry:
       automatic: true
 
-  - label: ":docker: GPU Tests (test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8)"
+  - label: ":docker: GPU Tests (test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8)"
     timeout_in_minutes: 60
     agents:
       queue: private-gpu
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.1.0:
-          build: test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          build: test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
           image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          cache-from: test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           push-retries: 5
       - docker-compose#v3.1.0:
-          push: test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          push: test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
       - docker-compose#v3.1.0:
-          run: test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8
+          run: test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,24 @@ matrix:
     # A single linux build to make sure that the build scripts work correctly outside of docker
     - os: linux
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.12.0 NEUROPOD_TORCH_VERSION=1.1.0 NEUROPOD_PYTHON_VERSION=2.7
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.13.1 NEUROPOD_TORCH_VERSION=1.2.0 NEUROPOD_PYTHON_VERSION=3.5
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.14.0 NEUROPOD_TORCH_VERSION=1.3.0 NEUROPOD_PYTHON_VERSION=3.6
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.15.0 NEUROPOD_TORCH_VERSION=1.4.0 NEUROPOD_PYTHON_VERSION=3.7
 
     - os: osx
-      env: NEUROPOD_TENSORFLOW_VERSION=2.2.0 NEUROPOD_TORCH_VERSION=1.5.0 NEUROPOD_PYTHON_VERSION=3.8
+      osx_image: xcode12
+      env: NEUROPOD_TENSORFLOW_VERSION=2.3.0 NEUROPOD_TORCH_VERSION=1.5.0 NEUROPOD_PYTHON_VERSION=3.8
 
 
 

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -97,7 +97,7 @@ FRAMEWORK_VERSIONS = [
     {"cuda": "10.0", "tensorflow": "1.13.1", "torch": "1.2.0", "python": "3.5"},
     {"cuda": "10.0", "tensorflow": "1.14.0", "torch": "1.3.0", "python": "3.6"},
     {"cuda": "10.0", "tensorflow": "1.15.0", "torch": "1.4.0", "python": "3.7"},
-    {"cuda": "10.1", "tensorflow": "2.2.0", "torch": "1.5.0", "python": "3.8"},
+    {"cuda": "10.1", "tensorflow": "2.3.0", "torch": "1.5.0", "python": "3.8"},
 ]
 
 travis_matrix = []
@@ -115,6 +115,7 @@ for platform, framework_version in itertools.product(PLATFORMS, FRAMEWORK_VERSIO
         # This is a Travis CI build
         travis_matrix.extend([
         "    - os: osx\n",
+        "      osx_image: xcode12\n",
         "      env: NEUROPOD_TENSORFLOW_VERSION={} NEUROPOD_TORCH_VERSION={} NEUROPOD_PYTHON_VERSION={}\n".format(tf_version, torch_version, py_version),
         "\n",
         ])

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -52,11 +52,11 @@ services:
         NEUROPOD_TORCH_VERSION: 1.4.0
         NEUROPOD_PYTHON_VERSION: 3.7
 
-  test-cpu-variant-tf-2_2_0-torch-1_5_0-py3_8:
+  test-cpu-variant-tf-2_3_0-torch-1_5_0-py3_8:
     extends: test-base
     build:
       args:
-        NEUROPOD_TENSORFLOW_VERSION: 2.2.0
+        NEUROPOD_TENSORFLOW_VERSION: 2.3.0
         NEUROPOD_TORCH_VERSION: 1.5.0
         NEUROPOD_PYTHON_VERSION: 3.8
 
@@ -96,12 +96,12 @@ services:
         NEUROPOD_TORCH_VERSION: 1.4.0
         NEUROPOD_PYTHON_VERSION: 3.7
 
-  test-gpu-variant-tf-2_2_0-torch-1_5_0-py3_8:
+  test-gpu-variant-tf-2_3_0-torch-1_5_0-py3_8:
     extends: test-gpu
     build:
       args:
         NEUROPOD_CUDA_VERSION: 10.1
-        NEUROPOD_TENSORFLOW_VERSION: 2.2.0
+        NEUROPOD_TENSORFLOW_VERSION: 2.3.0
         NEUROPOD_TORCH_VERSION: 1.5.0
         NEUROPOD_PYTHON_VERSION: 3.8
 

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -26,11 +26,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.15.0.tar.gz",
             "sha256": "decbfd5a709eced3523f55ccfa239337a87e1ab3e000efda3617db79e1034ded",
         },
-        # There isn't an official libtensorflow release for TF 2.x so I had to build this from source
-        # TODO(vip): Update to an official release once there is one
-        "2.2.0-linux-cpu": {
-            "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-cpu-linux-x86_64.tar.gz",
-            "sha256": "ee287e2ccd41e652f51e8c36370c841caf02115bf7b0cb7d4c2119b2c8cbd5fb",
+        "2.3.0-linux-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.3.0.tar.gz",
+            "sha256": "",
         },
 
         # Linux GPU
@@ -50,11 +48,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.15.0.tar.gz",
             "sha256": "98e20336ff2b9acf2121b5c1ea00c35561ae732303bba8cfec167db3f7aea681",
         },
-        # There isn't an official libtensorflow release for TF 2.x so I had to build this from source
-        # TODO(vip): Update to an official release once there is one
-        "2.2.0-linux-gpu": {
-            "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-gpu-linux-x86_64.tar.gz",
-            "sha256": "293f907623d7c9622d0ae9b17a2b5938c633eb8e32e9461346fe6afc36fe2e71",
+        "2.3.0-linux-gpu": {
+            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.3.0.tar.gz",
+            "sha256": "",
         },
 
         # Mac CPU
@@ -74,10 +70,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.15.0.tar.gz",
             "sha256": "1a9da42e31f613f1582cf996e3ead32528964994eb98b7c355923f2dc39bfce0",
         },
-        # TODO(vip): Replace this with a TF 2.2.0 URL once there's an official release
-        "2.2.0-mac-cpu": {
-            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.15.0.tar.gz",
-            "sha256": "1a9da42e31f613f1582cf996e3ead32528964994eb98b7c355923f2dc39bfce0",
+        "2.3.0-mac-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-2.3.0.tar.gz",
+            "sha256": "5db002213fe80f4144a1541cb0507222b057bb79f807cc51e02237e423bda174",
         },
     }
 

--- a/source/bazel/tensorflow_hdrs.bzl
+++ b/source/bazel/tensorflow_hdrs.bzl
@@ -24,9 +24,9 @@ def _impl(repository_ctx):
             "url": "https://files.pythonhosted.org/packages/ec/98/f968caf5f65759e78873b900cbf0ae20b1699fb11268ecc0f892186419a7/tensorflow-1.15.0-cp27-cp27mu-manylinux2010_x86_64.whl",
             "sha256": "af57e0e16adb4d6ccd387954c1d70e34cc4925b74da9135d2b83ca7d3dd9d102",
         },
-        "2.2.0-linux-cpu": {
-            "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
-            "sha256": "8d1b7c1d45e7f582d8703c0d0a034a60d4bac942b11205bed91fa55981124d60",
+        "2.3.0-linux-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.3.0-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "",
         },
 
         # Linux GPU
@@ -46,9 +46,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.15.0-cp27-cp27mu-manylinux2010_x86_64.whl",
             "sha256": "829c90021ec0fa33d74c2bcbff4e1e365fc63e875d2f04b60451c5abfeac8382",
         },
-        "2.2.0-linux-gpu": {
-            "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
-            "sha256": "845f261b0b922740bdd7f21fa3a4bed8ffd9e1712decd552fb33621da4d8ec45",
+        "2.3.0-linux-gpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.3.0-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "",
         },
 
         # Mac CPU
@@ -68,11 +68,9 @@ def _impl(repository_ctx):
             "url": "https://files.pythonhosted.org/packages/b9/be/140e6c4deef96ddfe3837ef7ffc396a06cca73c958989835ac8f05773678/tensorflow-1.15.0-cp27-cp27m-macosx_10_11_x86_64.whl",
             "sha256": "0a01def34c28298970dc83776dd43877fd59e43fddd8e960d01b6eb849ba9938",
         },
-
-        # TODO(vip): replace this with TF2.2 once we use the correct libtensorflow binary for 2.2 on mac
-        "2.2.0-mac-cpu": {
-            "url": "https://files.pythonhosted.org/packages/b9/be/140e6c4deef96ddfe3837ef7ffc396a06cca73c958989835ac8f05773678/tensorflow-1.15.0-cp27-cp27m-macosx_10_11_x86_64.whl",
-            "sha256": "0a01def34c28298970dc83776dd43877fd59e43fddd8e960d01b6eb849ba9938",
+        "2.3.0-mac-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.3.0-cp38-cp38-macosx_10_14_x86_64.whl",
+            "sha256": "44c8d979b2d19ed56dbe6b03aef87616d6138a58fd80c43e7a758c90105e9adf",
         },
     }
 
@@ -86,10 +84,6 @@ def _impl(repository_ctx):
     sha256 = download_mapping["sha256"]
 
     repository_ctx.download_and_extract(download_url, type = "zip", sha256 = sha256)
-
-    # TODO(vip): Remove once 2.2 on mac works
-    if version == "2.2.0":
-        version = "1.15.0"
 
     repository_ctx.template(
         "BUILD.bazel",

--- a/source/deps/BUILD.tensorflow
+++ b/source/deps/BUILD.tensorflow
@@ -19,7 +19,7 @@ package(
 cc_library(
     name = "libtensorflow",
     srcs = select({
-        "@bazel_tools//src/conditions:darwin": glob(["lib/libtensorflow.so", "lib/libtensorflow.1.dylib"]),
+        "@bazel_tools//src/conditions:darwin": glob(["lib/libtensorflow.so", "lib/libtensorflow.1.dylib", "lib/libtensorflow.2.dylib"]),
         "//conditions:default": glob([
             "lib/libtensorflow.so",
             "lib/libtensorflow_framework.so",

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -69,7 +69,7 @@ std::vector<BackendLoadSpec> get_default_backend_map()
     // Information about frameworks that we use to generate a list of `BackendLoadSpec`
     const std::vector<FrameworkInfo> frameworks = {
         {"torchscript", "libneuropod_torchscript_backend.so", true, {"1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"}},
-        {"tensorflow", "libneuropod_tensorflow_backend.so", true, {"1.12.0", "1.13.1", "1.14.0", "1.15.0"}},
+        {"tensorflow", "libneuropod_tensorflow_backend.so", true, {"1.12.0", "1.13.1", "1.14.0", "1.15.0", "2.3.0"}},
         {"python", "libneuropod_pythonbridge_backend.so", false, {"2.7", "3.5", "3.6", "3.7", "3.8"}}};
 
     // Base directory for Neuropod backends


### PR DESCRIPTION
### Summary:

This PR replaces our partial integration with TensorFlow 2.2.0 with a more broad integration of TF 2.3.0.

Since there are now official builds of libtensorflow for TF 2.x, we can use those directly instead of versions I manually built for TF 2.2.0.

_Note: There is still work to be done on the packaging side with TensorFlow 2.x; this PR just allows us to run models with the TF 2.3.0 runtime_

### Test Plan:

CI