### PR TITLE
Fix Unicode handling in Java bindings

### DIFF
--- a/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/executor.py
+++ b/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/executor.py
@@ -161,7 +161,10 @@ class NativePythonExecutor:
         # Convert bytes to unicode
         for k, v in inputs.items():
             if v.dtype.type == np.bytes_:
-                inputs[k] = np.char.decode(v, encoding="UTF-8")
+                try:
+                    inputs[k] = np.char.decode(v, encoding="UTF-8")
+                except UnicodeDecodeError:
+                    raise ValueError("Error in UTF-8 decoding: {}".format(v))
 
         out = self.model(**inputs)
 

--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -202,6 +202,24 @@ java_test(
 )
 
 java_test(
+    name = "PythonStringsModelTest",
+    srcs = [
+        "src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java",
+        "src/test/java/com/uber/neuropod/PythonStringsModelTest.java",
+    ],
+    data = [
+        "//neuropod/tests/test_data",
+    ],
+    javacopts = JAVACOPTS,
+    tags = ["requires_framework_python"],
+    test_class = "com.uber.neuropod.PythonStringsModelTest",
+    deps = [
+        ":neuropod_java_jar",
+        "@junit",
+    ],
+)
+
+java_test(
     name = "TensorSpecTest",
     srcs = ["src/test/java/com/uber/neuropod/TensorSpecTest.java"],
     data = [

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.cc
@@ -149,7 +149,7 @@ JNIEXPORT jobject JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeToStringLi
         for (size_t i = 0; i < size; ++i)
         {
             const std::string &elem          = flatAccessor[i];
-            jstring            convertedElem = env->NewStringUTF(elem.c_str());
+            jstring            convertedElem = njni::to_jstring(env, elem);
             env->CallBooleanMethod(ret, njni::java_util_ArrayList_add, convertedElem);
             env->DeleteLocalRef(convertedElem);
         }
@@ -174,7 +174,7 @@ JNIEXPORT jstring JNICALL Java_com_uber_neuropod_NeuropodTensor_nativeGetString(
                                 ->as_tensor()
                                 ->as_typed_tensor<std::string>();
         const std::string &elem = stringTensor->flat()[index];
-        return env->NewStringUTF(elem.c_str());
+        return njni::to_jstring(env, elem);
     }
     catch (const std::exception &e)
     {

--- a/source/neuropod/bindings/java/src/main/native/utils.h
+++ b/source/neuropod/bindings/java/src/main/native/utils.h
@@ -28,8 +28,11 @@ namespace neuropod
 namespace jni
 {
 
-// Convert jstring to cpp string
+// Convert jstring to UTF-8 encoded cpp string
 std::string to_string(JNIEnv *env, jstring target);
+
+// Convert UTF-8 encoded cpp string to a jstring
+jstring to_jstring(JNIEnv *env, const std::string &source);
 
 // A wrapper for env->FindClass, will throw a cpp exception if the find fails.
 jclass find_class(JNIEnv *env, const std::string &name);

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
@@ -51,7 +51,7 @@ public class NeuropodStringsModelTest {
     TensorType type = TensorType.STRING_TENSOR;
 
     List<String> bufferX = new ArrayList<String>();
-    bufferX.add("apple");
+    bufferX.add("applé🅫");
     bufferX.add("banana");
     NeuropodTensor tensorX = allocator.copyFrom(bufferX, new long[]{2L});
     inputs.put("x", tensorX);
@@ -74,7 +74,7 @@ public class NeuropodStringsModelTest {
     assertEquals(2, out.getNumberOfElements());
     assertEquals(TensorType.STRING_TENSOR, out.getTensorType());
 
-    assertEquals("apple sauce" , outStrings.get(0));
+    assertEquals("applé🅫 sauce" , outStrings.get(0));
     assertEquals("banana pudding" , outStrings.get(1));
 
     try {

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/PythonStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/PythonStringsModelTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+
+public class PythonStringsModelTest extends NeuropodStringsModelTest {
+  @Before
+  public void setUp() throws Exception {
+    this.model_path = "neuropod/tests/test_data/pytorch_strings_model/";
+    this.platform = "python";
+    this.prepareEnvironment();
+  }
+}


### PR DESCRIPTION
### Summary:

This PR fixes how the Java bindings deal with Unicode.

Java's Unicode handling methods in JNI (e.g. `GetStringUTFChars`, `NewStringUTF`) deal with "modified UTF-8" encoding.

According to most descriptions I found online, UTF-8 and modified UTF-8 are quite similar with one of the main differences being how they deal with embedded null bytes:

- https://docs.oracle.com/javase/6/docs/api/java/io/DataInput.html#modified-utf-8
- https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
- https://stackoverflow.com/questions/7921016/what-does-it-mean-to-say-java-modified-utf-8-encoding

Unfortunately, this does not mean that UTF-8 and modified UTF-8 are interoperable in cases without embedded null bytes. In fact, the encodings can be quite different and have different lengths.

This causes problems when doing something like this:

```
Java -> Neuropod Java bindings -> C++ -> Neuropod Python Model
```

because the JNI string methods in the Java bindings will encode strings in "modified UTF-8" and Numpy on the python side will try to decode them as UTF-8.

To fix this issue, I changed the Java bindings to explicitly do a UTF-8 conversion in C++.


Java internally represents strings in UTF-16 so the bindings now get that representation and explicitly convert to UTF-8 (and do the reverse when going from C++ to Java).

### Test Plan:

- Changed the Java string model tests to include Unicode characters
- Added a test to run a Python Neuropod model  from Java (failed before implementing the fix, succeeded after the fix)