### PR TITLE
Support StringTensor as model output in Neuropod JNI

### DIFF
--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -148,6 +148,24 @@ java_test(
 )
 
 java_test(
+    name = "TFStringsModelTest",
+    srcs = [
+        "src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java",
+        "src/test/java/com/uber/neuropod/TFStringsModelTest.java",
+    ],
+    data = [
+        "//neuropod/tests/test_data",
+    ],
+    javacopts = JAVACOPTS,
+    tags = ["requires_framework_tensorflow"],
+    test_class = "com.uber.neuropod.TFStringsModelTest",
+    deps = [
+        ":neuropod_java_jar",
+        "@junit",
+    ],
+)
+
+java_test(
     name = "TorchscriptAdditionTest",
     srcs = [
         "src/test/java/com/uber/neuropod/NeuropodAdditionTest.java",
@@ -159,6 +177,24 @@ java_test(
     javacopts = JAVACOPTS,
     tags = ["requires_framework_torchscript"],
     test_class = "com.uber.neuropod.TorchscriptAdditionTest",
+    deps = [
+        ":neuropod_java_jar",
+        "@junit",
+    ],
+)
+
+java_test(
+    name = "TorchscriptStringsModelTest",
+    srcs = [
+        "src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java",
+        "src/test/java/com/uber/neuropod/TorchscriptStringsModelTest.java",
+    ],
+    data = [
+        "//neuropod/tests/test_data",
+    ],
+    javacopts = JAVACOPTS,
+    tags = ["requires_framework_tensorflow"],
+    test_class = "com.uber.neuropod.TorchscriptStringsModelTest",
     deps = [
         ":neuropod_java_jar",
         "@junit",

--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -193,7 +193,7 @@ java_test(
         "//neuropod/tests/test_data",
     ],
     javacopts = JAVACOPTS,
-    tags = ["requires_framework_tensorflow"],
+    tags = ["requires_framework_torchscript"],
     test_class = "com.uber.neuropod.TorchscriptStringsModelTest",
     deps = [
         ":neuropod_java_jar",

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
@@ -28,6 +28,8 @@ import java.util.List;
  */
 public class NeuropodTensor extends NativeClass implements Serializable {
 
+    // buffer is used to store int32/ing64/float/double data
+    // if the tensor is string tensor, buffer would be null
     protected ByteBuffer buffer;
 
     // This flag is used to separate NeuropodTensor that is created as Input (from java)

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
@@ -44,7 +44,10 @@ public class NeuropodTensor extends NativeClass implements Serializable {
     protected NeuropodTensor(long handle) {
         super(handle);
         isFromJava = false;
-        buffer = nativeGetBuffer(handle).order(ByteOrder.nativeOrder());
+        buffer = nativeGetBuffer(handle);
+        if (buffer != null) {
+            buffer.order(ByteOrder.nativeOrder());
+        }
     }
 
     /**

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -56,6 +56,11 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetBuffer(
         case neuropod::INT64_TENSOR: {
             return njni::createDirectBuffer<int64_t>(env, neuropodTensor);
         }
+        case neuropod::STRING_TENSOR: {
+        // If it is STRING_TENSOR, we would flatten the tensor data and convert it to a string list
+        // we don't need the buffer to store the data
+            return env->NewGlobalRef(NULL);
+        }
         default:
             throw std::runtime_error("unsupported tensor type: " + njni::tensor_type_to_string(tensorType));
         }

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -57,8 +57,8 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetBuffer(
             return njni::createDirectBuffer<int64_t>(env, neuropodTensor);
         }
         case neuropod::STRING_TENSOR: {
-        // If it is STRING_TENSOR, we would flatten the tensor data and convert it to a string list
-        // we don't need the buffer to store the data
+            // If it is STRING_TENSOR, we would flatten the tensor data and convert it to a string list
+            // we don't need the buffer to store the data
             return env->NewGlobalRef(NULL);
         }
         default:

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
@@ -1,0 +1,101 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import java.nio.DoubleBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class NeuropodStringsModelTest {
+  protected Neuropod model;
+  // Model path should be set by derived class before setUp.
+  protected String model_path;
+
+  // Platform should be set by derived class to (tensorflow, torchscript).
+  protected String platform;
+
+  protected void prepareEnvironment() throws Exception {
+    LibraryLoader.load();
+
+    RuntimeOptions opts = new RuntimeOptions();
+    // TODO(haoyang): For now OPE is required to use the Java bindings
+    opts.useOpe = true;
+    model = new Neuropod(model_path, opts);
+  }
+
+  @Test
+  public void infer() {
+    NeuropodTensorAllocator allocator = model.getTensorAllocator();
+    Map<String, NeuropodTensor> inputs = new HashMap<>();
+    TensorType type = TensorType.STRING_TENSOR;
+
+    List<String> bufferX = new ArrayList<String>();
+    bufferX.add("apple");
+    bufferX.add("banana");
+    NeuropodTensor tensorX = allocator.copyFrom(bufferX, new long[]{2L});
+    inputs.put("x", tensorX);
+
+    List<String> bufferY = new ArrayList<String>();
+    bufferY.add("sauce");
+    bufferY.add("pudding");
+    NeuropodTensor tensorY = allocator.copyFrom(bufferY, new long[]{2L});
+    inputs.put("y", tensorY);
+
+    Map<String, NeuropodTensor> res = model.infer(inputs);
+    assertEquals(1, res.size());
+
+    assertTrue(res.containsKey("out"));
+    NeuropodTensor out = res.get("out");
+    assertNotNull(out);
+    List<String> outStrings = out.toStringList();
+
+    assertArrayEquals(new long[]{2L}, out.getDims());
+    assertEquals(2, out.getNumberOfElements());
+    assertEquals(TensorType.STRING_TENSOR, out.getTensorType());
+
+    assertEquals("apple sauce" , outStrings.get(0));
+    assertEquals("banana pudding" , outStrings.get(1));
+
+    try {
+      // Test that it detects type-mismatch if we try to take Float Output Tensor as Double.
+      DoubleBuffer doubleBuffer = out.toDoubleBuffer();
+      Assert.fail("Expected exception on wrong type");
+    } catch (Exception expected) {
+      assertTrue(expected.getMessage(), expected.getMessage().contains("tensorType mismatch"));
+    }
+
+    out.close();
+
+    // Inference with requested outputs.
+    List<String> requestedOutputs = new ArrayList<String>();
+    requestedOutputs.add("out");
+    Map<String, NeuropodTensor> res2 = model.infer(inputs, requestedOutputs);
+    assertEquals(1, res2.size());
+
+    tensorX.close();
+    tensorY.close();
+    allocator.close();
+  }
+
+}

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFStringsModelTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+
+public class TFStringsModelTest extends NeuropodStringsModelTest {
+  @Before
+  public void setUp() throws Exception {
+    this.model_path = "neuropod/tests/test_data/tf_strings_model/";
+    this.platform = "tensorflow";
+    this.prepareEnvironment();
+  }
+}

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptStringsModelTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+
+public class TorchscriptStringsModelTest extends NeuropodStringsModelTest {
+  @Before
+  public void setUp() throws Exception {
+    this.model_path = "neuropod/tests/test_data/torchscript_strings_model/";
+    this.platform = "torchscript";
+    this.prepareEnvironment();
+  }
+}


### PR DESCRIPTION
### Summary:
In neuropod JNI, it does not support STRING_TENSOR as model output. The reason is when it tries to create a Java Tensor from model output, it would check the tensor type. Only numerical tensors are supported and these tensors would be converted to ByteBuffer. However, Java NeuropodTensor itself do support STRING_TENSOR. It can get strings from the tensor data itself. Thus we refactor nativeGetBuffer method. This method would assign a null buffer to bytebuffer if it is a string tensor

### Test Plan:
Unit test
