### PR TITLE
[TF] Replace TF 2.6.0 with TF 2.6.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -372,7 +372,7 @@ steps:
     retry:
       automatic: true
 
-  - label: ":docker: CPU Tests (test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8)"
+  - label: ":docker: CPU Tests (test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8)"
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
@@ -381,16 +381,16 @@ steps:
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
-          build: test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          build: test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
           image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          cache-from: test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           push-retries: 5
       - docker-compose#v3.7.0:
-          push: test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          push: test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
       - docker-compose#v3.7.0:
-          run: test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          run: test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY
@@ -741,7 +741,7 @@ steps:
     retry:
       automatic: true
 
-  - label: ":docker: GPU Tests (test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8)"
+  - label: ":docker: GPU Tests (test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8)"
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
@@ -750,16 +750,16 @@ steps:
     command: build/ci/buildkite_build_gpu.sh
     plugins:
       - docker-compose#v3.7.0:
-          build: test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          build: test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
           image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          cache-from: test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           push-retries: 5
       - docker-compose#v3.7.0:
-          push: test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          push: test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
       - docker-compose#v3.7.0:
-          run: test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8
+          run: test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY

--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -78,7 +78,7 @@ jobs:
                       python: 3.8
                       test_frameworks: tensorflow
 
-                    - tf: 2.6.0
+                    - tf: 2.6.2
                       torch: 1.7.0
                       python: 3.8
                       test_frameworks: tensorflow

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -116,7 +116,7 @@ FRAMEWORK_VERSIONS = [
 
     # Only testing TF
     {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.5.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
-    {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.6.0", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
+    {"cuda": "11.2.1", "cudnn": "8", "tensorflow": "2.6.2", "torch": "1.7.0", "python": "3.8", "test_frameworks": "tensorflow"},
 ]
 
 gh_actions_matrix = []

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -83,11 +83,11 @@ services:
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 
-  test-cpu-variant-tf-2_6_0-torch-1_7_0-py3_8:
+  test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8:
     extends: test-base
     build:
       args:
-        NEUROPOD_TENSORFLOW_VERSION: 2.6.0
+        NEUROPOD_TENSORFLOW_VERSION: 2.6.2
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 
@@ -164,13 +164,13 @@ services:
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 
-  test-gpu-variant-tf-2_6_0-torch-1_7_0-py3_8:
+  test-gpu-variant-tf-2_6_2-torch-1_7_0-py3_8:
     extends: test-gpu
     build:
       args:
         NEUROPOD_CUDA_VERSION: 11.2.1
         NEUROPOD_CUDNN_VERSION: 8
-        NEUROPOD_TENSORFLOW_VERSION: 2.6.0
+        NEUROPOD_TENSORFLOW_VERSION: 2.6.2
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -99,7 +99,7 @@ Our build matrix is defined as all combinations of the following:
 | 10.1 | - | 1.6.0 | 3.8 |
 | 10.1 | - | 1.7.0 | 3.8 |
 | 11.2.1 | 2.5.0 | - | 3.8 |
-| 11.2.1 | 2.6.0 | - | 3.8 |
+| 11.2.1 | 2.6.2 | - | 3.8 |
 
 We also have the following ad-hoc builds:
 

--- a/source/bazel/tensorflow.bzl
+++ b/source/bazel/tensorflow.bzl
@@ -36,7 +36,8 @@ def _impl(repository_ctx):
             "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.5.0rc1-cpu-linux-x86_64.tar.gz",
             "sha256": "",
         },
-        "2.6.0-linux-cpu": {
+        "2.6.2-linux-cpu": {
+            # Note: they didn't release an updated libtensorflow for 2.6.2 (vs 2.6.0)
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.6.0.tar.gz",
             "sha256": "58ff05f77aa1d969f912857e8a4edb17cc5b8220eeff13aaf807dcc10716a45d",
         },
@@ -68,7 +69,8 @@ def _impl(repository_ctx):
             "url": "https://github.com/VivekPanyam/tensorflow-prebuilts/releases/download/0.0.1/libtensorflow2.5.0rc1-gpu-linux-x86_64.tar.gz",
             "sha256": "",
         },
-        "2.6.0-linux-gpu": {
+        "2.6.2-linux-gpu": {
+            # Note: they didn't release an updated libtensorflow for 2.6.2 (vs 2.6.0)
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.6.0.tar.gz",
             "sha256": "1a93057baa9f831a00a5935132c8e7438ee4ddfc166779dca51aae8c4a40870b",
         },
@@ -100,7 +102,8 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-2.5.0.tar.gz",
             "sha256": "",
         },
-        "2.6.0-mac-cpu": {
+        "2.6.2-mac-cpu": {
+            # Note: they didn't release an updated libtensorflow for 2.6.2 (vs 2.6.0)
             "url": "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-2.6.0.tar.gz",
             "sha256": "61c5478fa9ca813e5f30c536240bdbb77f1e5fd3d4687211baab84ecfe4bb3b9",
         },

--- a/source/bazel/tensorflow_hdrs.bzl
+++ b/source/bazel/tensorflow_hdrs.bzl
@@ -32,9 +32,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.5.0rc0-cp38-cp38-manylinux2010_x86_64.whl",
             "sha256": "",
         },
-        "2.6.0-linux-cpu": {
-            "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.6.0-cp38-cp38-manylinux2010_x86_64.whl",
-            "sha256": "8322106d9c4d48f8378f6a37aee231415b58c25a7223d96c6e5f1e37f9b129d8",
+        "2.6.2-linux-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.6.2-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "1d4ab4b0e1c64370e69b2d3efaae5cacd6d611dd3bfb81e22d86334af617fd59",
         },
 
         # Linux GPU
@@ -62,9 +62,9 @@ def _impl(repository_ctx):
             "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.5.0rc0-cp38-cp38-manylinux2010_x86_64.whl",
             "sha256": "",
         },
