### PR TITLE
Fix pip bootstrapping on Python 2.7

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -5,7 +5,7 @@ set -e
 NEUROPOD_PYTHON_BINARY="python${NEUROPOD_PYTHON_VERSION}"
 
 # Install pip
-wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+wget https://bootstrap.pypa.io/2.7/get-pip.py -O /tmp/get-pip.py
 ${NEUROPOD_PYTHON_BINARY} /tmp/get-pip.py
 
 # Setup a virtualenv


### PR DESCRIPTION
### Summary:

The latest version of pip drops support for Python 2.7 (https://github.com/pypa/pip/issues/6148).

This PR modifies `install_python_deps.sh` to install a Python 2.7 compatible version of pip.

We should also explore dropping Python 2.7 support in the future as it's been over a year since its EOL.

### Test Plan:

CI