### PR TITLE
Fix dylib id of libneuropod.so on macOS

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -15,17 +15,6 @@ cp bazel-bin/neuropod/bindings/neuropod_native.so python/neuropod/
 cp bazel-bin/neuropod/libneuropod.so python/neuropod/
 cp bazel-bin/neuropod/multiprocess/neuropod_multiprocess_worker python/neuropod/
 
-if [[ $(uname -s) == 'Darwin' ]]; then
-    # Postprocessing needed on mac
-    chmod 755 "python/neuropod/libneuropod.so"
-    for FILE in "python/neuropod/neuropod_native.so" "python/neuropod/neuropod_multiprocess_worker"
-    do
-        chmod 755 $FILE
-        OLD_PATH=$(otool -L ${FILE} | grep libneuropod.so | cut -d ' ' -f1 | column -t)
-        install_name_tool -change "${OLD_PATH}" "@rpath/libneuropod.so" "${FILE}"
-    done
-fi
-
 # Build a wheel
 pushd python
 if [[ $(uname -s) == 'Darwin' ]]; then

--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -40,18 +40,29 @@ cc_library(
 )
 
 cc_binary(
-    name = "libneuropod.so",
+    name = "libneuropod_orig.so",
     linkopts = select({
         "@bazel_tools//src/conditions:darwin": ["-Wl,-rpath,@loader_path"],
         "//conditions:default": ["-Wl,-rpath,$$ORIGIN"],
     }),
     linkshared = True,
     linkstatic = True,
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         ":neuropod_impl",
+    ],
+)
+
+# This genrule changes the dylib id for libneuropod.so on mac
+genrule(
+    name = "change_dylib_id",
+    srcs = [":libneuropod_orig.so"],
+    outs = ["libneuropod.so"],
+    cmd = select({
+        "@bazel_tools//src/conditions:darwin": "cp -f $< $@; chmod 755 $@; install_name_tool -id @rpath/libneuropod.so $@",
+        "//conditions:default": "cp -f $< $@",
+    }),
+    visibility = [
+        "//visibility:public",
     ],
 )
 

--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -45,15 +45,12 @@ filegroup(
     ],
 )
 
-# This genrule copies to a dylib and changes the libneuropod.so dependency path
+# This genrule copies the so to a file with a dylib extension
 genrule(
     name = "copy_to_dylib",
     srcs = [":libneuropod_jni.so"],
     outs = ["libneuropod_jni.dylib"],
-    cmd = select({
-        "@bazel_tools//src/conditions:darwin": "cp -f $< $@; chmod 755 $@; install_name_tool -change \"$$(otool -L $@ | grep libneuropod.so | cut -d ' ' -f1 | column -t)\" \"@rpath/libneuropod.so\" \"$@\"",
-        "//conditions:default": "cp -f $< $@",
-    }),
+    cmd = "cp -f $< $@",
 )
 
 filegroup(


### PR DESCRIPTION
### Summary:

Fixes #468

This change modifies the dylib id of `libneuropod.so` from a bazel internal path (e.g. `bazel-out/darwin-fastbuild/bin/neuropod/libneuropod.so`) to a generic one (`@rpath/libneuropod.so`).

Previously, we were modifying all the binaries that depended on `bazel-out/.../libneuropod.so` to depend on `@rpath/libneuropod.so` instead. This required logic in multiple places and more importantly didn't fix the issue for external code that links against `libneuropod.so`

By changing `libneuropod.so` itself, we can avoid changing all the binaries and libraries that depend on it.

### Test Plan:

CI