### PR TITLE
[Tools] Update lint and autofix to use a hermetic clang-format

### DIFF
--- a/tools/autofix.sh
+++ b/tools/autofix.sh
@@ -14,7 +14,8 @@ fi
 pushd source
 
 # Reformat with clang-format
-find . -name "*.hh" -o -name "*.h" -o -name "*.cc" -o -name "*.c" | xargs -L1 clang-format -style=file -i
+# Note: this assumes the script is being run from the root of the repo
+find . -name "*.hh" -o -name "*.h" -o -name "*.cc" -o -name "*.c" | xargs -L1 bazel-source/external/llvm_toolchain/bin/clang-format -style=file -i
 
 pushd python
 

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -29,7 +29,8 @@ fi
 pushd source
 
 # Run clang-format
-python /tmp/run-clang-format.py -r .
+# Note: this assumes the script is being run from the root of the repo
+python /tmp/run-clang-format.py --clang-format-executable bazel-source/external/llvm_toolchain/bin/clang-format -r .
 
 pushd python
 


### PR DESCRIPTION
### Summary:

Use a hermetic `clang-format` binary in lint/autofix instead of a user-installed one.

_Note: this requires users to build the project at least once before using lint or autofix_

### Test Plan:

Local testing

(These are local tools and are not used in CI)