### PR TITLE
Fix some of NOLINTNEXTLINE(google-build-using-namespace)

### DIFF
--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
@@ -30,13 +30,14 @@ limitations under the License.
 
 #include <jni.h>
 
+namespace njni = neuropod::jni;
 
 namespace
 {
 
 jobject toJavaTensorSpecList(JNIEnv *env, const std::vector<neuropod::TensorSpec> &specs)
 {
-    jobject ret = env->NewObject(java_util_ArrayList, java_util_ArrayList_, specs.size());
+    jobject ret = env->NewObject(njni::java_util_ArrayList, njni::java_util_ArrayList_, specs.size());
     if (!ret || env->ExceptionCheck())
     {
         throw std::runtime_error("NewObject failed: cannot create ArrayList");
@@ -46,30 +47,30 @@ jobject toJavaTensorSpecList(JNIEnv *env, const std::vector<neuropod::TensorSpec
     {
         auto    type = njni::get_tensor_type_field(env, njni::tensor_type_to_string(tensorSpec.type));
         jstring name = env->NewStringUTF(tensorSpec.name.c_str());
-        jobject dims = env->NewObject(java_util_ArrayList, java_util_ArrayList_, tensorSpec.dims.size());
+        jobject dims = env->NewObject(njni::java_util_ArrayList, njni::java_util_ArrayList_, tensorSpec.dims.size());
         for (const auto &dim : tensorSpec.dims)
         {
             // Neuropod uses "reserved" number for symbolic Dim.
             if (dim.value == -2)
             {
-                jstring symbol = env->NewStringUTF(dim.symbol.c_str());
-                jobject javaDim =
-                    env->NewObject(com_uber_neuropod_Dimension, com_uber_neuropod_Dimension_symbol_, symbol);
-                env->CallBooleanMethod(dims, java_util_ArrayList_add, javaDim);
+                jstring symbol  = env->NewStringUTF(dim.symbol.c_str());
+                jobject javaDim = env->NewObject(
+                    njni::com_uber_neuropod_Dimension, njni::com_uber_neuropod_Dimension_symbol_, symbol);
+                env->CallBooleanMethod(dims, njni::java_util_ArrayList_add, javaDim);
                 env->DeleteLocalRef(javaDim);
                 env->DeleteLocalRef(symbol);
             }
             else
             {
-                jobject javaDim =
-                    env->NewObject(com_uber_neuropod_Dimension, com_uber_neuropod_Dimension_value_, dim.value);
-                env->CallBooleanMethod(dims, java_util_ArrayList_add, javaDim);
+                jobject javaDim = env->NewObject(
+                    njni::com_uber_neuropod_Dimension, njni::com_uber_neuropod_Dimension_value_, dim.value);
+                env->CallBooleanMethod(dims, njni::java_util_ArrayList_add, javaDim);
                 env->DeleteLocalRef(javaDim);
             }
         }
         jobject javaTensorSpec =
-            env->NewObject(com_uber_neuropod_TensorSpec, com_uber_neuropod_TensorSpec_, name, type, dims);
-        env->CallBooleanMethod(ret, java_util_ArrayList_add, javaTensorSpec);
+            env->NewObject(njni::com_uber_neuropod_TensorSpec, njni::com_uber_neuropod_TensorSpec_, name, type, dims);
+        env->CallBooleanMethod(ret, njni::java_util_ArrayList_add, javaTensorSpec);
         env->DeleteLocalRef(name);
         env->DeleteLocalRef(dims);
         env->DeleteLocalRef(type);
@@ -91,15 +92,15 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_Neuropod_nativeNew__Ljava_lang_St
         {
             throw std::runtime_error("illegal state: invalid handle");
         }
-        neuropod::RuntimeOptions opts;
-        opts                              = *reinterpret_cast<neuropod::RuntimeOptions *>(optHandle);
-        auto                convertedPath = njni::to_string(env, path);
-        neuropod::Neuropod *ret           = new neuropod::Neuropod(convertedPath, opts);
+
+        neuropod::RuntimeOptions opts          = *reinterpret_cast<neuropod::RuntimeOptions *>(optHandle);
+        auto                     convertedPath = njni::to_string(env, path);
+        neuropod::Neuropod *     ret           = new neuropod::Neuropod(convertedPath, opts);
         return reinterpret_cast<jlong>(ret);
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }
@@ -114,7 +115,7 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_Neuropod_nativeDelete(JNIEnv *env,
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
 }
 
@@ -128,7 +129,7 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_Neuropod_nativeLoadModel(JNIEnv *e
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
 }
 
@@ -142,7 +143,7 @@ JNIEXPORT jstring JNICALL Java_com_uber_neuropod_Neuropod_nativeGetName(JNIEnv *
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -157,7 +158,7 @@ JNIEXPORT jstring JNICALL Java_com_uber_neuropod_Neuropod_nativeGetPlatform(JNIE
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -173,7 +174,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeGetInputs(JNIEnv
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -189,7 +190,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeGetOutputs(JNIEn
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -200,11 +201,11 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_Neuropod_nativeGetAllocator(JNIEn
     try
     {
         auto model = reinterpret_cast<neuropod::Neuropod *>(handle);
-        return reinterpret_cast<jlong>(neuropod::jni::toHeap(model->get_tensor_allocator()));
+        return reinterpret_cast<jlong>(njni::toHeap(model->get_tensor_allocator()));
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }
@@ -215,11 +216,11 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_Neuropod_nativeGetGenericAllocato
     try
     {
         std::shared_ptr<neuropod::NeuropodTensorAllocator> allocator = neuropod::get_generic_tensor_allocator();
-        return reinterpret_cast<jlong>(neuropod::jni::toHeap(allocator));
+        return reinterpret_cast<jlong>(njni::toHeap(allocator));
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }
@@ -234,11 +235,11 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
         std::vector<std::string> requestedOutputs;
         if (requestedOutputsJava != nullptr)
         {
-            jsize size = env->CallIntMethod(requestedOutputsJava, java_util_ArrayList_size);
+            jsize size = env->CallIntMethod(requestedOutputsJava, njni::java_util_ArrayList_size);
             for (jsize i = 0; i < size; i++)
             {
                 jstring element =
-                    static_cast<jstring>(env->CallObjectMethod(requestedOutputsJava, java_util_ArrayList_get, i));
+                    static_cast<jstring>(env->CallObjectMethod(requestedOutputsJava, njni::java_util_ArrayList_get, i));
                 requestedOutputs.emplace_back(njni::to_string(env, element));
                 env->DeleteLocalRef(element);
             }
@@ -251,9 +252,9 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
         {
             jobject     entry = env->GetObjectArrayElement(entryArray, i);
             std::string key   = njni::to_string(
-                env, static_cast<jstring>(env->CallObjectMethod(entry, java_util_Map_Entry_getKey)));
-            jobject value        = env->CallObjectMethod(entry, java_util_Map_Entry_getValue);
-            jlong   tensorHandle = env->CallLongMethod(value, com_uber_neuropod_NeuropodTensor_getHandle);
+                env, static_cast<jstring>(env->CallObjectMethod(entry, njni::java_util_Map_Entry_getKey)));
+            jobject value        = env->CallObjectMethod(entry, njni::java_util_Map_Entry_getValue);
+            jlong   tensorHandle = env->CallLongMethod(value, njni::com_uber_neuropod_NeuropodTensor_getHandle);
             if (tensorHandle == 0 || env->ExceptionCheck())
             {
                 throw std::runtime_error("invalid tensor handle");
@@ -268,7 +269,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
         auto inferredMap = model->infer(nativeMap, requestedOutputs);
 
         // Put data to Java Map
-        auto ret = env->NewObject(java_util_HashMap, java_util_HashMap_);
+        auto ret = env->NewObject(njni::java_util_HashMap, njni::java_util_HashMap_);
         if (!ret || env->ExceptionCheck())
         {
             throw std::runtime_error("NewObject failed: cannot create HashMap");
@@ -276,8 +277,8 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
 
         for (auto &entry : *inferredMap)
         {
-            jobject javaTensor = env->NewObject(com_uber_neuropod_NeuropodTensor,
-                                                com_uber_neuropod_NeuropodTensor_,
+            jobject javaTensor = env->NewObject(njni::com_uber_neuropod_NeuropodTensor,
+                                                njni::com_uber_neuropod_NeuropodTensor_,
                                                 reinterpret_cast<jlong>(njni::toHeap(entry.second)));
 
             if (!javaTensor || env->ExceptionCheck())
@@ -285,14 +286,14 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_Neuropod_nativeInfer(
                 throw std::runtime_error("NewObject failed: cannot create Tensor");
             }
 
-            env->CallObjectMethod(ret, java_util_HashMap_put, env->NewStringUTF(entry.first.c_str()), javaTensor);
+            env->CallObjectMethod(ret, njni::java_util_HashMap_put, env->NewStringUTF(entry.first.c_str()), javaTensor);
             env->DeleteLocalRef(javaTensor);
         }
         return ret;
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -12,9 +12,7 @@
 
 #include <jni.h>
 
-// TODO(vkuzmin): fix this
-// NOLINTNEXTLINE(google-build-using-namespace)
-using namespace neuropod::jni;
+namespace njni = neuropod::jni;
 
 // NOLINTNEXTLINE(readability-identifier-naming): Ignore function case for Java API methods
 JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeDoDelete(JNIEnv *env,
@@ -30,7 +28,7 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeDoDelete(JNIE
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
 }
 
@@ -47,24 +45,24 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetBuffer(
         switch (tensorType)
         {
         case neuropod::FLOAT_TENSOR: {
-            return createDirectBuffer<float>(env, neuropodTensor);
+            return njni::createDirectBuffer<float>(env, neuropodTensor);
         }
         case neuropod::DOUBLE_TENSOR: {
-            return createDirectBuffer<double>(env, neuropodTensor);
+            return njni::createDirectBuffer<double>(env, neuropodTensor);
         }
         case neuropod::INT32_TENSOR: {
-            return createDirectBuffer<int32_t>(env, neuropodTensor);
+            return njni::createDirectBuffer<int32_t>(env, neuropodTensor);
         }
         case neuropod::INT64_TENSOR: {
-            return createDirectBuffer<int64_t>(env, neuropodTensor);
+            return njni::createDirectBuffer<int64_t>(env, neuropodTensor);
         }
         default:
-            throw std::runtime_error("unsupported tensor type: " + tensor_type_to_string(tensorType));
+            throw std::runtime_error("unsupported tensor type: " + njni::tensor_type_to_string(tensorType));
         }
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -88,7 +86,7 @@ JNIEXPORT jlongArray JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetDims
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -102,11 +100,11 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetTensorT
     {
         auto tensor = (*reinterpret_cast<std::shared_ptr<neuropod::NeuropodValue> *>(handle))->as_tensor();
         auto type   = tensor->as_tensor()->get_tensor_type();
-        return get_tensor_type_field(env, tensor_type_to_string(type));
+        return njni::get_tensor_type_field(env, njni::tensor_type_to_string(type));
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -123,7 +121,7 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetNumberOfE
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return 0;
 }
@@ -136,7 +134,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeToStringLi
                                 ->as_tensor()
                                 ->as_typed_tensor<std::string>();
         auto    size = stringTensor->get_num_elements();
-        jobject ret  = env->NewObject(java_util_ArrayList, java_util_ArrayList_, size);
+        jobject ret  = env->NewObject(njni::java_util_ArrayList, njni::java_util_ArrayList_, size);
         if (!ret || env->ExceptionCheck())
         {
             throw std::runtime_error("NewObject failed: cannot create ArrayList");
@@ -147,7 +145,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeToStringLi
         {
             const std::string &elem          = flatAccessor[i];
             jstring            convertedElem = env->NewStringUTF(elem.c_str());
-            env->CallBooleanMethod(ret, java_util_ArrayList_add, convertedElem);
+            env->CallBooleanMethod(ret, njni::java_util_ArrayList_add, convertedElem);
             env->DeleteLocalRef(convertedElem);
         }
 
@@ -155,7 +153,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeToStringLi
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }
@@ -175,7 +173,7 @@ JNIEXPORT jstring JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetString(
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return nullptr;
 }

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.cc
@@ -26,7 +26,7 @@ limitations under the License.
 
 #include <jni.h>
 
-using namespace neuropod::jni;
+namespace njni = neuropod::jni;
 
 // NOLINTNEXTLINE(readability-identifier-naming): Ignore function case for Java API methods
 JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensorAllocator_nativeDelete(JNIEnv *env,
@@ -42,7 +42,7 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_NeuropodTensorAllocator_nativeDele
     }
     catch (const std::exception &e)
     {
-        neuropod::jni::throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
 }
 
@@ -89,11 +89,11 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_NeuropodTensorAllocator_nativeAll
         default:
             throw std::runtime_error("unsupported tensor type");
         }
-        return reinterpret_cast<jlong>(toHeap(tensor));
+        return reinterpret_cast<jlong>(njni::toHeap(tensor));
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }
@@ -112,20 +112,20 @@ JNIEXPORT jlong JNICALL Java_com_uber_neuropod_NeuropodTensorAllocator_nativeCre
         env->ReleaseLongArrayElements(dims, arr, JNI_ABORT);
 
         auto  stringTensor = allocator->allocate_tensor<std::string>(shapes);
-        jsize size         = env->CallIntMethod(data, java_util_ArrayList_size);
+        jsize size         = env->CallIntMethod(data, njni::java_util_ArrayList_size);
         auto  flatAccessor = stringTensor->flat();
         for (jsize i = 0; i < size; ++i)
         {
-            jstring element = static_cast<jstring>(env->CallObjectMethod(data, java_util_ArrayList_get, i));
-            flatAccessor[i] = to_string(env, element);
+            jstring element = static_cast<jstring>(env->CallObjectMethod(data, njni::java_util_ArrayList_get, i));
+            flatAccessor[i] = njni::to_string(env, element);
             env->DeleteLocalRef(element);
         }
 
-        return reinterpret_cast<jlong>(toHeap(stringTensor));
+        return reinterpret_cast<jlong>(njni::toHeap(stringTensor));
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.cc
@@ -23,9 +23,7 @@ limitations under the License.
 
 #include <jni.h>
 
-// TODO(vkuzmin): fix this
-// NOLINTNEXTLINE(google-build-using-namespace)
-using namespace neuropod::jni;
+namespace njni = neuropod::jni;
 
 JNIEXPORT jlong JNICALL
 // NOLINTNEXTLINE(readability-identifier-naming): Ignore function case for Java API methods
@@ -40,7 +38,7 @@ Java_com_uber_neuropod_RuntimeOptions_00024RuntimeOptionsNative_nativeCreate(JNI
 {
     try
     {
-        std::string controlQueueName              = to_string(env, jControlQueueName);
+        std::string controlQueueName              = njni::to_string(env, jControlQueueName);
         auto        opts                          = new neuropod::RuntimeOptions();
         opts->use_ope                             = (useOpe == JNI_TRUE);
         opts->ope_options.free_memory_every_cycle = (freeMemoryEveryCycle == JNI_TRUE);
@@ -52,7 +50,7 @@ Java_com_uber_neuropod_RuntimeOptions_00024RuntimeOptionsNative_nativeCreate(JNI
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
     return reinterpret_cast<jlong>(nullptr);
 }
@@ -67,6 +65,6 @@ JNIEXPORT void JNICALL Java_com_uber_neuropod_RuntimeOptions_00024RuntimeOptions
     }
     catch (const std::exception &e)
     {
-        throw_java_exception(env, e.what());
+        njni::throw_java_exception(env, e.what());
     }
 }


### PR DESCRIPTION
### Summary:
After we enabled Clang-Tidy it reports warning on:

using namespace neuropod::jni;

because including all is a "mauvais ton". This change fixes it in one of JNI file.

### Test Plan:

CI