### PR TITLE
[Python] Allow filtering tests based on framework

### DIFF
--- a/source/python/neuropod/backends/keras/test/test_keras_packaging.py
+++ b/source/python/neuropod/backends/keras/test/test_keras_packaging.py
@@ -24,7 +24,11 @@ from neuropod.backends.keras.packager import (
     infer_keras_input_spec,
     infer_keras_output_spec,
 )
-from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.tests.utils import (
+    get_addition_model_spec,
+    check_addition_model,
+    requires_frameworks,
+)
 
 
 def create_keras_addition_model(node_name_mapping=None):
@@ -46,6 +50,7 @@ def create_keras_addition_model(node_name_mapping=None):
     return model
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(tf.__version__[0] == "2", "Skipping TF 1.x tests for TF 2.x")
 class TestKerasPackaging(unittest.TestCase):
     def package_simple_addition_model(self, alias_names=False, do_fail=False):

--- a/source/python/neuropod/backends/python/test/test_python_deps.py
+++ b/source/python/neuropod/backends/python/test/test_python_deps.py
@@ -11,6 +11,7 @@ from testpath.tempdir import TemporaryDirectory
 from neuropod.loader import load_neuropod
 from neuropod.packagers import create_python_neuropod
 from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
+from neuropod.tests.utils import requires_frameworks
 
 # From the example at https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html
 SKLEARN_MODEL_SOURCE = """
@@ -33,6 +34,7 @@ def get_model(_):
 """
 
 
+@requires_frameworks("python")
 @unittest.skipIf(
     not RUN_NATIVE_TESTS,
     "Specifying python deps are only supported by the native bindings",

--- a/source/python/neuropod/backends/python/test/test_python_isolation.py
+++ b/source/python/neuropod/backends/python/test/test_python_isolation.py
@@ -19,6 +19,7 @@ from testpath.tempdir import TemporaryDirectory
 
 from neuropod.loader import load_neuropod
 from neuropod.packagers import create_python_neuropod
+from neuropod.tests.utils import requires_frameworks
 
 DUMMY_MODEL_SOURCE = """
 import numpy as np
@@ -33,6 +34,7 @@ def get_model(_):
 """
 
 
+@requires_frameworks("python")
 class TestPythonIsolation(unittest.TestCase):
     def package_dummy_model(self, test_dir, target):
         neuropod_path = os.path.join(test_dir, "test_neuropod")

--- a/source/python/neuropod/backends/python/test/test_python_packaging.py
+++ b/source/python/neuropod/backends/python/test/test_python_packaging.py
@@ -18,7 +18,11 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_python_neuropod
-from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.tests.utils import (
+    get_addition_model_spec,
+    check_addition_model,
+    requires_frameworks,
+)
 
 ADDITION_MODEL_SOURCE = """
 import sys
@@ -46,6 +50,7 @@ def get_model(_):
 """
 
 
+@requires_frameworks("python")
 class TestPythonPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False):
         with TemporaryDirectory() as test_dir:

--- a/source/python/neuropod/backends/pytorch/test/custom_ops/test_pytorch_custom_ops.py
+++ b/source/python/neuropod/backends/pytorch/test/custom_ops/test_pytorch_custom_ops.py
@@ -23,7 +23,7 @@ import torch
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_pytorch_neuropod
-from neuropod.tests.utils import get_addition_model_spec
+from neuropod.tests.utils import get_addition_model_spec, requires_frameworks
 from neuropod.utils.hash_utils import sha256sum
 
 ADDITION_MODEL_SOURCE = """
@@ -47,6 +47,7 @@ def build_op(workdir):
     return glob.glob(os.path.join(workdir, "build", "lib*", "addition_op.so"))[0]
 
 
+@requires_frameworks("python")
 @unittest.skipIf(
     not torch.__version__.startswith("1.4.0"),
     "Skipping custom op test for torch != 1.4.0",

--- a/source/python/neuropod/backends/pytorch/test/test_pytorch_packaging.py
+++ b/source/python/neuropod/backends/pytorch/test/test_pytorch_packaging.py
@@ -17,7 +17,11 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_pytorch_neuropod
-from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.tests.utils import (
+    get_addition_model_spec,
+    check_addition_model,
+    requires_frameworks,
+)
 
 ADDITION_MODEL_SOURCE = """
 import torch
@@ -34,6 +38,7 @@ def get_model(_):
 """
 
 
+@requires_frameworks("python")
 class TestPytorchPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False):
         with TemporaryDirectory() as test_dir:

--- a/source/python/neuropod/backends/pytorch/test/test_pytorch_strings.py
+++ b/source/python/neuropod/backends/pytorch/test/test_pytorch_strings.py
@@ -17,7 +17,11 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_pytorch_neuropod
-from neuropod.tests.utils import get_string_concat_model_spec, check_strings_model
+from neuropod.tests.utils import (
+    get_string_concat_model_spec,
+    check_strings_model,
+    requires_frameworks,
+)
 
 STRINGS_MODEL_SOURCE = """
 import numpy as np
