### PR TITLE
Update zlib URL to use GitHub

### DIFF
--- a/source/WORKSPACE
+++ b/source/WORKSPACE
@@ -139,9 +139,9 @@ http_archive(
 http_archive(
     name = "zlib_repo",
     build_file = "@//deps:BUILD.zlib",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
     strip_prefix = "zlib-1.2.11",
-    url = "https://zlib.net/zlib-1.2.11.tar.gz",
+    url = "https://github.com/madler/zlib/archive/refs/tags/v1.2.11.tar.gz",
 )
 
 http_archive(


### PR DESCRIPTION
### Summary:

Use a GitHub URL for zlib v1.2.11 instead of a zlib.net URL 

### Test Plan:

CI