### PR TITLE
[CI] Ensure we can make requests to the GitHub API from CI

### DIFF
--- a/build/ci/travis_build.sh
+++ b/build/ci/travis_build.sh
@@ -17,8 +17,13 @@ if [[ $(uname -s) == 'Darwin' ]]; then
         wget https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg &> /dev/null
         sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
     elif [[ "${NEUROPOD_PYTHON_VERSION}" == "3.5" ]]; then
-        wget https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg &> /dev/null
-        sudo installer -pkg python-3.5.4-macosx10.6.pkg -target /
+        # SSL is broken on the official python 3.5 release (and python 3.5 is deprecated)
+        # so we need to install it a different way
+        export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.15}"
+        brew install pyenv
+        pyenv install 3.5.4
+        pyenv global 3.5.4
+        eval "$(pyenv init -)"
     elif [[ "${NEUROPOD_PYTHON_VERSION}" == "3.6" ]]; then
         wget https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg &> /dev/null
         sudo installer -pkg python-3.6.8-macosx10.9.pkg -target /

--- a/build/test.sh
+++ b/build/test.sh
@@ -27,7 +27,7 @@ if [[ $(uname -s) == 'Linux' ]]; then
     export TF_CXX=g++-4.8
 else
     # For building custom ops
-    export MACOSX_DEPLOYMENT_TARGET=10.13
+    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.13}"
 fi
 
 # Run python tests

--- a/build/upload_release.py
+++ b/build/upload_release.py
@@ -78,6 +78,10 @@ def get_release_id(tag_name):
     print("Release ID: {}".format(release_id))
     return release_id
 
+def get_repo_info():
+    # https://api.github.com/repos/uber/neuropod
+    return requests.get('https://api.github.com/repos/uber/neuropod').json()
+
 def upload_package(local_path, release_id, asset_filename, content_type="application/gzip"):
     # POST https://uploads.github.com/repos/uber/neuropod/releases/{release_id}/assets?name={asset_filename}
     print("Uploading {}...".format(asset_filename))
@@ -97,6 +101,10 @@ def upload_package(local_path, release_id, asset_filename, content_type="applica
 
 
 if __name__ == '__main__':
+    if os.getenv("CI") is not None:
+        # Make a request to the github API to ensure we can (this helps catch failures like old SSL libs)
+        get_repo_info()
+
     if not GIT_TAG or not GH_UPLOAD_TOKEN:
         # Don't upload if we don't have a tag or token
         pass


### PR DESCRIPTION
### Summary:
Previously, we'd only make requests to the GitHub API when doing release builds. In some cases we'd see failures when making https requests because of broken dependencies in CI. These failures would only be visible during release builds.

This PR fixes such an issue with Python 3.5 on macOS. It also enables CI pipelines to always make a request to the GitHub API so we can catch similar issues earlier. 

### Test Plan:

CI
