### PR TITLE
[Python] Pin protobuf version to fix tensorflow

### DIFF
--- a/build/install_python_deps.sh
+++ b/build/install_python_deps.sh
@@ -13,10 +13,9 @@ ${NEUROPOD_PYTHON_BINARY} -m pip install virtualenv==16.7.9
 ${NEUROPOD_PYTHON_BINARY} -m virtualenv .neuropod_venv
 source .neuropod_venv/bin/activate
 
-# Install deps for the python interface
-# (the -f flag tells pip where to find the torch nightly builds)
+# Install deps for the python interface and tests
 pushd source/python
-pip install -U pip setuptools numpy coverage requests[security]
+pip install -U pip setuptools numpy coverage requests[security] protobuf==3.19.4
 python setup.py egg_info
 cat neuropod.egg-info/requires.txt | sed '/^\[/ d' | paste -sd " " - | xargs pip install
 popd


### PR DESCRIPTION
### Summary:

A major release of the `protobuf` python package ([4.21.0](https://pypi.org/project/protobuf/4.21.0/)) came out a few hours ago. It appears that `tensorflow` doesn't restrict the allowed versions of its `protobuf` dependency. This causes TF 2.2.0 to break and therefore breaks Neuropod CI.

An excerpt of the error:

```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

More details in the comments of this PR

### Test Plan:

CI