### PR TITLE
[Docs] Setup automated docs deployment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -76,6 +77,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -113,6 +115,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -150,6 +153,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -187,6 +191,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -224,6 +229,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -261,6 +267,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -298,6 +305,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -335,6 +343,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -372,6 +381,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -409,6 +419,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -446,6 +457,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -483,6 +495,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -520,6 +533,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 
@@ -557,6 +571,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - WEB_DEPLOY_KEY
     retry:
       automatic: true
 

--- a/build/ci/docs.sh
+++ b/build/ci/docs.sh
@@ -8,4 +8,61 @@ source .neuropod_venv/bin/activate
 python ./build/ci/set_status.py --context "docs/build" --description "Build the docs" \
     ./build/docs.sh
 
-# TODO(vip): After open-sourcing, deploy the docs here
+# Deploy docs if we're running on the master branch
+if [[ "$BUILDKITE_BRANCH" == "master" ]]; then
+
+# Get the repo root
+REPO_ROOT=`pwd`
+
+# Get the path of the docs
+pushd build/docs/_static
+DOCS_DIR=`pwd`
+popd
+
+# Switch to a tempdir
+tmpdir=$(mktemp -d)
+pushd $tmpdir
+
+# Setup keys used for deployment (only works on the master branch)
+eval "$(ssh-agent -s)"
+ssh-add - <<< "$WEB_DEPLOY_KEY"
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Checkout the docs
+git clone --branch docs --single-branch git@github.com:uber/neuropod.git
+cd neuropod
+
+# Make sure we're not deploying an older version of the docs
+LAST_REVISION="$(cat master_revision)"
+pushd "$REPO_ROOT"
+
+# Returns nonzero exit code if it's not an ancestor and the `set -e` at the top
+# will cause this to abort
+git merge-base --is-ancestor "$LAST_REVISION" "$BUILDKITE_COMMIT"
+popd
+
+# Write the current revision
+echo "$BUILDKITE_COMMIT" > master_revision
+
+# Remove the old docs
+pushd site/docs
+rm -rf master
+
+# Copy in the new ones
+mv "$DOCS_DIR" master
+popd
+
+# Add everything
+git add .
+git config --global user.email "vip+neuropodbot@uber.com"
+git config --global user.name "NeuropodBot"
+git commit -m "Build docs from uber/neuropod@$BUILDKITE_COMMIT"
+
+git push origin docs
+
+popd
+
+# Remove tempdir
+rm -rf "$tmpdir"
+
+fi

--- a/build/ci/install_lint_deps.sh
+++ b/build/ci/install_lint_deps.sh
@@ -8,6 +8,7 @@ add-apt-repository -y ppa:ubuntu-toolchain-r/test
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
 apt-get install -y --no-install-recommends libstdc++6 python3.6 python3.6-dev tzdata jq
+apt-get install -y git
 
 # Install infer
 VERSION=0.17.0; \

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -168,6 +168,7 @@ for platform, framework_version in itertools.product(PLATFORMS, FRAMEWORK_VERSIO
         "            - CODECOV_TOKEN\n",
         "            - GH_STATUS_TOKEN\n",
         "            - GH_UPLOAD_TOKEN\n",
+        "            - WEB_DEPLOY_KEY\n",
         "    retry:\n",
         "      automatic: true\n",
         "\n",


### PR DESCRIPTION
### Summary:
Deploy docs every time a PR is merged to the `master` branch. Since docs are versioned (as of #460), this doesn't affect the latest stable docs.

After this PR lands, docs for `master` should be visible at https://neuropod.ai/docs/master/

### Test Plan:
Since the added functionality only works on the master branch (for security reasons), passing CI doesn't test this.

I manually ran these steps locally to ensure that docs are correctly deployed 
