### PR TITLE
[Python] Add deprecation warning for _always_use_native=False

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -32,7 +32,7 @@ fi
 
 # Run python tests
 pushd python
-NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=false python -m unittest discover --verbose neuropod
 
 # Test the native bindings
 NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -43,13 +43,13 @@ fi
 
 # Run python tests
 pushd python
-NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=false python -m unittest discover --verbose neuropod
 
 # Test the native bindings
 NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod
 
 # Run GPU only python tests
-NEUROPOD_LOG_LEVEL=TRACE python -m unittest discover --verbose neuropod -p gpu_test*.py
+NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=false python -m unittest discover --verbose neuropod -p gpu_test*.py
 
 # Run GPU only python tests with native bindings
 NEUROPOD_LOG_LEVEL=TRACE NEUROPOD_RUN_NATIVE_TESTS=true python -m unittest discover --verbose neuropod -p gpu_test*.py

--- a/source/python/neuropod/loader.py
+++ b/source/python/neuropod/loader.py
@@ -150,6 +150,16 @@ def load_neuropod(neuropod_path, _always_use_native=True, **kwargs):
     """
     if _always_use_native:
         return NativeNeuropodExecutor(neuropod_path, **kwargs)
+    else:
+        import warnings
+
+        warnings.warn(
+            "_always_use_native=False is deprecated and will be removed soon. "
+            "Please use the default of `True` which uses the native code path to "
+            "run inference instead of the python implementation. This means it'll "
+            "use the same code path as Neuropod from C++. Java, C, Go, etc.",
+            DeprecationWarning,
+        )
 
     # If we were given a zipfile, extract it to a temp dir and use it
     neuropod_path = zip_loader.extract_neuropod_if_necessary(neuropod_path)

--- a/source/python/neuropod/utils/eval_utils.py
+++ b/source/python/neuropod/utils/eval_utils.py
@@ -21,7 +21,8 @@ import numpy as np
 from neuropod.utils.env_utils import eval_in_new_process
 from neuropod.loader import load_neuropod
 
-RUN_NATIVE_TESTS = os.getenv("NEUROPOD_RUN_NATIVE_TESTS") is not None
+# Unset or "true" => True
+RUN_NATIVE_TESTS = os.getenv("NEUROPOD_RUN_NATIVE_TESTS", "true") == "true"
 TEST_DATA_FILENAME = "test_data.pkl"
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Summary:

Add a deprecation warning when loading a model from python using `_always_use_native=False`

Also changes `load_and_test_neuropod` to use the non-deprecated path by default.

### Test Plan:

CI