### PR TITLE
Modify copyright headers and add an AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,13 @@
+# This is the list of Neuropod's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+#
+# Please see https://opensource.google/documentation/reference/releasing/authors for more information
+# about AUTHORS files
+
+Vivek Panyam
+UATC, LLC
+Uber Technologies, Inc

--- a/build/ci/set_status.py
+++ b/build/ci/set_status.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/gen_py_api_docs.py
+++ b/build/gen_py_api_docs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/install_frameworks.py
+++ b/build/install_frameworks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/upload_release.py
+++ b/build/upload_release.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.benchmark
+++ b/source/deps/BUILD.benchmark
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.boost
+++ b/source/deps/BUILD.boost
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.eigen3
+++ b/source/deps/BUILD.eigen3
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.filesystem
+++ b/source/deps/BUILD.filesystem
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.fmt
+++ b/source/deps/BUILD.fmt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.gtest
+++ b/source/deps/BUILD.gtest
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.libjsoncpp
+++ b/source/deps/BUILD.libjsoncpp
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.libtorch
+++ b/source/deps/BUILD.libtorch
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.minizip
+++ b/source/deps/BUILD.minizip
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.mklml
+++ b/source/deps/BUILD.mklml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.pfr
+++ b/source/deps/BUILD.pfr
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.picosha2
+++ b/source/deps/BUILD.picosha2
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.pybind11
+++ b/source/deps/BUILD.pybind11
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.python
+++ b/source/deps/BUILD.python
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.semver
+++ b/source/deps/BUILD.semver
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.spdlog
+++ b/source/deps/BUILD.spdlog
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.tensorflow
+++ b/source/deps/BUILD.tensorflow
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.tensorflow_hdrs
+++ b/source/deps/BUILD.tensorflow_hdrs
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.zipper
+++ b/source/deps/BUILD.zipper
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/deps/BUILD.zlib
+++ b/source/deps/BUILD.zlib
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/BUILD
+++ b/source/neuropod/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/BUILD
+++ b/source/neuropod/backends/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/neuropod_backend.cc
+++ b/source/neuropod/backends/neuropod_backend.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/neuropod_backend.hh
+++ b/source/neuropod/backends/neuropod_backend.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/BUILD
+++ b/source/neuropod/backends/python_bridge/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/BUILD
+++ b/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/executor.py
+++ b/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/executor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/hash_utils.py
+++ b/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/hash_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/pip_utils.py
+++ b/source/neuropod/backends/python_bridge/_neuropod_native_bootstrap/pip_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/python_bridge.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/python_bridge.hh
+++ b/source/neuropod/backends/python_bridge/python_bridge.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/test/BUILD
+++ b/source/neuropod/backends/python_bridge/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/test/gpu_test_python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/test/gpu_test_python_bridge.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/python_bridge/test/test_python_bridge.cc
+++ b/source/neuropod/backends/python_bridge/test/test_python_bridge.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensor_allocator.hh
+++ b/source/neuropod/backends/tensor_allocator.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/BUILD
+++ b/source/neuropod/backends/tensorflow/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/test/BUILD
+++ b/source/neuropod/backends/tensorflow/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/test/test_tensorflow_backend.cc
+++ b/source/neuropod/backends/tensorflow/test/test_tensorflow_backend.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_backend.cc
+++ b/source/neuropod/backends/tensorflow/tf_backend.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_backend.hh
+++ b/source/neuropod/backends/tensorflow/tf_backend.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_tensor.cc
+++ b/source/neuropod/backends/tensorflow/tf_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_tensor.hh
+++ b/source/neuropod/backends/tensorflow/tf_tensor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_utils.cc
+++ b/source/neuropod/backends/tensorflow/tf_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 UATC, LLC
+/* Copyright (c) 2021 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/tf_utils.hh
+++ b/source/neuropod/backends/tensorflow/tf_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 UATC, LLC
+/* Copyright (c) 2021 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/type_utils.cc
+++ b/source/neuropod/backends/tensorflow/type_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/tensorflow/type_utils.hh
+++ b/source/neuropod/backends/tensorflow/type_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/test/BUILD
+++ b/source/neuropod/backends/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/test/test_factories.cc
+++ b/source/neuropod/backends/test/test_factories.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/test/test_tensor_validation.cc
+++ b/source/neuropod/backends/test/test_tensor_validation.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/BUILD
+++ b/source/neuropod/backends/torchscript/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/test/BUILD
+++ b/source/neuropod/backends/torchscript/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/test/test_torchscript_backend.cc
+++ b/source/neuropod/backends/torchscript/test/test_torchscript_backend.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/torch_backend.cc
+++ b/source/neuropod/backends/torchscript/torch_backend.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/torch_backend.hh
+++ b/source/neuropod/backends/torchscript/torch_backend.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/torch_tensor.hh
+++ b/source/neuropod/backends/torchscript/torch_tensor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/type_utils.cc
+++ b/source/neuropod/backends/torchscript/type_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/backends/torchscript/type_utils.hh
+++ b/source/neuropod/backends/torchscript/type_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/BUILD
+++ b/source/neuropod/bindings/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/BUILD
+++ b/source/neuropod/bindings/c/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/c_api.cc
+++ b/source/neuropod/bindings/c/c_api.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/c_api.h
+++ b/source/neuropod/bindings/c/c_api.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/c_api_internal.h
+++ b/source/neuropod/bindings/c/c_api_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_status.cc
+++ b/source/neuropod/bindings/c/np_status.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_status.h
+++ b/source/neuropod/bindings/c/np_status.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_status_internal.h
+++ b/source/neuropod/bindings/c/np_status_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor.cc
+++ b/source/neuropod/bindings/c/np_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor.h
+++ b/source/neuropod/bindings/c/np_tensor.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor_allocator.cc
+++ b/source/neuropod/bindings/c/np_tensor_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor_allocator.h
+++ b/source/neuropod/bindings/c/np_tensor_allocator.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor_allocator_internal.h
+++ b/source/neuropod/bindings/c/np_tensor_allocator_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor_internal.h
+++ b/source/neuropod/bindings/c/np_tensor_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_tensor_spec.h
+++ b/source/neuropod/bindings/c/np_tensor_spec.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_valuemap.cc
+++ b/source/neuropod/bindings/c/np_valuemap.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_valuemap.h
+++ b/source/neuropod/bindings/c/np_valuemap.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/np_valuemap_internal.h
+++ b/source/neuropod/bindings/c/np_valuemap_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/test/BUILD
+++ b/source/neuropod/bindings/c/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/c/test/test_c_api.c
+++ b/source/neuropod/bindings/c/test/test_c_api.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/java_build_defs.bzl
+++ b/source/neuropod/bindings/java/java_build_defs.bzl
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Dimension.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Dimension.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/LibraryLoader.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/LibraryLoader.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NativeClass.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NativeClass.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/Neuropod.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodDevice.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodDevice.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodJNIException.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodJNIException.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensor.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensorAllocator.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/NeuropodTensorAllocator.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/RuntimeOptions.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/RuntimeOptions.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorSpec.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorSpec.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorType.java
+++ b/source/neuropod/bindings/java/src/main/java/com/uber/neuropod/TensorType.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_LibraryLoader.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_LibraryLoader.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_LibraryLoader.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_LibraryLoader.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_Neuropod.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensor.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_NeuropodTensorAllocator.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.cc
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.h
+++ b/source/neuropod/bindings/java/src/main/native/com_uber_neuropod_RuntimeOptions_RuntimeOptionsNative.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/jclass_register.cc
+++ b/source/neuropod/bindings/java/src/main/native/jclass_register.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/jclass_register.h
+++ b/source/neuropod/bindings/java/src/main/native/jclass_register.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/utils.cc
+++ b/source/neuropod/bindings/java/src/main/native/utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/utils.h
+++ b/source/neuropod/bindings/java/src/main/native/utils.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/main/native/utils_impl.h
+++ b/source/neuropod/bindings/java/src/main/native/utils_impl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/LibraryLoaderTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/LibraryLoaderTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodAdditionTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodAdditionTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodStringsModelTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodTensorAllocatorTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/NeuropodTensorAllocatorTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/PythonStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/PythonStringsModelTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2022 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFAdditionTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFAdditionTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFStringsModelTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TensorSpecTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TensorSpecTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptAdditionTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptAdditionTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptStringsModelTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptStringsModelTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/neuropod_native.cc
+++ b/source/neuropod/bindings/neuropod_native.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/python_bindings.cc
+++ b/source/neuropod/bindings/python_bindings.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/bindings/python_bindings.hh
+++ b/source/neuropod/bindings/python_bindings.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/conversions/BUILD
+++ b/source/neuropod/conversions/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/conversions/eigen.hh
+++ b/source/neuropod/conversions/eigen.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/conversions/test/BUILD
+++ b/source/neuropod/conversions/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/conversions/test/test_conversions_eigen.cc
+++ b/source/neuropod/conversions/test/test_conversions_eigen.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/core/BUILD
+++ b/source/neuropod/core/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/core/generic_tensor.cc
+++ b/source/neuropod/core/generic_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/core/generic_tensor.hh
+++ b/source/neuropod/core/generic_tensor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/BUILD
+++ b/source/neuropod/internal/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/backend_registration.cc
+++ b/source/neuropod/internal/backend_registration.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/backend_registration.hh
+++ b/source/neuropod/internal/backend_registration.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/blocking_spsc_queue.hh
+++ b/source/neuropod/internal/blocking_spsc_queue.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/config_utils.cc
+++ b/source/neuropod/internal/config_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/config_utils.hh
+++ b/source/neuropod/internal/config_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/cuda_device_mapping.cc
+++ b/source/neuropod/internal/cuda_device_mapping.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/cuda_device_mapping.hh
+++ b/source/neuropod/internal/cuda_device_mapping.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/deleter.cc
+++ b/source/neuropod/internal/deleter.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/deleter.hh
+++ b/source/neuropod/internal/deleter.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/error_utils.hh
+++ b/source/neuropod/internal/error_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/error_utils_header_only.cc
+++ b/source/neuropod/internal/error_utils_header_only.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/error_utils_header_only.hh
+++ b/source/neuropod/internal/error_utils_header_only.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/logging.cc
+++ b/source/neuropod/internal/logging.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/logging.hh
+++ b/source/neuropod/internal/logging.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/memory_utils.hh
+++ b/source/neuropod/internal/memory_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_loader.cc
+++ b/source/neuropod/internal/neuropod_loader.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_loader.hh
+++ b/source/neuropod/internal/neuropod_loader.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_tensor.cc
+++ b/source/neuropod/internal/neuropod_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_tensor.hh
+++ b/source/neuropod/internal/neuropod_tensor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_tensor_raw_data_access.cc
+++ b/source/neuropod/internal/neuropod_tensor_raw_data_access.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_tensor_raw_data_access.hh
+++ b/source/neuropod/internal/neuropod_tensor_raw_data_access.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/neuropod_tensor_serialization.cc
+++ b/source/neuropod/internal/neuropod_tensor_serialization.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/tensor_accessor.hh
+++ b/source/neuropod/internal/tensor_accessor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/tensor_types.cc
+++ b/source/neuropod/internal/tensor_types.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/tensor_types.hh
+++ b/source/neuropod/internal/tensor_types.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/BUILD
+++ b/source/neuropod/internal/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/benchmark_accessor.cc
+++ b/source/neuropod/internal/test/benchmark_accessor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/test_accessor.cc
+++ b/source/neuropod/internal/test/test_accessor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/test_backend_registration.cc
+++ b/source/neuropod/internal/test/test_backend_registration.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/test_config_utils.cc
+++ b/source/neuropod/internal/test/test_config_utils.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/test_internal_neuropod_tensor.cc
+++ b/source/neuropod/internal/test/test_internal_neuropod_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/test/test_loader.cc
+++ b/source/neuropod/internal/test/test_loader.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/internal/type_macros.hh
+++ b/source/neuropod/internal/type_macros.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/BUILD
+++ b/source/neuropod/multiprocess/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/control_messages.cc
+++ b/source/neuropod/multiprocess/control_messages.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/control_messages.hh
+++ b/source/neuropod/multiprocess/control_messages.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/ipc_control_channel.cc
+++ b/source/neuropod/multiprocess/ipc_control_channel.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/ipc_control_channel.hh
+++ b/source/neuropod/multiprocess/ipc_control_channel.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/BUILD
+++ b/source/neuropod/multiprocess/mq/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/heartbeat.hh
+++ b/source/neuropod/multiprocess/mq/heartbeat.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/ipc_message_queue.cc
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/ipc_message_queue.hh
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/ipc_message_queue_impl.hh
+++ b/source/neuropod/multiprocess/mq/ipc_message_queue_impl.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/test/BUILD
+++ b/source/neuropod/multiprocess/mq/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/test/test_ipc_message_queue.cc
+++ b/source/neuropod/multiprocess/mq/test/test_ipc_message_queue.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/test/test_ope_heartbeat.cc
+++ b/source/neuropod/multiprocess/mq/test/test_ope_heartbeat.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/test/test_ope_transferrables.cc
+++ b/source/neuropod/multiprocess/mq/test/test_ope_transferrables.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/test/test_ope_wire_format.cc
+++ b/source/neuropod/multiprocess/mq/test/test_ope_wire_format.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/transferrables.cc
+++ b/source/neuropod/multiprocess/mq/transferrables.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/transferrables.hh
+++ b/source/neuropod/multiprocess/mq/transferrables.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/wire_format.hh
+++ b/source/neuropod/multiprocess/mq/wire_format.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/mq/wire_format_impl.hh
+++ b/source/neuropod/multiprocess/mq/wire_format_impl.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/multiprocess.cc
+++ b/source/neuropod/multiprocess/multiprocess.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/multiprocess.hh
+++ b/source/neuropod/multiprocess/multiprocess.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/multiprocess_worker.hh
+++ b/source/neuropod/multiprocess/multiprocess_worker.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/multiprocess_worker_main.cc
+++ b/source/neuropod/multiprocess/multiprocess_worker_main.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/ope_load_config.hh
+++ b/source/neuropod/multiprocess/ope_load_config.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/serialization/BUILD
+++ b/source/neuropod/multiprocess/serialization/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/serialization/ipc_serialization.hh
+++ b/source/neuropod/multiprocess/serialization/ipc_serialization.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/serialization/test/BUILD
+++ b/source/neuropod/multiprocess/serialization/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/serialization/test/test_ipc_serialization.cc
+++ b/source/neuropod/multiprocess/serialization/test/test_ipc_serialization.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/BUILD
+++ b/source/neuropod/multiprocess/shm/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/raw_shm_block_allocator.cc
+++ b/source/neuropod/multiprocess/shm/raw_shm_block_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/raw_shm_block_allocator.hh
+++ b/source/neuropod/multiprocess/shm/raw_shm_block_allocator.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/shm_allocator.cc
+++ b/source/neuropod/multiprocess/shm/shm_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/shm_allocator.hh
+++ b/source/neuropod/multiprocess/shm/shm_allocator.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/test/BUILD
+++ b/source/neuropod/multiprocess/shm/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/test/benchmark_shm_allocator.cc
+++ b/source/neuropod/multiprocess/shm/test/benchmark_shm_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm/test/test_shm_allocator.cc
+++ b/source/neuropod/multiprocess/shm/test/test_shm_allocator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm_tensor.cc
+++ b/source/neuropod/multiprocess/shm_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/shm_tensor.hh
+++ b/source/neuropod/multiprocess/shm_tensor.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/tensor_utils.hh
+++ b/source/neuropod/multiprocess/tensor_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/BUILD
+++ b/source/neuropod/multiprocess/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/benchmark_multiprocess.cc
+++ b/source/neuropod/multiprocess/test/benchmark_multiprocess.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/test_ipc_control_channel.cc
+++ b/source/neuropod/multiprocess/test/test_ipc_control_channel.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/test_multiprocess_allowed_transitions.cc
+++ b/source/neuropod/multiprocess/test/test_multiprocess_allowed_transitions.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/test_multiprocess_worker.cc
+++ b/source/neuropod/multiprocess/test/test_multiprocess_worker.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/test_ope_multiple_instances.cc
+++ b/source/neuropod/multiprocess/test/test_ope_multiple_instances.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/multiprocess/test/test_shm_tensor.cc
+++ b/source/neuropod/multiprocess/test/test_shm_tensor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/neuropod.cc
+++ b/source/neuropod/neuropod.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/neuropod.hh
+++ b/source/neuropod/neuropod.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/options.hh
+++ b/source/neuropod/options.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/BUILD
+++ b/source/neuropod/serialization/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/serialization.cc
+++ b/source/neuropod/serialization/serialization.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/serialization.hh
+++ b/source/neuropod/serialization/serialization.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/test/BUILD
+++ b/source/neuropod/serialization/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/test/benchmark_serialization.cc
+++ b/source/neuropod/serialization/test/benchmark_serialization.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/test/test_input_output.cc
+++ b/source/neuropod/serialization/test/test_input_output.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/serialization/test/test_serialization.cc
+++ b/source/neuropod/serialization/test/test_serialization.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/tests/BUILD
+++ b/source/neuropod/tests/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/tests/test_data/BUILD
+++ b/source/neuropod/tests/test_data/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/neuropod/tests/test_utils.hh
+++ b/source/neuropod/tests/test_utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/neuropod/version.hh
+++ b/source/neuropod/version.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 UATC, LLC
+/* Copyright (c) 2020 The Neuropod Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/keras/packager.py
+++ b/source/python/neuropod/backends/keras/packager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/keras/test/test_keras_packaging.py
+++ b/source/python/neuropod/backends/keras/test/test_keras_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/python/packager.py
+++ b/source/python/neuropod/backends/python/packager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/python/test/test_python_deps.py
+++ b/source/python/neuropod/backends/python/test/test_python_deps.py
@@ -1,6 +1,16 @@
+# Copyright (c) 2020 The Neuropod Authors
 #
-# Uber, Inc. (c) 2020
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import numpy as np
 import os

--- a/source/python/neuropod/backends/python/test/test_python_isolation.py
+++ b/source/python/neuropod/backends/python/test/test_python_isolation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/python/test/test_python_packaging.py
+++ b/source/python/neuropod/backends/python/test/test_python_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/packager.py
+++ b/source/python/neuropod/backends/pytorch/packager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/test/custom_ops/addition_op_1/setup.py
+++ b/source/python/neuropod/backends/pytorch/test/custom_ops/addition_op_1/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/test/custom_ops/addition_op_2/setup.py
+++ b/source/python/neuropod/backends/pytorch/test/custom_ops/addition_op_2/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/test/custom_ops/test_pytorch_custom_ops.py
+++ b/source/python/neuropod/backends/pytorch/test/custom_ops/test_pytorch_custom_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/test/test_pytorch_packaging.py
+++ b/source/python/neuropod/backends/pytorch/test/test_pytorch_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/pytorch/test/test_pytorch_strings.py
+++ b/source/python/neuropod/backends/pytorch/test/test_pytorch_strings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/tensorflow/packager.py
+++ b/source/python/neuropod/backends/tensorflow/packager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/tensorflow/test/custom_ops/test_tensorflow_custom_ops.py
+++ b/source/python/neuropod/backends/tensorflow/test/custom_ops/test_tensorflow_custom_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_packaging.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_strings.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_strings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
+++ b/source/python/neuropod/backends/tensorflow/test/test_tensorflow_v2_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 UATC, LLC
+# Copyright (c) 2021 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/packager.py
+++ b/source/python/neuropod/backends/torchscript/packager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/test/custom_ops/setup.py
+++ b/source/python/neuropod/backends/torchscript/test/custom_ops/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/test/custom_ops/test_torchscript_custom_ops.py
+++ b/source/python/neuropod/backends/torchscript/test/custom_ops/test_torchscript_custom_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/test/gpu_test_torchscript_devices.py
+++ b/source/python/neuropod/backends/torchscript/test/gpu_test_torchscript_devices.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/test/test_torchscript_packaging.py
+++ b/source/python/neuropod/backends/torchscript/test/test_torchscript_packaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/backends/torchscript/test/test_torchscript_strings.py
+++ b/source/python/neuropod/backends/torchscript/test/test_torchscript_strings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/loader.py
+++ b/source/python/neuropod/loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/packagers.py
+++ b/source/python/neuropod/packagers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/registry.py
+++ b/source/python/neuropod/registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/tests/gpu_test_basic_environment_support.py
+++ b/source/python/neuropod/tests/gpu_test_basic_environment_support.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/tests/test_serialization.py
+++ b/source/python/neuropod/tests/test_serialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/tests/utils.py
+++ b/source/python/neuropod/tests/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/config_utils.py
+++ b/source/python/neuropod/utils/config_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/dtype_utils.py
+++ b/source/python/neuropod/utils/dtype_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/env_utils.py
+++ b/source/python/neuropod/utils/env_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/eval_utils.py
+++ b/source/python/neuropod/utils/eval_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/hash_utils.py
+++ b/source/python/neuropod/utils/hash_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/packaging_utils.py
+++ b/source/python/neuropod/utils/packaging_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/pip_utils.py
+++ b/source/python/neuropod/utils/pip_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/randomify.py
+++ b/source/python/neuropod/utils/randomify.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/test/test_config_utils.py
+++ b/source/python/neuropod/utils/test/test_config_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/test/test_eval_utils.py
+++ b/source/python/neuropod/utils/test/test_eval_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/python/neuropod/utils/test/test_randomify.py
+++ b/source/python/neuropod/utils/test/test_randomify.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/tools/coverage/BUILD
+++ b/source/tools/coverage/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/tools/coverage/run_under.sh
+++ b/source/tools/coverage/run_under.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020 UATC, LLC
+# Copyright (c) 2020 The Neuropod Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary:

This PR modifies the copyright headers across Neuropod to more correctly reflect the actual copyright holders of contributions to the project.

(Note that changing the text of the header doesn't change any ownership; it just more clearly reflects that all contributions are not owned by `UATC, LLC`)

A common way to do this is to introduce an AUTHORS file.

Please see https://opensource.google/documentation/reference/releasing/authors for more information about AUTHORS files

### Test Plan:

N/A