### PR TITLE
Update pip bootstrap URL

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -5,7 +5,7 @@ set -e
 NEUROPOD_PYTHON_BINARY="python${NEUROPOD_PYTHON_VERSION}"
 
 # Install pip
-wget https://bootstrap.pypa.io/2.7/get-pip.py -O /tmp/get-pip.py
+wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O /tmp/get-pip.py
 ${NEUROPOD_PYTHON_BINARY} /tmp/get-pip.py
 
 # Setup a virtualenv


### PR DESCRIPTION
### Summary:

This PR updates the pip bootstrap URL in `install_python_deps.sh`.

The bootstrap script at the original URL (https://bootstrap.pypa.io/2.7/get-pip.py) prints a message asking us to update to a new one:

```
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

[snip]
```

### Test Plan:
CI