### PR TITLE
Drop support for Python 2.7, 3.5 + Torch 1.1.0, 1.2.0 + TF 1.12.0, 1.13.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
 #
 
 steps:
-  - label: ":docker: CPU Tests (test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7)"
+  - label: ":docker: CPU Tests (test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6)"
     timeout_in_minutes: 60
     agents:
       queue: public-gpu
@@ -14,16 +14,16 @@ steps:
     command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
-          build: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
+          build: test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6
           config: docker-compose.test.yml
           image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
+          cache-from: test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6
           push-retries: 5
       - docker-compose#v3.7.0:
-          push: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
+          push: test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6
           config: docker-compose.test.yml
       - docker-compose#v3.7.0:
-          run: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
+          run: test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY
@@ -51,88 +51,6 @@ steps:
     agents:
       queue: public-gpu
     command: build/ci/buildkite_lint.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          build: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          push-retries: 5
-      - docker-compose#v3.7.0:
-          push: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-      - docker-compose#v3.7.0:
-          run: test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-          env:
-            - NEUROPOD_CACHE_ACCESS_KEY
-            - NEUROPOD_CACHE_ACCESS_SECRET
-            - BUILDKITE
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
-            - BUILDKITE_COMMIT
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_PROJECT_SLUG
-            - BUILDKITE_PULL_REQUEST
-            - BUILDKITE_TAG
-            - CI
-            - CODECOV_TOKEN
-            - GH_STATUS_TOKEN
-            - GH_UPLOAD_TOKEN
-            - NEUROPOD_TEST_FRAMEWORKS
-            - WEB_DEPLOY_KEY
-    retry:
-      automatic: true
-
-  - label: ":docker: CPU Tests (test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5)"
-    timeout_in_minutes: 60
-    agents:
-      queue: public-gpu
-    env:
-      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
-    command: build/ci/buildkite_build.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          build: test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          config: docker-compose.test.yml
-          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          push-retries: 5
-      - docker-compose#v3.7.0:
-          push: test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          config: docker-compose.test.yml
-      - docker-compose#v3.7.0:
-          run: test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          config: docker-compose.test.yml
-          env:
-            - NEUROPOD_CACHE_ACCESS_KEY
-            - NEUROPOD_CACHE_ACCESS_SECRET
-            - BUILDKITE
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
-            - BUILDKITE_COMMIT
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_PROJECT_SLUG
-            - BUILDKITE_PULL_REQUEST
-            - BUILDKITE_TAG
-            - CI
-            - CODECOV_TOKEN
-            - GH_STATUS_TOKEN
-            - GH_UPLOAD_TOKEN
-            - NEUROPOD_TEST_FRAMEWORKS
-            - WEB_DEPLOY_KEY
-    retry:
-      automatic: true
-
-  - label: ":docker: CPU Tests (test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6)"
-    timeout_in_minutes: 60
-    agents:
-      queue: public-gpu
-    env:
-      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
-    command: build/ci/buildkite_build.sh
     plugins:
       - docker-compose#v3.7.0:
           build: test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6
@@ -473,88 +391,6 @@ steps:
           config: docker-compose.test.yml
       - docker-compose#v3.7.0:
           run: test-cpu-variant-tf-2_6_2-torch-1_7_0-py3_8
-          config: docker-compose.test.yml
-          env:
-            - NEUROPOD_CACHE_ACCESS_KEY
-            - NEUROPOD_CACHE_ACCESS_SECRET
-            - BUILDKITE
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
-            - BUILDKITE_COMMIT
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_PROJECT_SLUG
-            - BUILDKITE_PULL_REQUEST
-            - BUILDKITE_TAG
-            - CI
-            - CODECOV_TOKEN
-            - GH_STATUS_TOKEN
-            - GH_UPLOAD_TOKEN
-            - NEUROPOD_TEST_FRAMEWORKS
-            - WEB_DEPLOY_KEY
-    retry:
-      automatic: true
-
-  - label: ":docker: GPU Tests (test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7)"
-    timeout_in_minutes: 60
-    agents:
-      queue: public-gpu
-    env:
-      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
-    command: build/ci/buildkite_build_gpu.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          build: test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          push-retries: 5
-      - docker-compose#v3.7.0:
-          push: test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-      - docker-compose#v3.7.0:
-          run: test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7
-          config: docker-compose.test.yml
-          env:
-            - NEUROPOD_CACHE_ACCESS_KEY
-            - NEUROPOD_CACHE_ACCESS_SECRET
-            - BUILDKITE
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_BUILD_URL
-            - BUILDKITE_COMMIT
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_PROJECT_SLUG
-            - BUILDKITE_PULL_REQUEST
-            - BUILDKITE_TAG
-            - CI
-            - CODECOV_TOKEN
-            - GH_STATUS_TOKEN
-            - GH_UPLOAD_TOKEN
-            - NEUROPOD_TEST_FRAMEWORKS
-            - WEB_DEPLOY_KEY
-    retry:
-      automatic: true
-
-  - label: ":docker: GPU Tests (test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5)"
-    timeout_in_minutes: 60
-    agents:
-      queue: public-gpu
-    env:
-      NEUROPOD_TEST_FRAMEWORKS: tensorflow,torchscript,python
-    command: build/ci/buildkite_build_gpu.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          build: test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          config: docker-compose.test.yml
-          image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-          cache-from: test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          push-retries: 5
-      - docker-compose#v3.7.0:
-          push: test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5:027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5
-          config: docker-compose.test.yml
-      - docker-compose#v3.7.0:
-          run: test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5
           config: docker-compose.test.yml
           env:
             - NEUROPOD_CACHE_ACCESS_KEY

