### PR TITLE
[TF] Add support for TF 2.5.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -331,6 +331,47 @@ steps:
     retry:
       automatic: true
 
+  - label: ":docker: CPU Tests (test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8)"
+    timeout_in_minutes: 60
+    agents:
+      queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow
+    command: build/ci/buildkite_build.sh
+    plugins:
+      - docker-compose#v3.7.0:
+          build: test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+          cache-from: test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          push-retries: 5
+      - docker-compose#v3.7.0:
+          push: test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+      - docker-compose#v3.7.0:
+          run: test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+          env:
+            - NEUROPOD_CACHE_ACCESS_KEY
+            - NEUROPOD_CACHE_ACCESS_SECRET
+            - BUILDKITE
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_COMMIT
+            - BUILDKITE_JOB_ID
+            - BUILDKITE_PROJECT_SLUG
+            - BUILDKITE_PULL_REQUEST
+            - BUILDKITE_TAG
+            - CI
+            - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
+            - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
+            - WEB_DEPLOY_KEY
+    retry:
+      automatic: true
+
   - label: ":docker: GPU Tests (test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7)"
     timeout_in_minutes: 60
     agents:
@@ -596,6 +637,47 @@ steps:
           config: docker-compose.test.yml
       - docker-compose#v3.7.0:
           run: test-gpu-variant-tf-2_2_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+          env:
+            - NEUROPOD_CACHE_ACCESS_KEY
+            - NEUROPOD_CACHE_ACCESS_SECRET
+            - BUILDKITE
+            - BUILDKITE_BRANCH
+            - BUILDKITE_BUILD_NUMBER
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_COMMIT
+            - BUILDKITE_JOB_ID
+            - BUILDKITE_PROJECT_SLUG
+            - BUILDKITE_PULL_REQUEST
+            - BUILDKITE_TAG
+            - CI
+            - CODECOV_TOKEN
+            - GH_STATUS_TOKEN
+            - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
+            - WEB_DEPLOY_KEY
+    retry:
+      automatic: true
+
+  - label: ":docker: GPU Tests (test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8)"
+    timeout_in_minutes: 60
+    agents:
+      queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow
+    command: build/ci/buildkite_build_gpu.sh
+    plugins:
+      - docker-compose#v3.7.0:
+          build: test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+          cache-from: test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          push-retries: 5
+      - docker-compose#v3.7.0:
+          push: test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8
+          config: docker-compose.test.yml
+      - docker-compose#v3.7.0:
+          run: test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY

--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -12,8 +12,6 @@ on:
     tags:
       - v*
   pull_request:
-    branches:
-      - master
 jobs:
     build:
         runs-on: macos-10.15
@@ -73,5 +71,10 @@ jobs:
                       torch: 1.7.0
                       python: 3.8
                       test_frameworks: torchscript,python
+
+                    - tf: 2.5.0
+                      torch: 1.7.0
+                      python: 3.8
+                      test_frameworks: tensorflow
 
 

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -30,8 +30,6 @@ on:
     tags:
       - v*
   pull_request:
-    branches:
-      - master
 jobs:
     build:
         runs-on: macos-10.15
