### PR TITLE
[Docs] Add links to blog post and GTC talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 It currently supports TensorFlow, PyTorch, TorchScript, Keras and [Ludwig](http://ludwig.ai).
 
+For more information:
+
+ - [Uber Engineering blog post introducing Neuropod](https://eng.uber.com/introducing-neuropod/)
+ - [Talk at NVIDIA GTC Spring 2021](https://www.nvidia.com/en-us/on-demand/session/gtcspring21-s31643/)
+
 ## Why use Neuropod?
 
 #### Run models from any supported framework using one API

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,11 @@
 
 It currently supports TensorFlow, PyTorch, TorchScript, Keras and [Ludwig](http://ludwig.ai).
 
+For more information:
+
+ - [Uber Engineering blog post introducing Neuropod](https://eng.uber.com/introducing-neuropod/)
+ - [Talk at NVIDIA GTC Spring 2021](https://www.nvidia.com/en-us/on-demand/session/gtcspring21-s31643/)
+
 ## Why use Neuropod?
 
 #### Run models from any supported framework using one API


### PR DESCRIPTION
### Summary:

Add links to the Uber Eng blog post and the Spring 2021 GTC talk about Neuropod

### Test Plan:

CI (verifies that docs build successfully)