### PR TITLE
[TF] Add runtime support for TF 2.2.0 on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,23 @@ matrix:
     # A single linux build to make sure that the build scripts work correctly outside of docker
     - os: linux
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.12.0 NEUROPOD_TORCH_VERSION=1.1.0 NEUROPOD_PYTHON_VERSION=2.7
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.13.1 NEUROPOD_TORCH_VERSION=1.2.0 NEUROPOD_PYTHON_VERSION=3.5
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.14.0 NEUROPOD_TORCH_VERSION=1.3.0 NEUROPOD_PYTHON_VERSION=3.6
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=1.15.0 NEUROPOD_TORCH_VERSION=1.4.0 NEUROPOD_PYTHON_VERSION=3.7
 
     - os: osx
+      osx_image: xcode12
       env: NEUROPOD_TENSORFLOW_VERSION=2.2.0 NEUROPOD_TORCH_VERSION=1.5.0 NEUROPOD_PYTHON_VERSION=3.8
 
 

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -115,6 +115,7 @@ for platform, framework_version in itertools.product(PLATFORMS, FRAMEWORK_VERSIO
         # This is a Travis CI build
         travis_matrix.extend([
         "    - os: osx\n",
+        "      osx_image: xcode12\n",
         "      env: NEUROPOD_TENSORFLOW_VERSION={} NEUROPOD_TORCH_VERSION={} NEUROPOD_PYTHON_VERSION={}\n".format(tf_version, torch_version, py_version),
         "\n",
         ])

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -74,10 +74,11 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.15.0.tar.gz",
             "sha256": "1a9da42e31f613f1582cf996e3ead32528964994eb98b7c355923f2dc39bfce0",
         },
-        # TODO(vip): Replace this with a TF 2.2.0 URL once there's an official release
+        # There isn't an official libtensorflow release for TF 2.x so I had to build this from source
+        # TODO(vip): Update to an official release once there is one
         "2.2.0-mac-cpu": {
-            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.15.0.tar.gz",
-            "sha256": "1a9da42e31f613f1582cf996e3ead32528964994eb98b7c355923f2dc39bfce0",
+            "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-cpu-darwin-x86_64.tar.gz",
+            "sha256": "78e788a9ada69c8b6edd4061b21ee2a87dbcc41e0c55893c5b063140c28f969d",
         },
     }
 

--- a/source/bazel/tensorflow_hdrs.bzl
+++ b/source/bazel/tensorflow_hdrs.bzl
@@ -68,11 +68,9 @@ def _impl(repository_ctx):
             "url": "https://files.pythonhosted.org/packages/b9/be/140e6c4deef96ddfe3837ef7ffc396a06cca73c958989835ac8f05773678/tensorflow-1.15.0-cp27-cp27m-macosx_10_11_x86_64.whl",
             "sha256": "0a01def34c28298970dc83776dd43877fd59e43fddd8e960d01b6eb849ba9938",
         },
-
-        # TODO(vip): replace this with TF2.2 once we use the correct libtensorflow binary for 2.2 on mac
         "2.2.0-mac-cpu": {
-            "url": "https://files.pythonhosted.org/packages/b9/be/140e6c4deef96ddfe3837ef7ffc396a06cca73c958989835ac8f05773678/tensorflow-1.15.0-cp27-cp27m-macosx_10_11_x86_64.whl",
-            "sha256": "0a01def34c28298970dc83776dd43877fd59e43fddd8e960d01b6eb849ba9938",
+            "url": "https://files.pythonhosted.org/packages/1c/fd/dea30c9b6db9305309477b8b6fc0330edbed9b36bc81c3d6094458de8b94/tensorflow-2.2.0rc3-cp35-cp35m-macosx_10_11_x86_64.whl",
+            "sha256": "bc0030f7ee9b47893cb1ed312a1e91715a911d76d24b121a7934a0d6769b1297",
         },
     }
 
@@ -86,10 +84,6 @@ def _impl(repository_ctx):
     sha256 = download_mapping["sha256"]
 
     repository_ctx.download_and_extract(download_url, type = "zip", sha256 = sha256)
-
-    # TODO(vip): Remove once 2.2 on mac works
-    if version == "2.2.0":
-        version = "1.15.0"
 
     repository_ctx.template(
         "BUILD.bazel",

--- a/source/deps/BUILD.tensorflow
+++ b/source/deps/BUILD.tensorflow
@@ -19,7 +19,7 @@ package(
 cc_library(
     name = "libtensorflow",
     srcs = select({
-        "@bazel_tools//src/conditions:darwin": glob(["lib/libtensorflow.so", "lib/libtensorflow.1.dylib"]),
+        "@bazel_tools//src/conditions:darwin": glob(["lib/libtensorflow.so", "lib/libtensorflow.1.dylib", "lib/libtensorflow.2.dylib"]),
         "//conditions:default": glob([
             "lib/libtensorflow.so",
             "lib/libtensorflow_framework.so",


### PR DESCRIPTION
### Summary:
This PR enables us to run models with TF 2.2.0 on Mac (we already had TF 2.2.0 runtime support on Linux).

_Note: There are no official builds of libtensorflow for TF 2.2.0 so we're using binaries I built from source. These will be replaced with official builds from TF 2.3.0 or TF 2.4.0 once they're available. See #455 for more details._ 

### Test Plan:

CI