### PR TITLE
Default to running models in isolated Python environments

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -13,10 +13,6 @@ echo "import coverage; coverage.process_startup()" > \
 # Override the Neuropod backend base directory
 export NEUROPOD_BASE_DIR=`pwd`/.neuropod_test_base
 
-# Enable python isolation
-# TODO(vip): Remove this once isolation is default behavior
-export NEUROPOD_ENABLE_PYTHON_ISOLATION=true
-
 pushd source
 
 # Add the python library to the pythonpath

--- a/build/test_gpu.sh
+++ b/build/test_gpu.sh
@@ -13,10 +13,6 @@ echo "import coverage; coverage.process_startup()" > \
 # Override the Neuropod backend base directory
 export NEUROPOD_BASE_DIR=`pwd`/.neuropod_test_base
 
-# Enable python isolation
-# TODO(vip): Remove this once isolation is default behavior
-export NEUROPOD_ENABLE_PYTHON_ISOLATION=true
-
 pushd source
 
 # Make sure we have GPUs

--- a/source/.bazelrc
+++ b/source/.bazelrc
@@ -39,7 +39,7 @@ build:profile -c dbg --copt='-fno-omit-frame-pointer'
 test --test_output=errors
 
 # Pass certain env vars through to tests
-test --test_env=LLVM_PROFILE_FILE --test_env=COVERAGE_PROCESS_START --test_env=PATH --test_env=PYTHONPATH --test_env=NEUROPOD_BASE_DIR --test_env=NEUROPOD_ENABLE_PYTHON_ISOLATION
+test --test_env=LLVM_PROFILE_FILE --test_env=COVERAGE_PROCESS_START --test_env=PATH --test_env=PYTHONPATH --test_env=NEUROPOD_BASE_DIR --test_env=NEUROPOD_DISABLE_PYTHON_ISOLATION
 
 # Build with warnings as errors in CI
 build:ci --copt='-Werror'

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -117,7 +117,7 @@ std::unique_ptr<py::gil_scoped_release> maybe_initialize()
         (sodir / ("opt/python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION))).string();
 #endif
 
-    if (std::getenv("NEUROPOD_ENABLE_PYTHON_ISOLATION") != nullptr)
+    if (std::getenv("NEUROPOD_DISABLE_PYTHON_ISOLATION") == nullptr)
     {
         // Isolate from the environment, set PYTOHNHOME to the packaged python environment
         SPDLOG_TRACE("Setting PYTHONHOME to isolated environment at {}", pythonhome);


### PR DESCRIPTION
### Summary:

This PR modifies Neuropod to run models in isolated python environments by default. This makes it possible to have consistent model behavior between execution environments (without depending on system-installed python packages).

Using this behavior requires passing in `requirements` when packaging python models.

### Test Plan:

CI