-        "2.6.0-linux-gpu": {
-            "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.6.0-cp38-cp38-manylinux2010_x86_64.whl",
-            "sha256": "80e68a0efba86eea87ea8ec9a1ffd1def48d22db16268af547305bf0ba889746",
+        "2.6.2-linux-gpu": {
+            "url": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-2.6.2-cp38-cp38-manylinux2010_x86_64.whl",
+            "sha256": "0c373e6b61d989cf5bf55dffda8cde066f3ad56aaafe57a60c223479c351f933",
         },
 
         # Mac CPU
@@ -92,9 +92,9 @@ def _impl(repository_ctx):
             "url": "https://files.pythonhosted.org/packages/ee/b9/35492679a1a35fb9d8e8c075fb5d4bb26b200fbe214c14717d59e996021e/tensorflow-2.5.0rc0-cp38-cp38-macosx_10_11_x86_64.whl",
             "sha256": "",
         },
-        "2.6.0-mac-cpu": {
-            "url": "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.6.0-cp38-cp38-macosx_10_11_x86_64.whl",
-            "sha256": "2a067d22a356c2cd4753bdd16ee492c55a610f5ebc52713e2954c642f070321c",
+        "2.6.2-mac-cpu": {
+            "url": "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-2.6.2-cp38-cp38-macosx_10_11_x86_64.whl",
+            "sha256": "caffa6d919b428901e224f778206d5bac4b553dadc1301409781af971b06e000",
         },
     }
 

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -75,7 +75,7 @@ std::vector<BackendLoadSpec> get_default_backend_map()
         {"tensorflow",
          "libneuropod_tensorflow_backend.so",
          true,
-         {"1.12.0", "1.13.1", "1.14.0", "1.15.0", "2.2.0", "2.5.0", "2.6.0"}},
+         {"1.12.0", "1.13.1", "1.14.0", "1.15.0", "2.2.0", "2.5.0", "2.6.2"}},
         {"python", "libneuropod_pythonbridge_backend.so", false, {"2.7", "3.5", "3.6", "3.7", "3.8"}}};
 
     // Base directory for Neuropod backends


### PR DESCRIPTION
### Summary:

Keras in TF 2.6.0 broke when TF 2.7.0 was released. TF 2.6.2 fixes this (see https://github.com/tensorflow/tensorflow/releases/tag/v2.6.2 for more details). This PR replaces TF 2.6.0 with TF 2.6.2

### Test Plan:

CI