### PR TITLE
ci: bump macos-10.15 to macos-12

### DIFF
--- a/.github/workflows/mac_ci.yml
+++ b/.github/workflows/mac_ci.yml
@@ -14,7 +14,7 @@ on:
   pull_request:
 jobs:
     build:
-        runs-on: macos-10.15
+        runs-on: macos-12
         name: TF ${{ matrix.tf }}, Torch ${{ matrix.torch }}, Python ${{ matrix.python }}
         env:
             NEUROPOD_TENSORFLOW_VERSION: ${{ matrix.tf }}

--- a/build/ci_matrix.py
+++ b/build/ci_matrix.py
@@ -32,7 +32,7 @@ on:
   pull_request:
 jobs:
     build:
-        runs-on: macos-10.15
+        runs-on: macos-12
         name: TF ${{{{ matrix.tf }}}}, Torch ${{{{ matrix.torch }}}}, Python ${{{{ matrix.python }}}}
         env:
             NEUROPOD_TENSORFLOW_VERSION: ${{{{ matrix.tf }}}}


### PR DESCRIPTION
### Summary:

Updated the runs-on to macos-12.

[GitHub Actions The macOS 10.15 Actions runner image is being deprecated and will be removed by 8/30/22](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/).

### Test Plan:

n/a