### PR TITLE
Use TF2.6.2 in CI TF2.6 Py3.8 Pipeline

### DIFF
--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -78,7 +78,7 @@ jobs:
                       python: 3.8
                       test_frameworks: tensorflow
 
-                    - tf: 2.6.0
+                    - tf: 2.6.2
                       torch: 1.7.0
                       python: 3.8
                       test_frameworks: tensorflow

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -116,7 +116,7 @@ FRAMEWORK_VERSIONS = [
 
     # Only testing TF
     {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.5.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
-    {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.6.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
+    {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.6.2", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
 ]
 
 gh_actions_matrix = []


### PR DESCRIPTION
### Summary:
Keras 2.7 breaks TF2.6.0. The issue is fixed in TF2.6.2. We would ping our TF 2.6 version to https://github.com/tensorflow/tensorflow/releases/tag/v2.6.2 in CI 

### Test Plan:

