### PR TITLE
[Java API] Add ExceptionCheck when exception is expected after JNI call

### DIFF
--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -78,13 +78,13 @@ JNIEXPORT jlongArray JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetDims
     {
         auto       tensor = (*reinterpret_cast<std::shared_ptr<neuropod::NeuropodValue> *>(handle))->as_tensor();
         auto       dims   = tensor->as_tensor()->get_dims();
-        jlongArray result = env->NewLongArray(dims.size());
-        if (!result)
+        jlongArray ret    = env->NewLongArray(dims.size());
+        if (!ret || env->ExceptionCheck())
         {
-            throw std::runtime_error("out of memory");
+            throw std::runtime_error("NewLongArray failed: cannot allocate long array");
         }
-        env->SetLongArrayRegion(result, 0, dims.size(), reinterpret_cast<jlong *>(dims.data()));
-        return result;
+        env->SetLongArrayRegion(ret, 0, dims.size(), reinterpret_cast<jlong *>(dims.data()));
+        return ret;
     }
     catch (const std::exception &e)
     {
@@ -137,9 +137,9 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeToStringLi
                                 ->as_typed_tensor<std::string>();
         auto    size = stringTensor->get_num_elements();
         jobject ret  = env->NewObject(java_util_ArrayList, java_util_ArrayList_, size);
-        if (!ret)
+        if (!ret || env->ExceptionCheck())
         {
-            throw std::runtime_error("out of memory: cannot create ArrayList");
+            throw std::runtime_error("NewObject failed: cannot create ArrayList");
         }
 
         auto flatAccessor = stringTensor->flat();

--- a/source/neuropod/bindings/java/src/main/native/utils.cc
+++ b/source/neuropod/bindings/java/src/main/native/utils.cc
@@ -33,9 +33,9 @@ const std::string TENSOR_TYPE = "Lcom/uber/neuropod/TensorType;";
 std::string to_string(JNIEnv *env, jstring target)
 {
     const char *raw = env->GetStringUTFChars(target, nullptr);
-    if (raw == nullptr)
+    if (!raw || env->ExceptionCheck())
     {
-        throw std::runtime_error("unexpected null pointer in to_string");
+        throw std::runtime_error("invalid jstring in to_string");
     }
 
     std::string res(raw);
@@ -46,7 +46,7 @@ std::string to_string(JNIEnv *env, jstring target)
 jclass find_class(JNIEnv *env, const std::string &name)
 {
     jclass ret = env->FindClass(name.c_str());
-    if (reinterpret_cast<jlong>(ret) == 0)
+    if (!ret || env->ExceptionCheck())
     {
         throw std::runtime_error("class not found: " + name);
     }
@@ -56,7 +56,7 @@ jclass find_class(JNIEnv *env, const std::string &name)
 jmethodID get_method_id(JNIEnv *env, jclass clazz, const std::string &name, const std::string &sig)
 {
     jmethodID ret = env->GetMethodID(clazz, name.c_str(), sig.c_str());
-    if (reinterpret_cast<jlong>(ret) == 0)
+    if (!ret || env->ExceptionCheck())
     {
         throw std::runtime_error("method ID not found: " + name + sig);
     }
@@ -66,7 +66,7 @@ jmethodID get_method_id(JNIEnv *env, jclass clazz, const std::string &name, cons
 jobject get_tensor_type_field(JNIEnv *env, const std::string &fieldName)
 {
     jfieldID field = env->GetStaticFieldID(com_uber_neuropod_TensorType, fieldName.c_str(), TENSOR_TYPE.c_str());
-    if (reinterpret_cast<jlong>(field) == 0)
+    if (!field || env->ExceptionCheck())
     {
         throw std::runtime_error("field not found: " + fieldName);
     }
@@ -84,6 +84,14 @@ std::string tensor_type_to_string(TensorType type)
 
 void throw_java_exception(JNIEnv *env, const std::string &message)
 {
+    // We encountered an error condition. There can be active Java exception.
+    if (env->ExceptionCheck())
+    {
+        // Prints an exception and a backtrace of the stack to stderr.
+        // This is a convenience routine provided for debugging.
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
     env->ThrowNew(com_uber_neuropod_NeuropodJNIException, message.c_str());
 }
 


### PR DESCRIPTION
### Summary:
Most of JNI calls may cause Java Exception that is not thrown automatically in JNI code. We already check results of calls in some cases. This change also adds ExceptionCheck where this is reasonable. If Java exception detected, we print it, clear and throw custom exception. Issue #434 

### Test Plan:
CI
