### PR TITLE
[Python] Add additional flags when compiling requirements.lock 

### DIFF
--- a/source/python/neuropod/utils/pip_utils.py
+++ b/source/python/neuropod/utils/pip_utils.py
@@ -30,6 +30,8 @@ def compile_requirements(requirements, lockfile):
             "--no-header",
             "--no-annotate",
             "--allow-unsafe",
+            "--no-emit-index-url",
+            "--no-emit-trusted-host",
             "-q",
             "-o",
             lockfile,


### PR DESCRIPTION
### Summary:

When packaging a python model in some environments, a `requirements.lock` file will be generated that contains lines like `--index-url ...` and other lines that are not of the form `name==version` as expected by

https://github.com/uber/neuropod/blob/ca7e3b8b97b6ca4cb8bab0f5267bdd7f8215583f/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/pip_utils.py#L132-L136

This PR fixes the issue by adding the "--no-emit-index-url" and "--no-emit-trusted-host" flags when compling requirements.lock.

### Test Plan:
Local testing before and after this change to confirm the issue was fixed.


***Note: This description was substantially modified by @VivekPanyam  to make it more informative***