### PR TITLE
[TF] Add initial support for SavedModel

### DIFF
--- a/source/neuropod/backends/tensorflow/BUILD
+++ b/source/neuropod/backends/tensorflow/BUILD
@@ -34,14 +34,12 @@ neuropod_cc_binary(
 
 neuropod_cc_library(
     name = "tensorflow_backend",
-    srcs = [
-        "tf_backend.cc",
-        "tf_backend.hh",
-        "tf_tensor.cc",
-        "tf_tensor.hh",
-        "type_utils.cc",
-        "type_utils.hh",
-    ],
+    srcs = glob([
+        "*.cc",
+        "*.hh",
+        "saved_model/*.cc",
+        "saved_model/*.h",
+    ]),
     visibility = [
         "//neuropod:__subpackages__",
     ],

--- a/source/neuropod/backends/tensorflow/saved_model/README.md
+++ b/source/neuropod/backends/tensorflow/saved_model/README.md
@@ -1,0 +1,22 @@
+The code in this folder is necessary because we can't use the built-in `LoadSavedModel` in TensorFlow.
+
+TF doesn't provide a good way to run graphs on different devices in the same process
+For example, we can't use GPUOptions::visible_device_list as it is a per process setting
+
+From: https://github.com/tensorflow/tensorflow/issues/18861#issuecomment-385610497
+> Unfortunately, though `visible_deivces_list` is included in `ConfigProto`, it is
+> actually a per-process setting. In fact, this is true of almost all options inside
+> the GPUOptions protocol buffer.
+
+The issue linked above goes through several other alternatives that don't work either.
+
+Instead, we have to set the device of the graph by moving each node in the `GraphDef` to the target device before creating a session.
+
+`LoadSavedModel` creates a session and loads a `GraphDef` internally so we can't use it directly.
+
+The code in this folder is a port of saved model loader code in TF r2.4 with the `GraphDef` modification
+described above.
+
+All the code in this folder is based on the code from https://github.com/tensorflow/tensorflow/tree/r2.4/tensorflow/cc/saved_model
+
+There are also a few minor changes to support multiple TF versions, remove some unneeded code, and remove some tensorflow-internal profiling code.

--- a/source/neuropod/backends/tensorflow/saved_model/constants.h
+++ b/source/neuropod/backends/tensorflow/saved_model/constants.h
@@ -1,0 +1,61 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// From https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/constants.h
+
+#ifndef TENSORFLOW_CC_SAVED_MODEL_CONSTANTS_H_
+#define TENSORFLOW_CC_SAVED_MODEL_CONSTANTS_H_
+
+namespace tensorflow
+{
+
+/// SavedModel assets directory.
+constexpr char kSavedModelAssetsDirectory[] = "assets";
+
+/// SavedModel assets.extra directory.
+constexpr char kSavedModelAssetsExtraDirectory[] = "assets.extra";
+
+/// SavedModel assets key for graph collection-def.
+constexpr char kSavedModelAssetsKey[] = "saved_model_assets";
+
+/// SavedModel proto filename.
+constexpr char kSavedModelFilenamePb[] = "saved_model.pb";
+
+/// SavedModel text format proto filename.
+constexpr char kSavedModelFilenamePbTxt[] = "saved_model.pbtxt";
+
+/// SavedModel legacy init op collection key. Used in v1 SavedModels.
+constexpr char kSavedModelLegacyInitOpKey[] = "legacy_init_op";
+
+/// SavedModel main op collection key. Used in v1 SavedModels.
+constexpr char kSavedModelMainOpKey[] = "saved_model_main_op";
+
+/// Directory in which to save the SavedModel variables.
+constexpr char kSavedModelVariablesDirectory[] = "variables";
+
+/// SavedModel variables filename.
+constexpr char kSavedModelVariablesFilename[] = "variables";
+
+/// SavedModel SignatureDef keys for the initialization and train ops. Used in
+/// V2 SavedModels.
+constexpr char kSavedModelInitOpSignatureKey[]  = "__saved_model_init_op";
+constexpr char kSavedModelTrainOpSignatureKey[] = "__saved_model_train_op";
+
+// Key in the TensorBundle for the object graph proto.
+constexpr char kObjectGraphProtoKey[] = "_CHECKPOINTABLE_OBJECT_GRAPH";
+
+} // namespace tensorflow
+
+#endif // TENSORFLOW_CC_SAVED_MODEL_CONSTANTS_H_

--- a/source/neuropod/backends/tensorflow/saved_model/loader.cc
+++ b/source/neuropod/backends/tensorflow/saved_model/loader.cc
@@ -1,0 +1,329 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/loader.cc
+// with some modifications
+
+#include "neuropod/backends/tensorflow/saved_model/loader.h"
+
+#include "neuropod/backends/tensorflow/saved_model/constants.h"
+#include "neuropod/backends/tensorflow/saved_model/loader_util.h"
+#include "neuropod/backends/tensorflow/saved_model/reader.h"
+#include "neuropod/backends/tensorflow/tf_utils.hh"
+#include "tensorflow/core/framework/attr_value.pb.h"
+#include "tensorflow/core/framework/function.pb.h"
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/framework/tensor.pb.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/lib/monitoring/counter.h"
+#include "tensorflow/core/lib/monitoring/sampler.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/lib/strings/stringprintf.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+#include "tensorflow/core/protobuf/saver.pb.h"
+#include "tensorflow/core/public/session.h"
+#include "tensorflow/core/public/session_options.h"
+#include "tensorflow/core/public/version.h"
+
+#include <unordered_set>
+
+namespace tensorflow
+{
+namespace
+{
+
+// Ensure that constant tensors loaded from the saved model have valid shape.
+// Also ensure that constant nodes have a value assigned to them.
+// TODO(b/154763635): this is temporary and will be replaced with a better audit
+static Status ValidateNode(const NodeDef &node)
+{
+    const auto node_iterator = node.attr().find("value");
+    if (node_iterator != node.attr().end())
+    {
+        AttrValue node_value = node_iterator->second;
+        if (node_value.has_tensor())
+        {
+            const PartialTensorShape node_shape(node_value.tensor().tensor_shape());
+            if (node_shape.num_elements() < 0)
+            {
+                return errors::FailedPrecondition("Saved model contains node \"",
+                                                  node.name(),
+                                                  "\" (op \"",
+                                                  node.op(),
+                                                  "\") which initializes from a tensor with ",
+                                                  node_shape.num_elements(),
+                                                  " elements");
+            }
+        }
+    }
+    else if (node.op() == "Const")
+    {
+        return errors::FailedPrecondition("Saved model contains node \"",
+                                          node.name(),
+                                          "\" which is a constant tensor but no value has been provided");
+    }
+    return Status::OK();
+}
+
+static Status ValidateSavedTensors(const GraphDef &graph_def)
+{
+    for (const auto &node : graph_def.node())
+    {
+        TF_RETURN_IF_ERROR(ValidateNode(node));
+    }
+
+    if (graph_def.has_library())
+    {
+        const FunctionDefLibrary &library = graph_def.library();
+        for (const auto &function : library.function())
+        {
+            for (const auto &node : function.node_def())
+            {
+                TF_RETURN_IF_ERROR(ValidateNode(node));
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+// NEUROPOD MODIFICATION (to be compatible with TF 1.x and TF 2.x)
+#if TF_MAJOR_VERSION > 1
+using TFStringType = tensorflow::tstring;
+#else
+using TFStringType = std::string;
+#endif
+
+Tensor CreateStringTensor(const string &value)
+{
+    Tensor tensor(DT_STRING, TensorShape({}));
+    tensor.scalar<TFStringType>()() = value;
+    return tensor;
+}
+
+void AddAssetsTensorsToInputs(const StringPiece                       export_dir,
+                              const std::vector<AssetFileDef> &       asset_file_defs,
+                              std::vector<std::pair<string, Tensor>> *inputs)
+{
+    if (asset_file_defs.empty())
+    {
+        return;
+    }
+    for (auto &asset_file_def : asset_file_defs)
+    {
+        Tensor assets_file_path_tensor =
+            CreateStringTensor(io::JoinPath(export_dir, kSavedModelAssetsDirectory, asset_file_def.filename()));
+        inputs->push_back({asset_file_def.tensor_info().name(), assets_file_path_tensor});
+    }
+}
+
+// Like Session::Run(), but uses the Make/Run/ReleaseCallable() API to avoid
+// leaving behind non-GC'ed state.
+//
+// Detailed motivation behind this approach, from ashankar@:
+//
+// Each call to Session::Run() that identifies a new subgraph (based on feeds
+// and fetches) creates some datastructures that live as long as the session
+// (the partitioned graph, associated executors etc.).
+//
+// A pathological case of this would be if say the initialization op
+// (main_op/legacy_init_op) involves the use of a large constant. Then we
+// allocate memory for that large constant that will just stick around till the
+// session dies. With this Callable mechanism, that memory will be released
+// right after ReleaseCallable returns.
+//
+// However, the resource manager state remains.
+Status RunOnce(const RunOptions &                            run_options,
+               const std::vector<std::pair<string, Tensor>> &inputs,
+               const std::vector<string> &                   output_tensor_names,
+               const std::vector<string> &                   target_node_names,
+               std::vector<Tensor> *                         outputs,
+               RunMetadata *                                 run_metadata,
+               Session *                                     session)
+{
+    CallableOptions     callable_options;
+    std::vector<Tensor> feed_tensors;
+    *callable_options.mutable_run_options() = run_options;
+    for (const auto &input : inputs)
+    {
+        const string &name   = input.first;
+        const Tensor &tensor = input.second;
+        callable_options.add_feed(name);
+        feed_tensors.push_back(tensor);
+    }
+    for (const string &output_tensor_name : output_tensor_names)
+    {
+        callable_options.add_fetch(output_tensor_name);
+    }
+    for (const string &target_node_name : target_node_names)
+    {
+        callable_options.add_target(target_node_name);
+    }
+
+    Session::CallableHandle callable_handle;
+    TF_RETURN_IF_ERROR(session->MakeCallable(callable_options, &callable_handle));
+    const Status run_status = session->RunCallable(callable_handle, feed_tensors, outputs, run_metadata);
+    // Be sure to call ReleaseCallable() regardless of the outcome of
+    // RunCallable().
+    session->ReleaseCallable(callable_handle).IgnoreError();
+    return run_status;
+}
+
+// RunInitOp will return OK if the initialization op was run successfully.
+// An empty init_op_name indicates that there are no init ops to run.
+Status RunInitOp(const RunOptions &               run_options,
+                 const string &                   export_dir,
+                 const std::vector<AssetFileDef> &asset_file_defs,
+                 Session *                        session,
+                 const string &                   init_op_name)
+{
+    if (!init_op_name.empty())
+    {
+        LOG(INFO) << "Running initialization op on SavedModel bundle at path: " << export_dir;
+        std::vector<std::pair<string, Tensor>> inputs;
+        AddAssetsTensorsToInputs(export_dir, asset_file_defs, &inputs);
+        RunMetadata run_metadata;
+        return RunOnce(run_options, inputs, {}, {init_op_name}, nullptr /* outputs */, &run_metadata, session);
+    }
+    return Status::OK();
+}
+
+// From https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/core/util/tensor_bundle/naming.cc
+string MetaFilename(StringPiece prefix)
+{
+    return strings::Printf("%.*s.index", static_cast<int>(prefix.size()), prefix.data());
+}
+
+Status RunRestore(const RunOptions &               run_options,
+                  const string &                   export_dir,
+                  const StringPiece                restore_op_name,
+                  const StringPiece                variable_filename_const_op_name,
+                  const std::vector<AssetFileDef> &asset_file_defs,
+                  Session *                        session)
+{
+    LOG(INFO) << "Restoring SavedModel bundle.";
+    // Find path to variables to be restored in export directory.
+    const string variables_directory = io::JoinPath(export_dir, kSavedModelVariablesDirectory);
+    // Check for saver checkpoints in v2 format. Models exported in the checkpoint
+    // v2 format will have a variables.index file. The corresponding
+    // variables are stored in the variables.data-?????-of-????? files.
+    const string variables_index_path = io::JoinPath(variables_directory, MetaFilename(kSavedModelVariablesFilename));
+    if (!Env::Default()->FileExists(variables_index_path).ok())
+    {
+        LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
+                     "were restored. File does not exist: "
+                  << variables_index_path;
+        return Status::OK();
+    }
+    const string variables_path = io::JoinPath(variables_directory, kSavedModelVariablesFilename);
+
+    // Add variables to the graph.
+    Tensor variables_path_tensor(DT_STRING, TensorShape({}));
+    variables_path_tensor.scalar<TFStringType>()() = variables_path;
+
+    std::vector<std::pair<string, Tensor>> inputs = {{string(variable_filename_const_op_name), variables_path_tensor}};
+
+    AddAssetsTensorsToInputs(export_dir, asset_file_defs, &inputs);
+
+    RunMetadata run_metadata;
+    return RunOnce(run_options, inputs, {}, {string(restore_op_name)}, nullptr /* outputs */, &run_metadata, session);
+}
+
+Status LoadSavedModelInternal(const SessionOptions &            session_options,
+                              const RunOptions &                run_options,
+                              const string &                    export_dir,
+                              const std::unordered_set<string> &tags,
+                              SavedModelBundle *const           bundle)
+{
+    TF_RETURN_IF_ERROR(ReadMetaGraphDefFromSavedModel(export_dir, tags, &bundle->meta_graph_def));
+
+    // NEUROPOD MODIFICATION
+    // DebugInfo isn't available in all supported TF versions and is not critical to running a
+    // SavedModel so we ignore it for now
+    //
+    //   TF_RETURN_IF_ERROR(
+    //       ReadSavedModelDebugInfoIfPresent(export_dir, &bundle->debug_info));
+    TF_RETURN_IF_ERROR(LoadMetagraphIntoSession(session_options, bundle->meta_graph_def, &bundle->session));
+    TF_RETURN_IF_ERROR(RestoreSession(run_options, bundle->meta_graph_def, export_dir, &bundle->session));
+    return Status::OK();
+}
+
+} // namespace
+
+SavedModelBundleInterface::~SavedModelBundleInterface() {}
+
+Status LoadMetagraphIntoSession(const SessionOptions &    session_options,
+                                MetaGraphDef &            meta_graph,
+                                std::unique_ptr<Session> *session)
+{
+    Session *session_p = nullptr;
+    TF_RETURN_IF_ERROR(NewSession(session_options, &session_p));
+    session->reset(session_p);
+
+    GraphDef &graph = *meta_graph.mutable_graph_def();
+    TF_RETURN_IF_ERROR(ValidateSavedTensors(graph));
+
+    // NEUROPOD MODIFICATION
+    // This moves the graph to the appropriate device before loading it
+    neuropod::move_graph_to_device(graph, *(session->get()), 0);
+
+    return (*session)->Create(graph);
+}
+
+Status LoadSavedModel(const SessionOptions &            session_options,
+                      const RunOptions &                run_options,
+                      const string &                    export_dir,
+                      const std::unordered_set<string> &tags,
+                      SavedModelBundle *const           bundle)
+{
+    return LoadSavedModelInternal(session_options, run_options, export_dir, tags, bundle);
+}
+
+Status RestoreSession(const RunOptions &        run_options,
+                      const MetaGraphDef &      meta_graph,
+                      const string &            export_dir,
+                      std::unique_ptr<Session> *session)
+{
+    std::vector<AssetFileDef> asset_file_defs;
+    TF_RETURN_IF_ERROR(internal::GetAssetFileDefs(meta_graph, &asset_file_defs));
+    if (meta_graph.has_saver_def())
+    {
+        TF_RETURN_IF_ERROR(RunRestore(run_options,
+                                      export_dir,
+                                      meta_graph.saver_def().restore_op_name(),
+                                      meta_graph.saver_def().filename_tensor_name(),
+                                      asset_file_defs,
+                                      session->get()));
+    }
+
+    string init_op_name;
+    TF_RETURN_IF_ERROR(internal::GetInitOp(export_dir, meta_graph, &init_op_name));
+    TF_RETURN_IF_ERROR(RunInitOp(run_options, export_dir, asset_file_defs, session->get(), init_op_name));
+
+    return Status::OK();
+}
+
+bool MaybeSavedModelDirectory(const string &export_dir)
+{
+    const string saved_model_pb_path    = io::JoinPath(export_dir, kSavedModelFilenamePb);
+    const string saved_model_pbtxt_path = io::JoinPath(export_dir, kSavedModelFilenamePbTxt);
+    return Env::Default()->FileExists(saved_model_pb_path).ok() ||
+           Env::Default()->FileExists(saved_model_pbtxt_path).ok();
+}
+
+} // namespace tensorflow

--- a/source/neuropod/backends/tensorflow/saved_model/loader.h
+++ b/source/neuropod/backends/tensorflow/saved_model/loader.h
@@ -1,0 +1,148 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/loader.h
+// with some modifications
+
+/// SavedModel loading functions and SavedModelBundle struct.
+
+#ifndef TENSORFLOW_CC_SAVED_MODEL_LOADER_H_
+#define TENSORFLOW_CC_SAVED_MODEL_LOADER_H_
+
+// Workaround for TF issue
+// https://github.com/abseil/abseil-cpp/issues/211
+#include "absl/base/config.h"
+#undef ABSL_HAVE_STD_STRING_VIEW
+#undef ABSL_USES_STD_STRING_VIEW
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+#include "tensorflow/core/public/session.h"
+
+#include <string>
+#include <unordered_set>
+
+namespace tensorflow
+{
+
+/// Represents a SavedModel that is loaded from storage.
+class SavedModelBundleInterface
+{
+public:
+    virtual ~SavedModelBundleInterface();
+
+    /// Returns the TensorFlow Session that can be used to interact with the
+    /// SavedModel.
+    virtual Session *GetSession() const = 0;
+
+    /// Returns a map from signature name to SignatureDef for all signatures in
+    /// in the SavedModel.
+    virtual const protobuf::Map<string, SignatureDef> &GetSignatures() const = 0;
+};
+
+/// SavedModel representation once the SavedModel is loaded from storage.
+///
+/// NOTE: Prefer to use SavedModelBundleLite in new code, as it consumes less
+/// RAM.
+struct SavedModelBundle : public SavedModelBundleInterface
+{
+    /// A TensorFlow Session does not Close itself on destruction. To avoid
+    /// resource leaks, we explicitly call Close on Sessions that we create.
+    ~SavedModelBundle() override
+    {
+        if (session)
+        {
+            session->Close().IgnoreError();
+        }
+    }
+
+    SavedModelBundle() = default;
+
+    Session *                                  GetSession() const override { return session.get(); }
+    const protobuf::Map<string, SignatureDef> &GetSignatures() const override { return meta_graph_def.signature_def(); }
+
+    std::unique_ptr<Session> session;
+    MetaGraphDef             meta_graph_def;
+};
+
+// A version of SavedModelBundle that avoids storing a potentially large
+// MetaGraphDef. Prefer to use SavedModelBundleLite in new code.
+class SavedModelBundleLite : public SavedModelBundleInterface
+{
+public:
+    SavedModelBundleLite()        = default;
+    SavedModelBundleLite &operator=(SavedModelBundleLite &&other) = default;
+
+    SavedModelBundleLite(std::unique_ptr<Session> session, protobuf::Map<string, SignatureDef> signatures)
+        : session_(std::move(session)), signatures_(std::move(signatures))
+    {
+    }
+
+    /// A TensorFlow Session does not Close itself on destruction. To avoid
+    /// resource leaks, we explicitly call Close on Sessions that we create.
+    ~SavedModelBundleLite() override
+    {
+        if (session_)
+        {
+            session_->Close().IgnoreError();
+        }
+    }
+
+    Session *                                  GetSession() const override { return session_.get(); }
+    const protobuf::Map<string, SignatureDef> &GetSignatures() const override { return signatures_; }
+
+private:
+    std::unique_ptr<Session>            session_;
+    protobuf::Map<string, SignatureDef> signatures_;
+};
+
+// Restore variable and resources in the SavedModel export dir for the
+// indicated metagraph.
+// The recommended way to load a saved model is to call LoadSavedModel,
+// which provides an already initialized Metagraph, Session, and DebugInfo.
+Status RestoreSession(const RunOptions &        run_options,
+                      const MetaGraphDef &      meta_graph,
+                      const string &            export_dir,
+                      std::unique_ptr<Session> *session);
+
+// Initialize a session which wraps this metagraph.
+// The recommended way to load a saved model is to call LoadSavedModel,
+// which provides an already initialized Metagraph, Session, and DebugInfo.
+Status LoadMetagraphIntoSession(const SessionOptions &    session_options,
+                                MetaGraphDef &            meta_graph,
+                                std::unique_ptr<Session> *session);
+
+/// Loads a SavedModel from the specified export directory. The MetaGraphDef
+/// to be loaded is identified by the supplied tags, corresponding exactly to
+/// the set of tags used at SavedModel build time. Stores a SavedModel bundle in
+/// *bundle with a session and the requested MetaGraphDef, if found.
+///
+/// NOTE: Prefer the overload that takes a SavedModelBundleLite* in new code.
+Status LoadSavedModel(const SessionOptions &            session_options,
+                      const RunOptions &                run_options,
+                      const string &                    export_dir,
+                      const std::unordered_set<string> &tags,
+                      SavedModelBundle *const           bundle);
+
+/// Checks whether the provided directory could contain a SavedModel. Note that
+/// the method does not load any data by itself. If the method returns `false`,
+/// the export directory definitely does not contain a SavedModel. If the method
+/// returns `true`, the export directory may contain a SavedModel but provides
+/// no guarantee that it can be loaded.
+bool MaybeSavedModelDirectory(const std::string &export_dir);
+
+} // namespace tensorflow
+
+#endif // TENSORFLOW_CC_SAVED_MODEL_LOADER_H_

--- a/source/neuropod/backends/tensorflow/saved_model/loader_util.cc
+++ b/source/neuropod/backends/tensorflow/saved_model/loader_util.cc
@@ -1,0 +1,99 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/loader_util.cc
+// with some modifications
+
+#include "neuropod/backends/tensorflow/saved_model/loader_util.h"
+
+#include "neuropod/backends/tensorflow/saved_model/constants.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/protobuf_internal.h"
+
+#include <vector>
+
+namespace tensorflow
+{
+namespace internal
+{
+
+// A SavedModel may store the name of the initialization op to run in the
+// in the SignatureDef (v2) or a collection (v1). If an init_op collection
+// exists, then the collection must contain exactly one op.
+Status GetInitOp(const string &export_dir, const MetaGraphDef &meta_graph_def, string *init_op_name)
+{
+    const auto &sig_def_map    = meta_graph_def.signature_def();
+    const auto &init_op_sig_it = meta_graph_def.signature_def().find(kSavedModelInitOpSignatureKey);
+    if (init_op_sig_it != sig_def_map.end())
+    {
+        *init_op_name = init_op_sig_it->second.outputs().find(kSavedModelInitOpSignatureKey)->second.name();
+        return Status::OK();
+    }
+
+    const auto &collection_def_map = meta_graph_def.collection_def();
+    string      init_op_collection_key;
+    if (collection_def_map.find(kSavedModelMainOpKey) != collection_def_map.end())
+    {
+        init_op_collection_key = kSavedModelMainOpKey;
+    }
+    else
+    {
+        init_op_collection_key = kSavedModelLegacyInitOpKey;
+    }
+
+    const auto init_op_it = collection_def_map.find(init_op_collection_key);
+    if (init_op_it != collection_def_map.end())
+    {
+        if (init_op_it->second.node_list().value_size() != 1)
+        {
+            return errors::FailedPrecondition(strings::StrCat("Expected exactly one main op in : ", export_dir));
+        }
+        *init_op_name = init_op_it->second.node_list().value(0);
+    }
+    return Status::OK();
+}
+
+Status GetAssetFileDefs(const MetaGraphDef &meta_graph_def, std::vector<AssetFileDef> *asset_file_defs)
+{
+    // With SavedModel v2, we write asset file def into metagraph instead of
+    // collection, so read from metagraph first.
+    if (meta_graph_def.asset_file_def_size() > 0)
+    {
+        for (const auto &asset : meta_graph_def.asset_file_def())
+        {
+            asset_file_defs->push_back(asset);
+        }
+        return Status::OK();
+    }
+    // Fall back to read from collection to be backward compatible with v1.
+    const auto &collection_def_map = meta_graph_def.collection_def();
+    const auto  assets_it          = collection_def_map.find(kSavedModelAssetsKey);
+    if (assets_it == collection_def_map.end())
+    {
+        return Status::OK();
+    }
+    const auto &any_assets = assets_it->second.any_list().value();
+    for (const auto &any_asset : any_assets)
+    {
+        AssetFileDef asset_file_def;
+        TF_RETURN_IF_ERROR(ParseAny(any_asset, &asset_file_def, "tensorflow.AssetFileDef"));
+        asset_file_defs->push_back(asset_file_def);
+    }
+    return Status::OK();
+}
+
+} // namespace internal
+} // namespace tensorflow

--- a/source/neuropod/backends/tensorflow/saved_model/loader_util.h
+++ b/source/neuropod/backends/tensorflow/saved_model/loader_util.h
@@ -1,0 +1,48 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/loader_util.h
+// with some modifications
+
+#ifndef TENSORFLOW_CC_SAVED_MODEL_LOADER_UTIL_H_
+#define TENSORFLOW_CC_SAVED_MODEL_LOADER_UTIL_H_
+
+// Workaround for TF issue
+// https://github.com/abseil/abseil-cpp/issues/211
+#include "absl/base/config.h"
+#undef ABSL_HAVE_STD_STRING_VIEW
+#undef ABSL_USES_STD_STRING_VIEW
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+
+#include <string>
+
+namespace tensorflow
+{
+namespace internal
+{
+
+// A SavedModel may store the name of the initialization op to run in the
+// in the SignatureDef (v2) or a collection (v1). If an init_op collection
+// exists, then the collection must contain exactly one op.
+Status GetInitOp(const string &export_dir, const MetaGraphDef &meta_graph_def, string *init_op_name);
+
+Status GetAssetFileDefs(const MetaGraphDef &meta_graph_def, std::vector<AssetFileDef> *asset_file_defs);
+
+} // namespace internal
+} // namespace tensorflow
+
+#endif // TENSORFLOW_CC_SAVED_MODEL_LOADER_UTIL_H_

--- a/source/neuropod/backends/tensorflow/saved_model/reader.cc
+++ b/source/neuropod/backends/tensorflow/saved_model/reader.cc
@@ -1,0 +1,101 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/reader.cc
+// with some modifications
+
+#include "neuropod/backends/tensorflow/saved_model/reader.h"
+
+#include "neuropod/backends/tensorflow/saved_model/constants.h"
+#include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/protobuf/saved_model.pb.h"
+
+#include <unordered_set>
+
+namespace tensorflow
+{
+namespace
+{
+
+Status ReadSavedModel(const string &export_dir, SavedModel *saved_model_proto)
+{
+    LOG(INFO) << "Reading SavedModel from: " << export_dir;
+
+    const string saved_model_pb_path = io::JoinPath(export_dir, kSavedModelFilenamePb);
+    if (Env::Default()->FileExists(saved_model_pb_path).ok())
+    {
+        return ReadBinaryProto(Env::Default(), saved_model_pb_path, saved_model_proto);
+    }
+    const string saved_model_pbtxt_path = io::JoinPath(export_dir, kSavedModelFilenamePbTxt);
+    if (Env::Default()->FileExists(saved_model_pbtxt_path).ok())
+    {
+        return ReadTextProto(Env::Default(), saved_model_pbtxt_path, saved_model_proto);
+    }
+    return Status(error::Code::NOT_FOUND,
+                  "Could not find SavedModel .pb or .pbtxt at supplied export "
+                  "directory path: " +
+                      export_dir);
+}
+
+Status FindMetaGraphDef(const std::unordered_set<string> &tags,
+                        SavedModel *                      saved_model_proto,
+                        MetaGraphDef *                    meta_graph_def)
+{
+    // NEUROPOD MODIFICATION
+    // absl::StrJoin doesn't work with all supported TF versions
+    //
+    //   LOG(INFO) << "Reading meta graph with tags { " << absl::StrJoin(tags, " ")
+    //             << " }";
+    for (MetaGraphDef &graph_def : *saved_model_proto->mutable_meta_graphs())
+    {
+        // Get tags from the graph_def.
+        std::unordered_set<string> graph_tags;
+        for (const string &tag : graph_def.meta_info_def().tags())
+        {
+            graph_tags.insert(tag);
+        }
+        // Match with the set of tags provided.
+        if (graph_tags == tags)
+        {
+            *meta_graph_def = std::move(graph_def);
+            return Status::OK();
+        }
+    }
+    return Status(error::Code::NOT_FOUND,
+                  strings::StrCat("Could not find meta graph def matching supplied tags: { ",
+                                  // NEUROPOD MODIFICATION
+                                  // absl::StrJoin doesn't work with all supported TF versions
+                                  //
+                                  //   absl::StrJoin(tags, " "),
+                                  " }. To inspect available tag-sets in the SavedModel, please "
+                                  "use the SavedModel CLI: `saved_model_cli`"));
+}
+
+} // namespace
+
+Status ReadMetaGraphDefFromSavedModel(const string &                    export_dir,
+                                      const std::unordered_set<string> &tags,
+                                      MetaGraphDef *const               meta_graph_def)
+{
+    SavedModel saved_model_proto;
+    TF_RETURN_IF_ERROR(ReadSavedModel(export_dir, &saved_model_proto));
+    TF_RETURN_IF_ERROR(FindMetaGraphDef(tags, &saved_model_proto, meta_graph_def));
+    return Status::OK();
+}
+
+} // namespace tensorflow

--- a/source/neuropod/backends/tensorflow/saved_model/reader.h
+++ b/source/neuropod/backends/tensorflow/saved_model/reader.h
@@ -1,0 +1,49 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Mostly from https://github.com/tensorflow/tensorflow/blob/r2.4/tensorflow/cc/saved_model/reader.h
+// with some modifications
+
+/// Functions to read the SavedModel proto, or parts of it.
+
+#ifndef TENSORFLOW_CC_SAVED_MODEL_READER_H_
+#define TENSORFLOW_CC_SAVED_MODEL_READER_H_
+
+// Workaround for TF issue
+// https://github.com/abseil/abseil-cpp/issues/211
+#include "absl/base/config.h"
+#undef ABSL_HAVE_STD_STRING_VIEW
+#undef ABSL_USES_STD_STRING_VIEW
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+
+#include <string>
+#include <unordered_set>
+
+namespace tensorflow
+{
+
+// Reads the SavedModel proto from saved_model.pb(txt) in the given directory,
+// finds the MetaGraphDef that matches the given set of tags and writes it to
+// the `meta_graph_def` parameter. Returns a failure status when the SavedModel
+// file does not exist or no MetaGraphDef matches the tags.
+Status ReadMetaGraphDefFromSavedModel(const string &                    export_dir,
+                                      const std::unordered_set<string> &tags,
+                                      MetaGraphDef *const               meta_graph_def);
+
+} // namespace tensorflow
+
+#endif // TENSORFLOW_CC_SAVED_MODEL_READER_H_

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -56,6 +56,10 @@ private:
     int64_t get_callable(const std::map<std::string, tensorflow::Tensor> &tensor_feeds,
                          const std::map<std::string, std::string> &       tensor_fetches);
 
+    void load_saved_model();
+
+    void load_frozen_graph(std::istream &graph_stream);
+
 public:
     TensorflowNeuropodBackend(const std::string &neuropod_path, const RuntimeOptions &options);
 

--- a/source/neuropod/backends/tensorflow/tf_utils.cc
+++ b/source/neuropod/backends/tensorflow/tf_utils.cc
@@ -1,0 +1,77 @@
+/* Copyright (c) 2021 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "neuropod/backends/tensorflow/tf_utils.hh"
+
+#include "neuropod/internal/error_utils.hh"
+#include "neuropod/internal/logging.hh"
+#include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/public/session.h"
+
+namespace neuropod
+{
+
+// Utility to move a TF graph to a specific device
+void move_graph_to_device(tensorflow::GraphDef &graph, tensorflow::Session &session, const NeuropodDevice target)
+{
+    // Figure out the correct target device
+    std::string target_device = "/device:CPU:0";
+    if (target != Device::CPU)
+    {
+        // Get all the available devices
+        std::vector<tensorflow::DeviceAttributes> devices;
+        check_tf_status(session.ListDevices(&devices));
+
+        // Check if we have any GPUs
+        bool found_gpu = std::any_of(devices.begin(), devices.end(), [](const tensorflow::DeviceAttributes &device) {
+            return device.device_type() == "GPU";
+        });
+
+        // If we have a GPU, update the target device
+        if (found_gpu)
+        {
+            target_device = std::string("/device:GPU:") + std::to_string(target);
+        }
+    }
+
+    // Iterate through all the nodes in the graph and move them to the target device
+    for (auto &node : *graph.mutable_node())
+    {
+        const auto &node_device = node.device();
+
+        // If a node is on CPU, leave it there
+        if (node_device != "/device:CPU:0" && node_device != target_device)
+        {
+            SPDLOG_TRACE("TF: Moving node {} from device {} to device {}", node.name(), node_device, target_device);
+            node.set_device(target_device);
+        }
+        else
+        {
+            SPDLOG_TRACE("TF: Leaving node {} on device {}", node.name(), node_device);
+        }
+    }
+}
+
+// Throws an error if `status` is not ok
+void check_tf_status(const tensorflow::Status &status)
+{
+    if (!status.ok())
+    {
+        NEUROPOD_ERROR("TensorFlow error: {}", status.error_message());
+    }
+}
+
+} // namespace neuropod

--- a/source/neuropod/backends/tensorflow/tf_utils.hh
+++ b/source/neuropod/backends/tensorflow/tf_utils.hh
@@ -1,0 +1,41 @@
+/* Copyright (c) 2021 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "neuropod/options.hh"
+
+namespace tensorflow
+{
+
+// Forward declarations
+class GraphDef;
+class Session;
+class Status;
+
+} // namespace tensorflow
+
+namespace neuropod
+{
+
+// Utility to move a TF graph to a specific device
+void move_graph_to_device(tensorflow::GraphDef &graph,
+                          tensorflow::Session & session,
+                          const NeuropodDevice  target_device);
+
+// Throws an error if `status` is not ok
+void check_tf_status(const tensorflow::Status &status);
+
+} // namespace neuropod

--- a/source/neuropod/internal/neuropod_loader.cc
+++ b/source/neuropod/internal/neuropod_loader.cc
@@ -48,7 +48,13 @@ public:
 
     std::unique_ptr<std::istream> get_istream_for_file(const std::string &path) override
     {
-        return stdx::make_unique<std::ifstream>(get_file_path(path));
+        auto ret = stdx::make_unique<std::ifstream>(get_file_path(path));
+        if (!(*ret))
+        {
+            return nullptr;
+        }
+
+        return ret;
     }
 
     std::string get_file_path(const std::string &path) override
@@ -94,7 +100,11 @@ public:
     std::unique_ptr<std::istream> get_istream_for_file(const std::string &path) override
     {
         auto out = stdx::make_unique<std::stringstream>();
-        unzipper_.extractEntryToStream(path, *out);
+        if (!unzipper_.extractEntryToStream(path, *out))
+        {
+            return nullptr;
+        }
+
         return out;
     }
 

--- a/source/python/neuropod/backends/tensorflow/packager.py
+++ b/source/python/neuropod/backends/tensorflow/packager.py
@@ -25,9 +25,11 @@ def create_tensorflow_neuropod(
     neuropod_path,
     input_spec,
     output_spec,
-    node_name_mapping,
+    node_name_mapping=None,
     frozen_graph_path=None,
     graph_def=None,
+    saved_model_dir=None,
+    trackable_obj=None,
     init_op_names=[],
     **kwargs
 ):
@@ -37,7 +39,7 @@ def create_tensorflow_neuropod(
     {common_doc_pre}
 
     :param  node_name_mapping:  Mapping from a neuropod input/output name to a node in the graph. The `:0` is
-                                optional.
+                                optional. Required unless using a saved model.
 
                                 !!! note ""
                                     ***Example***:
@@ -49,11 +51,20 @@ def create_tensorflow_neuropod(
                                     }
                                     ```
 
-    :param  frozen_graph_path:  The path to a frozen tensorflow graph. If this is not provided, `graph_def` must
-                                be set
+    :param  frozen_graph_path:  The path to a frozen tensorflow graph. Exactly one of `frozen_graph_path`, `graph_def`, `saved_model_dir`
+                                and `trackable_obj` must be provided.
 
-    :param  graph_def:          A tensorflow `GraphDef` object. If this is not provided, `frozen_graph_path` must
-                                be set
+    :param  graph_def:          A tensorflow `GraphDef` object. Exactly one of `frozen_graph_path`, `graph_def`, `saved_model_dir`
+                                and `trackable_obj` must be provided.
+
+    :param  saved_model_dir:    The path to a tensorflow saved model dir. Exactly one of `frozen_graph_path`, `graph_def`, `saved_model_dir`
+                                and `trackable_obj` must be provided.
+                                Note: this is only tested with TF 2.x at the moment
+
+    :param  trackable_obj:      A trackable object that can be passed to `tf.saved_model.save`. For more control over the
+                                saved model, you can create one yourself and pass in the path using `saved_model_dir`.
+                                Exactly one of `frozen_graph_path`, `graph_def`, `saved_model_dir` and `trackable_obj` must be provided.
+                                Note: this is only tested with TF 2.x at the moment
 
     :param init_op_names:       A list of initialization operator names. These operations are evaluated in the session
                                 used for inference right after the session is created. These operators may be used
@@ -62,17 +73,18 @@ def create_tensorflow_neuropod(
     {common_doc_post}
     """
     # Make sure the inputs are valid
-    if (frozen_graph_path is not None and graph_def is not None) or (
-        frozen_graph_path is None and graph_def is None
-    ):
+    # fmt: off
+    if sum([frozen_graph_path is not None, graph_def is not None, saved_model_dir is not None, trackable_obj is not None]) != 1:
         raise ValueError(
-            "Exactly one of 'frozen_graph_path' and 'graph_def' must be provided."
+            "Exactly one of `frozen_graph_path`, `graph_def`, `saved_model_dir` and `trackable_obj` must be provided."
         )
+    # fmt: on
 
     # Create a folder to store the model
     neuropod_data_path = os.path.join(neuropod_path, "0", "data")
     os.makedirs(neuropod_data_path)
 
+    # Copy/export the model into the neuropod package
     if frozen_graph_path is not None:
         # Copy in the frozen graph
         shutil.copyfile(frozen_graph_path, os.path.join(neuropod_data_path, "model.pb"))
@@ -80,22 +92,80 @@ def create_tensorflow_neuropod(
         # Write out the frozen graph. tf.io.write_graph is an alias to tf.train.write_graph but is safer
         # as it is also present in tensorflow 2.
         tf.io.write_graph(graph_def, neuropod_data_path, "model.pb", as_text=False)
+    elif saved_model_dir is not None:
+        # Copy the saved model in if we have it
+        shutil.copytree(saved_model_dir, os.path.join(neuropod_data_path, "savedmodel"))
+    elif trackable_obj is not None:
+        # Save trackable_obj to a SavedModel
+        saved_model_dir = os.path.join(neuropod_data_path, "savedmodel")
+        tf.saved_model.save(trackable_obj, saved_model_dir)
 
-    # Make sure we have mappings for everything in the spec
-    expected_keys = set()
-    for spec in [input_spec, output_spec]:
-        for tensor in spec:
-            expected_keys.add(tensor["name"])
+    # Validate the args
+    if saved_model_dir is not None:
+        # Load the model and make sure its inputs and outputs match the provided spec
+        loaded = tf.saved_model.load(saved_model_dir)
 
-    actual_keys = set(node_name_mapping.keys())
-    missing_keys = expected_keys - actual_keys
+        # Get the input SignatureDef from the SavedModel
+        structured_inputs = loaded.signatures[
+            "serving_default"
+        ].structured_input_signature[1]
 
-    if len(missing_keys) > 0:
-        raise ValueError(
-            "Expected an item in `node_name_mapping` for every tensor in input_spec and output_spec. Missing: `{}`".format(
-                missing_keys
+        # Make sure the inputs match the spec
+        actual_inputs = set(name for name in structured_inputs)
+        expected_inputs = set(tensor["name"] for tensor in input_spec)
+        missing_inputs = expected_inputs - actual_inputs
+        extra_inputs = actual_inputs - expected_inputs
+
+        if len(missing_inputs) > 0:
+            raise ValueError(
+                "The supplied SavedModel is missing the following inputs in the spec: `{}`".format(
+                    missing_inputs
+                )
             )
+
+        if len(extra_inputs) > 0:
+            raise ValueError(
+                "The supplied SavedModel expects inputs that are not in the spec: `{}`".format(
+                    extra_inputs
+                )
+            )
+
+        # Make sure the model outputs are a superset of the spec
+        actual_outputs = set(
+            name for name in loaded.signatures["serving_default"].structured_outputs
         )
+        expected_outputs = set(tensor["name"] for tensor in output_spec)
+        missing_outputs = expected_outputs - actual_outputs
+
+        if len(missing_outputs) > 0:
+            raise ValueError(
+                "The supplied SavedModel does not return the following outputs in the spec: `{}`".format(
+                    missing_outputs
+                )
+            )
+
+    else:
+        # We require a node name mapping when using a frozen graph or a graphdef
+        if node_name_mapping is None:
+            raise ValueError(
+                "node_name_mapping is required when using `frozen_graph_path` or `graph_def"
+            )
+
+        # Make sure we have mappings for everything in the spec
+        expected_keys = set()
+        for spec in [input_spec, output_spec]:
+            for tensor in spec:
+                expected_keys.add(tensor["name"])
+
+        actual_keys = set(node_name_mapping.keys())
+        missing_keys = expected_keys - actual_keys
+
+        if len(missing_keys) > 0:
+            raise ValueError(
+                "Expected an item in `node_name_mapping` for every tensor in input_spec and output_spec. Missing: `{}`".format(
+                    missing_keys
+                )
+            )
 
     # We also need to save the node name mapping so we know how to run the model
     # This is tensorflow specific config so it's not saved in the overall neuropod config

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2021 UATC, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tensorflow as tf
+import unittest
+from testpath.tempdir import TemporaryDirectory
+
+from neuropod.packagers import create_tensorflow_neuropod
+from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
+
+
+def create_tf_addition_model():
+    """
+    A simple addition model
+    """
+
+    class Adder(tf.Module):
+        @tf.function(
+            input_signature=[
+                tf.TensorSpec(shape=None, dtype=tf.float32),
+                tf.TensorSpec(shape=None, dtype=tf.float32),
+            ]
+        )
+        def add(self, x, y):
+            return {"out": x + y}
+
+    return Adder()
+
+
+@unittest.skipIf(tf.__version__[0] != "2", "Skipping TF 2.x tests for TF 1.x")
+class TestTensorflowV2Packaging(unittest.TestCase):
+    def package_simple_addition_model(self, do_fail=False, **kwargs):
+        with TemporaryDirectory() as test_dir:
+            neuropod_path = os.path.join(test_dir, "test_neuropod")
+
+            # Get the input/output spec along with test data
+            kwargs.update(get_addition_model_spec(do_fail=do_fail))
+
+            # `create_tensorflow_neuropod` runs inference with the test data immediately
+            # after creating the neuropod. Raises a ValueError if the model output
+            # does not match the expected output.
+            create_tensorflow_neuropod(
+                neuropod_path=neuropod_path,
+                model_name="addition_model",
+                trackable_obj=create_tf_addition_model(),
+                **kwargs
+            )
+
+            # Run some additional checks
+            check_addition_model(neuropod_path)
+
+    def test_simple_addition_model(self):
+        # Tests a case where packaging works correctly and
+        # the model output matches the expected output
+        self.package_simple_addition_model()
+
+    def test_simple_addition_model_no_zip(self):
+        # Tests a case where packaging works correctly and
+        # the model output matches the expected output
+        self.package_simple_addition_model(package_as_zip=False)
+
+    def test_simple_addition_model_failure(self):
+        # Tests a case where the output does not match the expected output
+        with self.assertRaises(ValueError):
+            self.package_simple_addition_model(do_fail=True)
+
+    #
+    # Note: The following tests only run against the native bindings. This is okay because the
+    # native bindings are the default inference implementation (and will soon be the only
+    # inference implementation)
+    #
+
+    @unittest.skipIf(
+        not RUN_NATIVE_TESTS,
+        "Target versions are only supported by the native bindings",
+    )
+    def test_simple_addition_model_invalid_target_version(self):
+        # Tests a case where the target platform is an invalid version or range
+        with self.assertRaises(RuntimeError):
+            self.package_simple_addition_model(platform_version_semver="a.b.c")
+
+    @unittest.skipIf(
+        not RUN_NATIVE_TESTS,
+        "Target versions are only supported by the native bindings",
+    )
+    def test_simple_addition_model_no_matching_version(self):
+        # Tests a case where the target platform version is not one that is
+        # available
+        with self.assertRaises(RuntimeError):
+            self.package_simple_addition_model(platform_version_semver="0.0.1")
+
+    @unittest.skipIf(
+        not RUN_NATIVE_TESTS,
+        "Target versions are only supported by the native bindings",
+    )
+    def test_simple_addition_model_matching_range(self):
+        # Tests a case where we have an appropraite backend for the target range
+        self.package_simple_addition_model(platform_version_semver="2.0.0 - 3.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary:

This PR adds initial support for packaging and loading TensorFlow `SavedModel`s

Doing so is not entirely straightforward as described in my comment [here](https://github.com/uber/neuropod/issues/486#issuecomment-820228901).

As mentioned in that comment, we can't use TF's `LoadSavedModel` directly because of device issues with multiple TF models running in one process. As a solution, this PR pulls in the [TF 2.4 SavedModel loading code](https://github.com/tensorflow/tensorflow/tree/r2.4/tensorflow/cc/saved_model) and modifies it to handle devices correctly.

The comment linked above goes into more detail on what the modifications are and why they're needed. There is also a README file in this PR that includes a few more details. 

### Test Plan:

CI + added tests

Note: this is currently only tested with TF 2.x