@@ -114,6 +112,9 @@ FRAMEWORK_VERSIONS = [
     # No need to rerun tensorflow tests for 2.2.0 on py3.8
     {"cuda": "10.1", "tensorflow": "2.2.0", "torch": "1.6.0", "python": "3.8", "test_frameworks": "torchscript,python"},
     {"cuda": "10.1", "tensorflow": "2.2.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "torchscript,python"},
+
+    # Only testing TF
+    {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.5.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
 ]
 
 gh_actions_matrix = []
@@ -151,6 +152,7 @@ for platform, framework_version in itertools.product(PLATFORMS, FRAMEWORK_VERSIO
         "    build:\n",
         "      args:\n",
         "        NEUROPOD_CUDA_VERSION: {}\n".format(framework_version["cuda"]) if is_gpu else "",
+        "        NEUROPOD_CUDNN_VERSION: {}\n".format(framework_version["cudnn"]) if is_gpu and "cudnn" in framework_version else "",
         "        NEUROPOD_TENSORFLOW_VERSION: {}\n".format(tf_version),
         "        NEUROPOD_TORCH_VERSION: {}\n".format(torch_version),
         "        NEUROPOD_PYTHON_VERSION: {}\n".format(py_version),

--- a/build/install_frameworks.py
+++ b/build/install_frameworks.py
@@ -44,6 +44,10 @@ def install_pytorch(version):
     # Get the torch cuda string (e.g. cpu, cu90, cu92, cu100)
     torch_cuda_string = "cu{}".format(CUDA_VERSION.replace(".", "")) if IS_GPU else "cpu"
 
+    # TODO(vip): Fix this once we have a better way of dealing with CUDA 11.2
+    if torch_cuda_string == "cu1121":
+        torch_cuda_string = "cpu"
+
     # The base version of torch (e.g. 1.2.0)
     version_base = None
 

--- a/build/neuropod.dockerfile
+++ b/build/neuropod.dockerfile
@@ -3,7 +3,8 @@
 # To only install deps (and skip build and tests), pass `--target neuropod-base` to docker build
 # FROM ubuntu:16.04 as neuropod-base
 ARG NEUROPOD_CUDA_VERSION=10.0
-FROM nvidia/cuda:${NEUROPOD_CUDA_VERSION}-cudnn7-runtime-ubuntu16.04 as neuropod-base
+ARG NEUROPOD_CUDNN_VERSION=7
+FROM nvidia/cuda:${NEUROPOD_CUDA_VERSION}-cudnn${NEUROPOD_CUDNN_VERSION}-runtime-ubuntu16.04 as neuropod-base
 
 # Use utf8
 ENV LC_ALL=C.UTF-8

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -69,13 +69,19 @@ else
 fi
 
 # GPU tests with trace logging
-bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --test_lang_filters="-java" --test_tag_filters="gpu,-no_trace_logging" --test_env="NEUROPOD_LOG_LEVEL=TRACE" $TEST_TARGETS
+bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --test_lang_filters="-java" --test_tag_filters="gpu,-no_trace_logging" --test_env="NEUROPOD_LOG_LEVEL=TRACE" $TEST_TARGETS ||
+    # Allow an exit code of 4 (no tests run)
+    [ "$?" = 4 ]
 
 # GPU tests without trace logging
-bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --test_lang_filters="-java" --test_tag_filters="gpu,no_trace_logging" $TEST_TARGETS
+bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --test_lang_filters="-java" --test_tag_filters="gpu,no_trace_logging" $TEST_TARGETS ||
+    # Allow an exit code of 4 (no tests run)
+    [ "$?" = 4 ]
 
 # Java GPU tests
-bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --combined_report=lcov --test_lang_filters="java" --test_tag_filters="gpu" $TEST_TARGETS
+bazel test "$@" --sandbox_writable_path="$HOME/.neuropod/pythonpackages/" --combined_report=lcov --test_lang_filters="java" --test_tag_filters="gpu" $TEST_TARGETS ||
+    # Allow an exit code of 4 (no tests run)
+    [ "$?" = 4 ]
 
 popd
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -75,6 +75,14 @@ services:
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 
+  test-cpu-variant-tf-2_5_0-torch-1_7_0-py3_8:
+    extends: test-base
+    build:
+      args:
+        NEUROPOD_TENSORFLOW_VERSION: 2.5.0
+        NEUROPOD_TORCH_VERSION: 1.7.0
+        NEUROPOD_PYTHON_VERSION: 3.8
+
   test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7:
     extends: test-gpu
     build:
@@ -135,6 +143,16 @@ services:
       args:
         NEUROPOD_CUDA_VERSION: 10.1
         NEUROPOD_TENSORFLOW_VERSION: 2.2.0
+        NEUROPOD_TORCH_VERSION: 1.7.0
+        NEUROPOD_PYTHON_VERSION: 3.8
+
+  test-gpu-variant-tf-2_5_0-torch-1_7_0-py3_8:
+    extends: test-gpu
+    build:
+      args:
+        NEUROPOD_CUDA_VERSION: 11.2.1
+        NEUROPOD_CUDNN_VERSION: 8
+        NEUROPOD_TENSORFLOW_VERSION: 2.5.0
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 

--- a/source/bazel/libtorch.bzl
+++ b/source/bazel/libtorch.bzl
@@ -9,6 +9,11 @@ def _impl(repository_ctx):
     IS_GPU = (repository_ctx.os.environ.get("NEUROPOD_IS_GPU") or None) != None
     CUDA_VERSION = repository_ctx.os.environ.get("NEUROPOD_CUDA_VERSION") or "10.0"
 
+    # TODO(vip): Fix this once we have a better way of dealing with CUDA 11.2
+    if CUDA_VERSION == "11.2.1":
+        CUDA_VERSION = "10.1"
+        IS_GPU = False
+
     # Get the torch cuda string (e.g. cpu, cu90, cu92, cu100)
     torch_cuda_string = "cu" + CUDA_VERSION.replace(".", "") if IS_GPU else "cpu"
 

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -32,6 +32,10 @@ def _impl(repository_ctx):
             "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-cpu-linux-x86_64.tar.gz",
             "sha256": "ee287e2ccd41e652f51e8c36370c841caf02115bf7b0cb7d4c2119b2c8cbd5fb",
         },
+        "2.5.0-linux-cpu": {
+            "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.5.0rc1-cpu-linux-x86_64.tar.gz",
+            "sha256": "",
+        },
 
         # Linux GPU
         "1.12.0-linux-gpu": {
@@ -56,6 +60,10 @@ def _impl(repository_ctx):
             "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-gpu-linux-x86_64.tar.gz",
             "sha256": "293f907623d7c9622d0ae9b17a2b5938c633eb8e32e9461346fe6afc36fe2e71",
         },
+        "2.5.0-linux-gpu": {
+            "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.5.0rc1-gpu-linux-x86_64.tar.gz",
+            "sha256": "",
+        },
 
         # Mac CPU
         "1.12.0-mac-cpu": {
@@ -79,6 +87,10 @@ def _impl(repository_ctx):
         "2.2.0-mac-cpu": {
             "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.2.0rc3+-cpu-darwin-x86_64.tar.gz",
             "sha256": "78e788a9ada69c8b6edd4061b21ee2a87dbcc41e0c55893c5b063140c28f969d",
+        },
+        "2.5.0-mac-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-2.5.0.tar.gz",
+            "sha256": "",
         },
     }
 

--- a/source/bazel/tensorflow_hdrs.bzl
+++ b/source/bazel/tensorflow_hdrs.bzl
@@ -28,6 +28,10 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
             "sha256": "8d1b7c1d45e7f582d8703c0d0a034a60d4bac942b11205bed91fa55981124d60",
         },