--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -38,16 +38,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - tf: 1.12.0
-                      torch: 1.1.0
-                      python: 2.7
-                      test_frameworks: tensorflow,torchscript,python
-
-                    - tf: 1.13.1
-                      torch: 1.2.0
-                      python: 3.5
-                      test_frameworks: tensorflow,torchscript,python
-
                     - tf: 1.14.0
                       torch: 1.3.0
                       python: 3.6

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -104,8 +104,6 @@ PLATFORMS = [
 
 # Versions of frameworks to test with
 FRAMEWORK_VERSIONS = [
-    {"cuda": "9.0", "tensorflow": "1.12.0", "torch": "1.1.0", "python": "2.7"},
-    {"cuda": "10.0", "tensorflow": "1.13.1", "torch": "1.2.0", "python": "3.5"},
     {"cuda": "10.0", "tensorflow": "1.14.0", "torch": "1.3.0", "python": "3.6"},
     {"cuda": "10.0", "tensorflow": "1.15.0", "torch": "1.4.0", "python": "3.7"},
     {"cuda": "10.1", "tensorflow": "2.2.0", "torch": "1.5.0", "python": "3.8"},

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,22 +19,6 @@ services:
         NEUROPOD_IS_GPU: "true"
     runtime: nvidia
 
-  test-cpu-variant-tf-1_12_0-torch-1_1_0-py2_7:
-    extends: test-base
-    build:
-      args:
-        NEUROPOD_TENSORFLOW_VERSION: 1.12.0
-        NEUROPOD_TORCH_VERSION: 1.1.0
-        NEUROPOD_PYTHON_VERSION: 2.7
-
-  test-cpu-variant-tf-1_13_1-torch-1_2_0-py3_5:
-    extends: test-base
-    build:
-      args:
-        NEUROPOD_TENSORFLOW_VERSION: 1.13.1
-        NEUROPOD_TORCH_VERSION: 1.2.0
-        NEUROPOD_PYTHON_VERSION: 3.5
-
   test-cpu-variant-tf-1_14_0-torch-1_3_0-py3_6:
     extends: test-base
     build:
@@ -106,24 +90,6 @@ services:
         NEUROPOD_TENSORFLOW_VERSION: 2.6.2
         NEUROPOD_TORCH_VERSION: 1.7.0
         NEUROPOD_PYTHON_VERSION: 3.8
-
-  test-gpu-variant-tf-1_12_0-torch-1_1_0-py2_7:
-    extends: test-gpu
-    build:
-      args:
-        NEUROPOD_CUDA_VERSION: 9.0
-        NEUROPOD_TENSORFLOW_VERSION: 1.12.0
-        NEUROPOD_TORCH_VERSION: 1.1.0
-        NEUROPOD_PYTHON_VERSION: 2.7
-
-  test-gpu-variant-tf-1_13_1-torch-1_2_0-py3_5:
-    extends: test-gpu
-    build:
-      args:
-        NEUROPOD_CUDA_VERSION: 10.0
-        NEUROPOD_TENSORFLOW_VERSION: 1.13.1
-        NEUROPOD_TORCH_VERSION: 1.2.0
-        NEUROPOD_PYTHON_VERSION: 3.5
 
   test-gpu-variant-tf-1_14_0-torch-1_3_0-py3_6:
     extends: test-gpu


### PR DESCRIPTION
### Summary:

As described in #497 and #518, we are dropping support for old versions of frameworks that are years old and past EOL.

No use cases requiring these frameworks were identified so we will begin dropping support by turning off those builds in CI.

### Test Plan:

CI