### PR TITLE
Allow users to catch OPE disconnect errors

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -5,7 +5,7 @@ set -e
 NEUROPOD_PYTHON_BINARY="python${NEUROPOD_PYTHON_VERSION}"
 
 # Install pip
-wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+wget https://bootstrap.pypa.io/2.7/get-pip.py -O /tmp/get-pip.py
 ${NEUROPOD_PYTHON_BINARY} /tmp/get-pip.py
 
 # Setup a virtualenv

--- a/source/neuropod/multiprocess/mq/ipc_message_queue.hh
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue.hh
@@ -105,6 +105,9 @@ private:
     // Whether or not a shutdown is in progress
     bool shutdown_started_ = false;
 
+    // If we lost the heartbeat from the other process
+    std::atomic_bool lost_heartbeat_;
+
     // A thread that handles incoming messages
     std::thread read_worker_;
 
@@ -113,6 +116,9 @@ private:
 
     // Send a message to the other process
     void send_message(const WireFormat &msg);
+
+    // Throw an error if we lost communication with the other process
+    void throw_if_lost_heartbeat();
 
 public:
     IPCMessageQueue(const std::string &control_queue_name, ProcessType type);


### PR DESCRIPTION
### Summary:

Fixes #395.

Previously, OPE disconnects were not catchable by user code (as an error was thrown in another thread).

This PR refactors some of the IPC message queue send and recv code to handle disconnects in a way that gives the user more control

### Test Plan:

CI