+        "2.5.0-linux-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.5.0rc0-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "",
+        },
 
         # Linux GPU
         "1.12.0-linux-gpu": {
@@ -50,6 +54,10 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
             "sha256": "845f261b0b922740bdd7f21fa3a4bed8ffd9e1712decd552fb33621da4d8ec45",
         },
+        "2.5.0-linux-gpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.5.0rc0-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "",
+        },
 
         # Mac CPU
         "1.12.0-mac-cpu": {
@@ -71,6 +79,10 @@ def _impl(repository_ctx):
         "2.2.0-mac-cpu": {
             "url": "https://files.pythonhosted.org/packages/1c/fd/dea30c9b6db9305309477b8b6fc0330edbed9b36bc81c3d6094458de8b94/tensorflow-2.2.0rc3-cp35-cp35m-macosx_10_11_x86_64.whl",
             "sha256": "bc0030f7ee9b47893cb1ed312a1e91715a911d76d24b121a7934a0d6769b1297",
+        },
+        "2.5.0-mac-cpu": {
+            "url": "https://files.pythonhosted.org/packages/ee/b9/35492679a1a35fb9d8e8c075fb5d4bb26b200fbe214c14717d59e996021e/tensorflow-2.5.0rc0-cp38-cp38-macosx_10_11_x86_64.whl",
+            "sha256": "",
         },
     }
 

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -72,7 +72,10 @@ std::vector<BackendLoadSpec> get_default_backend_map()
          "libneuropod_torchscript_backend.so",
          true,
          {"1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"}},
-        {"tensorflow", "libneuropod_tensorflow_backend.so", true, {"1.12.0", "1.13.1", "1.14.0", "1.15.0", "2.2.0"}},
+        {"tensorflow",
+         "libneuropod_tensorflow_backend.so",
+         true,
+         {"1.12.0", "1.13.1", "1.14.0", "1.15.0", "2.2.0", "2.5.0"}},
         {"python", "libneuropod_pythonbridge_backend.so", false, {"2.7", "3.5", "3.6", "3.7", "3.8"}}};
 
     // Base directory for Neuropod backends


### PR DESCRIPTION
### Summary:

This PR adds support for TF 2.5.0

### Test Plan:

CI (+ TF2 and  SavedModel tests added in #487). This PR also adds a build variant in CI that tests just TF 2.5.0 as it requires a different CUDA and cuDNN version than the rest of our supported frameworks.