### PR TITLE
[CI] Filter tests in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -39,6 +41,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -77,6 +80,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -85,6 +89,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -115,6 +121,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -123,6 +130,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -153,6 +162,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -161,6 +171,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -191,6 +203,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -199,6 +212,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -229,6 +244,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -237,6 +253,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -267,6 +285,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -275,6 +294,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: torchscript,python
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -305,6 +326,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -313,6 +335,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -343,6 +367,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -351,6 +376,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -381,6 +408,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -389,6 +417,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -419,6 +449,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -427,6 +458,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -457,6 +490,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -465,6 +499,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -495,6 +531,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -503,6 +540,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -533,6 +572,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true
@@ -541,6 +581,8 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
+    env:
+      NEUROPOD_TEST_FRAMEWORKS: torchscript,python
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -571,6 +613,7 @@ steps:
             - CODECOV_TOKEN
             - GH_STATUS_TOKEN
             - GH_UPLOAD_TOKEN
+            - NEUROPOD_TEST_FRAMEWORKS
             - WEB_DEPLOY_KEY
     retry:
       automatic: true

--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -34,35 +34,44 @@ jobs:
             # Build and test
             - name: Build and Test
               run: ./build/ci/gh_actions_build.sh
+              env:
+                NEUROPOD_TEST_FRAMEWORKS: ${{ matrix.test_frameworks }}
         strategy:
             matrix:
                 include:
                     - tf: 1.12.0
                       torch: 1.1.0
                       python: 2.7
+                      test_frameworks: tensorflow,torchscript,python
 
                     - tf: 1.13.1
                       torch: 1.2.0
                       python: 3.5
+                      test_frameworks: tensorflow,torchscript,python
 
                     - tf: 1.14.0
                       torch: 1.3.0
                       python: 3.6
+                      test_frameworks: tensorflow,torchscript,python
 
                     - tf: 1.15.0
                       torch: 1.4.0
                       python: 3.7
+                      test_frameworks: tensorflow,torchscript,python
 
                     - tf: 2.2.0
                       torch: 1.5.0
                       python: 3.8
+                      test_frameworks: tensorflow,torchscript,python
 
                     - tf: 2.2.0
                       torch: 1.6.0
                       python: 3.8
+                      test_frameworks: torchscript,python
 
                     - tf: 2.2.0
                       torch: 1.7.0
                       python: 3.8
+                      test_frameworks: torchscript,python
 
 


### PR DESCRIPTION
### Summary:

This PR enables us to filter tests in CI using the capabilities added in https://github.com/uber/neuropod/pull/501 and https://github.com/uber/neuropod/pull/502.

This lets us have variants in our build matrix that only test a subset of frameworks. https://github.com/uber/neuropod/pull/492 uses this to add a variant that tests just TF 2.5.0 as it requires a different CUDA and cuDNN version than the rest of our supported frameworks.

### Test Plan:

CI + https://github.com/uber/neuropod/pull/492