### PR TITLE
Write a manifest when packaging models

### DIFF
--- a/source/python/neuropod/backends/python/packager.py
+++ b/source/python/neuropod/backends/python/packager.py
@@ -154,4 +154,5 @@ def create_python_neuropod(
         json.dump(
             {"entrypoint_package": entrypoint_package, "entrypoint": entrypoint},
             config_file,
+            sort_keys=True,
         )

--- a/source/python/neuropod/backends/python/test/test_python_packaging.py
+++ b/source/python/neuropod/backends/python/test/test_python_packaging.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import numpy as np
 import unittest
 from testpath.tempdir import TemporaryDirectory
@@ -52,48 +53,80 @@ def get_model(_):
 
 @requires_frameworks("python")
 class TestPythonPackaging(unittest.TestCase):
-    def package_simple_addition_model(self, do_fail=False):
-        with TemporaryDirectory() as test_dir:
-            neuropod_path = os.path.join(test_dir, "test_neuropod")
-            model_code_dir = os.path.join(test_dir, "model_code")
-            os.makedirs(model_code_dir)
+    def package_simple_addition_model(self, test_dir, do_fail=False, **kwargs):
+        neuropod_path = os.path.join(test_dir, "test_neuropod")
+        model_code_dir = os.path.join(test_dir, "model_code")
+        os.makedirs(model_code_dir)
 
-            with open(os.path.join(model_code_dir, "addition_model.py"), "w") as f:
-                f.write(ADDITION_MODEL_SOURCE)
+        with open(os.path.join(model_code_dir, "addition_model.py"), "w") as f:
+            f.write(ADDITION_MODEL_SOURCE)
 
-            # `create_python_neuropod` runs inference with the test data immediately
-            # after creating the neuropod. Raises a ValueError if the model output
-            # does not match the expected output.
-            create_python_neuropod(
-                neuropod_path=neuropod_path,
-                model_name="addition_model",
-                data_paths=[],
-                code_path_spec=[
-                    {
-                        "python_root": model_code_dir,
-                        "dirs_to_package": [
-                            ""  # Package everything in the python_root
-                        ],
-                    }
-                ],
-                entrypoint_package="addition_model",
-                entrypoint="get_model",
-                # Get the input/output spec along with test data
-                **get_addition_model_spec(do_fail=do_fail)
-            )
+        # `create_python_neuropod` runs inference with the test data immediately
+        # after creating the neuropod. Raises a ValueError if the model output
+        # does not match the expected output.
+        create_python_neuropod(
+            neuropod_path=neuropod_path,
+            model_name="addition_model",
+            data_paths=[],
+            code_path_spec=[
+                {
+                    "python_root": model_code_dir,
+                    "dirs_to_package": [""],  # Package everything in the python_root
+                }
+            ],
+            entrypoint_package="addition_model",
+            entrypoint="get_model",
+            # Get the input/output spec along with test data
+            **get_addition_model_spec(do_fail=do_fail),
+            **kwargs
+        )
 
-            # Run some additional checks
-            check_addition_model(neuropod_path)
+        # Run some additional checks
+        check_addition_model(neuropod_path)
 
     def test_simple_addition_model(self):
         # Tests a case where packaging works correctly and
         # the model output matches the expected output
-        self.package_simple_addition_model()
+        with TemporaryDirectory() as test_dir:
+            self.package_simple_addition_model(test_dir)
 
     def test_simple_addition_model_failure(self):
         # Tests a case where the output does not match the expected output
-        with self.assertRaises(ValueError):
-            self.package_simple_addition_model(do_fail=True)
+        with TemporaryDirectory() as test_dir:
+            with self.assertRaises(ValueError):
+                self.package_simple_addition_model(test_dir, do_fail=True)
+
+    def test_manifest(self):
+        # Packages a model and ensures the manifest contains what we expect
+        TARGET = """{
+            "files": {
+                "0/code/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "0/code/addition_model.py": "14566dd9b13641f6482f492398cd1b567d132a08facde7b2f86cddd198f93415",
+                "0/config.json": "a52f77051501f426b04f865580ee81ad1c242e47c45dcc4108c673a95f12b755",
+                "config.json": "0309cf2117d887218e7edb4c918097a6a427fffcbf0a948115d32414b2b6e144"
+            },
+            "manifest_version": 1
+        }"""
+
+        def remove_whitespace_except_newline(text):
+            space_regex = re.compile(r"[^\S\r\n]")
+            return space_regex.sub("", text)
+
+        with TemporaryDirectory() as test_dir:
+            # Package the model
+            self.package_simple_addition_model(
+                test_dir, package_as_zip=False, persist_test_data=False
+            )
+
+            # Get the manifest path
+            manifest_path = os.path.join(test_dir, "test_neuropod", "manifest.json")
+
+            # Confirm the contents match our target
+            with open(manifest_path, "r") as manifest_file:
+                contents = remove_whitespace_except_newline(manifest_file.read())
+                target = remove_whitespace_except_newline(TARGET)
+
+                self.assertEqual(contents, target)
 
     def test_noncontiguous_array(self):
         x = np.arange(16).astype(np.int64).reshape(4, 4)

--- a/source/python/neuropod/utils/config_utils.py
+++ b/source/python/neuropod/utils/config_utils.py
@@ -255,7 +255,7 @@ def write_neuropod_config(
         validate_neuropod_config(config)
 
         # Write out the config as JSON
-        json.dump(config, config_file, indent=4)
+        json.dump(config, config_file, indent=4, sort_keys=True)
 
 
 def read_neuropod_config(neuropod_path):


### PR DESCRIPTION
### Summary:

When packaging a model, write a `manifest.json` file listing all packaged files along with their sha256 hashes.

### Test Plan:

CI + local testing + added test to ensure the manifest is correct
