### PR TITLE
Remove unnecessary version check in python bridge test

### DIFF
--- a/source/neuropod/backends/python_bridge/test/BUILD
+++ b/source/neuropod/backends/python_bridge/test/BUILD
@@ -38,6 +38,5 @@ cc_test(
     deps = [
         "//neuropod:neuropod_impl",
         "//neuropod/tests:neuropod_test_utils",
-        "@python_repo//:python_hdrs",
     ],
 )

--- a/source/neuropod/backends/python_bridge/test/gpu_test_python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/test/gpu_test_python_bridge.cc
@@ -17,24 +17,18 @@ limitations under the License.
 
 #include <thread>
 
-#include <patchlevel.h>
-
 TEST(test_models, test_pytorch_addition_model)
 {
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
     // Test the PyTorch addition model using the python bridge
     test_addition_model("neuropod/tests/test_data/pytorch_addition_model_gpu/");
-#endif
 }
 
 TEST(test_models, test_pytorch_addition_model_threaded)
 {
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
     std::thread t([]() {
         // Test the PyTorch addition model using the python bridge
         test_addition_model("neuropod/tests/test_data/pytorch_addition_model_gpu/");
     });
 
     t.join();
-#endif
 }


### PR DESCRIPTION
### Summary:
Remove an unnecessary Python version check in a test

### Test Plan:

CI