@@ -35,6 +39,7 @@ def get_model(_):
 """
 
 
+@requires_frameworks("python")
 def package_strings_model(out_dir, do_fail=False):
     neuropod_path = os.path.join(out_dir, "test_neuropod")
     model_code_dir = os.path.join(out_dir, "model_code")

--- a/source/python/neuropod/backends/tensorflow/test/custom_ops/test_tensorflow_custom_ops.py
+++ b/source/python/neuropod/backends/tensorflow/test/custom_ops/test_tensorflow_custom_ops.py
@@ -21,7 +21,7 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_tensorflow_neuropod
-from neuropod.tests.utils import get_addition_model_spec
+from neuropod.tests.utils import get_addition_model_spec, requires_frameworks
 
 
 def create_tf_addition_model(custom_op_path):
@@ -42,6 +42,7 @@ def create_tf_addition_model(custom_op_path):
     return g.as_graph_def()
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(
     tf.__version__ == "1.14.0" and sys.platform == "darwin",
     "See https://github.com/tensorflow/tensorflow/issues/30633",

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_packaging.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_packaging.py
@@ -20,7 +20,11 @@ from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_tensorflow_neuropod
 from neuropod.loader import load_neuropod
-from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.tests.utils import (
+    get_addition_model_spec,
+    check_addition_model,
+    requires_frameworks,
+)
 from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
 
 
@@ -63,6 +67,7 @@ def create_tf_accumulator_model():
     return g.as_graph_def(), init_op.name
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(tf.__version__[0] == "2", "Skipping TF 1.x tests for TF 2.x")
 class TestTensorflowPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False, **kwargs):

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_strings.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_strings.py
@@ -18,7 +18,11 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_tensorflow_neuropod
-from neuropod.tests.utils import get_string_concat_model_spec, check_strings_model
+from neuropod.tests.utils import (
+    get_string_concat_model_spec,
+    check_strings_model,
+    requires_frameworks,
+)
 
 
 def create_tf_strings_model():
@@ -37,6 +41,7 @@ def create_tf_strings_model():
     return g.as_graph_def()
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(tf.__version__[0] == "2", "Skipping TF 1.x tests for TF 2.x")
 class TestTensorflowStrings(unittest.TestCase):
     def package_strings_model(self, do_fail=False):

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
@@ -18,7 +18,11 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_tensorflow_neuropod
-from neuropod.tests.utils import get_addition_model_spec, check_addition_model
+from neuropod.tests.utils import (
+    get_addition_model_spec,
+    check_addition_model,
+    requires_frameworks,
+)
 from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
 
 
@@ -40,6 +44,7 @@ def create_tf_addition_model():
     return Adder()
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(tf.__version__[0] != "2", "Skipping TF 2.x tests for TF 1.x")
 class TestTensorflowV2Packaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False, **kwargs):

--- a/source/python/neuropod/backends/torchscript/test/custom_ops/test_torchscript_custom_ops.py
+++ b/source/python/neuropod/backends/torchscript/test/custom_ops/test_torchscript_custom_ops.py
@@ -22,7 +22,7 @@ import unittest
 from testpath.tempdir import TemporaryDirectory
 
 from neuropod.packagers import create_torchscript_neuropod
-from neuropod.tests.utils import get_addition_model_spec
+from neuropod.tests.utils import get_addition_model_spec, requires_frameworks
 from neuropod.utils.eval_utils import RUN_NATIVE_TESTS
 
 
@@ -36,6 +36,7 @@ class CustomOpModel(torch.jit.ScriptModule):
         return {"out": torch.ops.neuropod_test_ops.add(x, y)}
 
 
+@requires_frameworks("torchscript")
 @unittest.skipIf(
     not RUN_NATIVE_TESTS,
     "A torch bug causes a segfault when destroying a catch-all custom op",

--- a/source/python/neuropod/backends/torchscript/test/gpu_test_torchscript_devices.py
+++ b/source/python/neuropod/backends/torchscript/test/gpu_test_torchscript_devices.py
@@ -22,6 +22,7 @@ from typing import Dict
 
 from neuropod.packagers import create_torchscript_neuropod
 from neuropod.utils.eval_utils import load_and_test_neuropod
+from neuropod.tests.utils import requires_frameworks
 
 
 class DevicesModel(torch.jit.ScriptModule):
@@ -57,6 +58,7 @@ class DevicesModel(torch.jit.ScriptModule):
         }
 
 
+@requires_frameworks("torchscript")
 class TestTorchScriptDevices(unittest.TestCase):
     def package_devices_model(self):
         with TemporaryDirectory() as test_dir:

--- a/source/python/neuropod/backends/torchscript/test/test_torchscript_packaging.py
+++ b/source/python/neuropod/backends/torchscript/test/test_torchscript_packaging.py
@@ -27,6 +27,7 @@ from neuropod.tests.utils import (
     get_addition_model_spec,
     get_mixed_model_spec,
     check_addition_model,
+    requires_frameworks,
 )
 
 
@@ -117,6 +118,7 @@ class NamedTupleModel(torch.jit.ScriptModule):
         return SomeNamedTuple(sum=x + y, difference=x - y, product=x * y)
 
 
+@requires_frameworks("torchscript")
 class TestTorchScriptPackaging(unittest.TestCase):
     def package_simple_addition_model(self, do_fail=False):
         for model in [AdditionModel, AdditionModelDictInput, AdditionModelTensorOutput]:

--- a/source/python/neuropod/backends/torchscript/test/test_torchscript_strings.py
+++ b/source/python/neuropod/backends/torchscript/test/test_torchscript_strings.py
@@ -19,7 +19,11 @@ from testpath.tempdir import TemporaryDirectory
 from typing import Dict, List
 
 from neuropod.packagers import create_torchscript_neuropod
-from neuropod.tests.utils import get_string_concat_model_spec, check_strings_model
+from neuropod.tests.utils import (
+    get_string_concat_model_spec,
+    check_strings_model,
+    requires_frameworks,
+)
 
 
 class StringsModel(torch.jit.ScriptModule):
@@ -102,6 +106,7 @@ def package_strings_model(out_dir, model=StringsModel, do_fail=False):
     check_strings_model(neuropod_path)
 
 
+@requires_frameworks("torchscript")
 class TestTorchScriptStrings(unittest.TestCase):
     def test_strings_model(self):
         # Tests a case where packaging works correctly and

--- a/source/python/neuropod/tests/gpu_test_basic_environment_support.py
+++ b/source/python/neuropod/tests/gpu_test_basic_environment_support.py
@@ -15,6 +15,9 @@
 import unittest
 
 
+from neuropod.tests.utils import requires_frameworks
+
+
 class TestGPUEnvSupport(unittest.TestCase):
     """
     Tests that the environment running the tests has GPUs available
@@ -22,11 +25,13 @@ class TestGPUEnvSupport(unittest.TestCase):
     GPUs
     """
 
+    @requires_frameworks("torchscript")  # TODO(vip): Maybe find a better way to do this
     def test_torch_gpu(self):
         import torch
 
         self.assertTrue(torch.cuda.is_available())
 
+    @requires_frameworks("tensorflow")
     def test_tf_gpu(self):
         import tensorflow as tf
 

--- a/source/python/neuropod/tests/utils.py
+++ b/source/python/neuropod/tests/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import numpy as np
+import os
+import unittest
 
 from neuropod.loader import load_neuropod
 
@@ -147,3 +149,24 @@ def check_specs_match(specs, targets):
 
         if spec != target:
             raise ValueError("Spec ({}) not equal to target ({})".format(spec, target))
+
+
+AVAILABLE_FRAMEWORKS = os.getenv("NEUROPOD_TEST_FRAMEWORKS")
+
+if AVAILABLE_FRAMEWORKS is not None:
+    AVAILABLE_FRAMEWORKS = AVAILABLE_FRAMEWORKS.split(",")
+
+
+def _identity(obj):
+    return obj
+
+
+def requires_frameworks(*frameworks):
+    if AVAILABLE_FRAMEWORKS is None:
+        return _identity
+
+    for framework in frameworks:
+        if framework not in AVAILABLE_FRAMEWORKS:
+            return unittest.skip("Skipping test that requires {}".format(framework))
+
+    return _identity

--- a/source/python/neuropod/utils/test/test_randomify.py
+++ b/source/python/neuropod/utils/test/test_randomify.py
@@ -23,6 +23,7 @@ from tempfile import mkdtemp
 
 from neuropod.loader import load_neuropod
 from neuropod.utils.randomify import randomify_neuropod
+from neuropod.tests.utils import requires_frameworks
 
 input_spec = [
     {"name": "in_string_vector", "dtype": "string", "shape": ("N",)},
@@ -39,6 +40,7 @@ output_spec = [
 ]
 
 
+@requires_frameworks("tensorflow")
 @unittest.skipIf(tf.__version__[0] == "2", "Skipping TF 1.x tests for TF 2.x")
 class TestSpecValidation(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
### Summary:

This PR enables filtering python tests based on the framework they require. Tests are annotated with `@requires_framework(...)` and are skipped if the `NEUROPOD_TEST_FRAMEWORKS` environment variable is set and doesn't contain the required framework.

### Test Plan:

Local testing + https://github.com/uber/neuropod/pull/499